### PR TITLE
Tests: Gaussian09 low- & high-precision vib displ

### DIFF
--- a/Gaussian/Gaussian09/benzene_HPfreq.log
+++ b/Gaussian/Gaussian09/benzene_HPfreq.log
@@ -1,0 +1,1270 @@
+ Entering Gaussian System, Link 0=g09
+ Input=benzene.com
+ Output=benzene.log
+ Initial command:
+ /software/G09_RevC01/g09/l1.exe /scratch/Gau-13747.inp -scrdir=/scratch/
+ Entering Link 1 = /software/G09_RevC01/g09/l1.exe PID=     13749.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2011,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 09, Revision C.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci, 
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian, 
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada, 
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, 
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr., 
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers, 
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi, 
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth, 
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels, 
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski, 
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2010.
+  
+ ******************************************
+ Gaussian 09:  EM64L-G09RevC.01 23-Sep-2011
+                 5-Aug-2015 
+ ******************************************
+ %chk=benzene.chk
+ %mem=200mb
+ Default route:  CacheSize=87000
+ ----------------------------------------
+ # AM1 freq=HPmodes geom=check guess=read
+ ----------------------------------------
+ 1/4=87000,10=4,29=2,30=1,38=1/1,3;
+ 2/4=87000,12=2,40=1/2;
+ 3/4=87000,5=2,14=-4,16=1,25=1,41=700000,71=2,116=-2/1,2,3;
+ 4/4=87000,5=1,35=1/1;
+ 5/4=87000,5=2,35=1,38=6,98=1/2;
+ 8/4=87000,6=4,10=90,11=11/1;
+ 11/4=87000,6=1,8=1,9=11,15=111,16=1/1,2,10;
+ 10/4=87000,6=1/2;
+ 6/4=87000,7=2,8=2,9=2,10=2,18=1,28=1/1;
+ 7/4=87000,8=11,10=1,25=1/1,2,3,16;
+ 1/4=87000,10=4,30=1/3;
+ 99/4=87000/99;
+ ----------------------------------------------------------------------
+ Benzene frequency calculation printing out normal mode displacements i
+ n higher precision
+ ----------------------------------------------------------------------
+ Structure from the checkpoint file:  benzene.chk
+ Charge =  0 Multiplicity = 1
+ Redundant internal coordinates found in file.
+ C,0,-0.318996994,1.9256612966,0.000058544
+ C,0,1.0760606099,1.9255751224,0.0004857433
+ C,0,1.7736449418,3.1336925304,-0.0000452677
+ C,0,1.0761756697,4.3418853264,-0.0010517012
+ C,0,-0.318882027,4.3419677736,-0.0014924252
+ C,0,-1.0164619031,3.133840281,-0.00093409
+ H,0,-0.8688554649,0.9733291622,0.0005086263
+ H,0,1.625828445,0.9731977218,0.0012816161
+ H,0,2.8733191108,3.1336505628,0.0003201048
+ H,0,1.626065422,5.2942021326,-0.0014852623
+ H,0,-0.8686896202,5.2943230331,-0.0022605138
+ H,0,-2.1161335499,3.1339184171,-0.0012963743
+ Recover connectivity data from disk.
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.3951         calculate D2E/DX2 analytically  !
+ ! R2    R(1,6)                  1.395          calculate D2E/DX2 analytically  !
+ ! R3    R(1,7)                  1.0997         calculate D2E/DX2 analytically  !
+ ! R4    R(2,3)                  1.3951         calculate D2E/DX2 analytically  !
+ ! R5    R(2,8)                  1.0997         calculate D2E/DX2 analytically  !
+ ! R6    R(3,4)                  1.3951         calculate D2E/DX2 analytically  !
+ ! R7    R(3,9)                  1.0997         calculate D2E/DX2 analytically  !
+ ! R8    R(4,5)                  1.3951         calculate D2E/DX2 analytically  !
+ ! R9    R(4,10)                 1.0997         calculate D2E/DX2 analytically  !
+ ! R10   R(5,6)                  1.3951         calculate D2E/DX2 analytically  !
+ ! R11   R(5,11)                 1.0997         calculate D2E/DX2 analytically  !
+ ! R12   R(6,12)                 1.0997         calculate D2E/DX2 analytically  !
+ ! A1    A(2,1,6)              120.0008         calculate D2E/DX2 analytically  !
+ ! A2    A(2,1,7)              119.9978         calculate D2E/DX2 analytically  !
+ ! A3    A(6,1,7)              120.0014         calculate D2E/DX2 analytically  !
+ ! A4    A(1,2,3)              119.9992         calculate D2E/DX2 analytically  !
+ ! A5    A(1,2,8)              119.9996         calculate D2E/DX2 analytically  !
+ ! A6    A(3,2,8)              120.0012         calculate D2E/DX2 analytically  !
+ ! A7    A(2,3,4)              120.0001         calculate D2E/DX2 analytically  !
+ ! A8    A(2,3,9)              120.0006         calculate D2E/DX2 analytically  !
+ ! A9    A(4,3,9)              119.9993         calculate D2E/DX2 analytically  !
+ ! A10   A(3,4,5)              120.0005         calculate D2E/DX2 analytically  !
+ ! A11   A(3,4,10)             119.9998         calculate D2E/DX2 analytically  !
+ ! A12   A(5,4,10)             119.9997         calculate D2E/DX2 analytically  !
+ ! A13   A(4,5,6)              119.999          calculate D2E/DX2 analytically  !
+ ! A14   A(4,5,11)             120.0018         calculate D2E/DX2 analytically  !
+ ! A15   A(6,5,11)             119.9992         calculate D2E/DX2 analytically  !
+ ! A16   A(1,6,5)              120.0004         calculate D2E/DX2 analytically  !
+ ! A17   A(1,6,12)             120.0013         calculate D2E/DX2 analytically  !
+ ! A18   A(5,6,12)             119.9983         calculate D2E/DX2 analytically  !
+ ! D1    D(6,1,2,3)              0.0016         calculate D2E/DX2 analytically  !
+ ! D2    D(6,1,2,8)            179.9992         calculate D2E/DX2 analytically  !
+ ! D3    D(7,1,2,3)           -179.9981         calculate D2E/DX2 analytically  !
+ ! D4    D(7,1,2,8)             -0.0005         calculate D2E/DX2 analytically  !
+ ! D5    D(2,1,6,5)             -0.0003         calculate D2E/DX2 analytically  !
+ ! D6    D(2,1,6,12)           179.9985         calculate D2E/DX2 analytically  !
+ ! D7    D(7,1,6,5)            179.9994         calculate D2E/DX2 analytically  !
+ ! D8    D(7,1,6,12)            -0.0018         calculate D2E/DX2 analytically  !
+ ! D9    D(1,2,3,4)             -0.0023         calculate D2E/DX2 analytically  !
+ ! D10   D(1,2,3,9)            179.9983         calculate D2E/DX2 analytically  !
+ ! D11   D(8,2,3,4)           -179.9998         calculate D2E/DX2 analytically  !
+ ! D12   D(8,2,3,9)              0.0007         calculate D2E/DX2 analytically  !
+ ! D13   D(2,3,4,5)              0.0016         calculate D2E/DX2 analytically  !
+ ! D14   D(2,3,4,10)          -179.9991         calculate D2E/DX2 analytically  !
+ ! D15   D(9,3,4,5)           -179.9989         calculate D2E/DX2 analytically  !
+ ! D16   D(9,3,4,10)             0.0003         calculate D2E/DX2 analytically  !
+ ! D17   D(3,4,5,6)             -0.0004         calculate D2E/DX2 analytically  !
+ ! D18   D(3,4,5,11)           179.9985         calculate D2E/DX2 analytically  !
+ ! D19   D(10,4,5,6)          -179.9996         calculate D2E/DX2 analytically  !
+ ! D20   D(10,4,5,11)           -0.0008         calculate D2E/DX2 analytically  !
+ ! D21   D(4,5,6,1)             -0.0003         calculate D2E/DX2 analytically  !
+ ! D22   D(4,5,6,12)          -179.9991         calculate D2E/DX2 analytically  !
+ ! D23   D(11,5,6,1)          -179.9991         calculate D2E/DX2 analytically  !
+ ! D24   D(11,5,6,12)            0.0021         calculate D2E/DX2 analytically  !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07
+ Number of steps in this run=      2 maximum allowed number of steps=      2.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -0.318997    1.925661    0.000059
+      2          6           0        1.076061    1.925575    0.000486
+      3          6           0        1.773645    3.133693   -0.000045
+      4          6           0        1.076176    4.341885   -0.001052
+      5          6           0       -0.318882    4.341968   -0.001492
+      6          6           0       -1.016462    3.133840   -0.000934
+      7          1           0       -0.868855    0.973329    0.000509
+      8          1           0        1.625828    0.973198    0.001282
+      9          1           0        2.873319    3.133651    0.000320
+     10          1           0        1.626065    5.294202   -0.001485
+     11          1           0       -0.868690    5.294323   -0.002261
+     12          1           0       -2.116134    3.133918   -0.001296
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.395058   0.000000
+     3  C    2.416297   1.395053   0.000000
+     4  C    2.790098   2.416311   1.395061   0.000000
+     5  C    2.416307   2.790129   2.416320   1.395058   0.000000
+     6  C    1.395047   2.416311   2.790107   2.416300   1.395059
+     7  H    1.099673   2.165519   3.413206   3.889771   3.413239
+     8  H    2.165533   1.099667   2.165546   3.413236   3.889797
+     9  H    3.413227   2.165545   1.099674   2.165539   3.413236
+    10  H    3.889773   3.413233   2.165545   1.099676   2.165542
+    11  H    3.413217   3.889797   3.413248   2.165558   1.099668
+    12  H    2.165545   3.413239   3.889779   3.413213   2.165524
+                    6          7          8          9         10
+     6  C    0.000000
+     7  H    2.165548   0.000000
+     8  H    3.413221   2.494684   0.000000
+     9  H    3.889781   4.320979   2.494753   0.000000
+    10  H    3.413226   4.989447   4.321005   2.494720   0.000000
+    11  H    2.165531   4.320995   4.989465   4.321012   2.494755
+    12  H    1.099672   2.494765   4.320995   4.989453   4.320981
+                   11         12
+    11  H    0.000000
+    12  H    2.494687   0.000000
+ Stoichiometry    C6H6
+ Framework group  C1[X(C6H6)]
+ Deg. of freedom    30
+ Full point group                 C1      NOp   1
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -0.506751    1.299753    0.000002
+      2          6           0       -1.379012    0.211017   -0.000013
+      3          6           0       -0.872253   -1.088740    0.000008
+      4          6           0        0.506756   -1.299756   -0.000005
+      5          6           0        1.379014   -0.211017   -0.000003
+      6          6           0        0.872244    1.088742    0.000004
+      7          1           0       -0.906238    2.324298    0.000018
+      8          1           0       -2.466023    0.377372   -0.000001
+      9          1           0       -1.559805   -1.946968    0.000024
+     10          1           0        0.906212   -2.324315   -0.000004
+     11          1           0        2.466033   -0.377328    0.000012
+     12          1           0        1.559823    1.946946   -0.000010
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      5.6861529      5.6860641      2.8430542
+ Standard basis: VSTO-6G (5D, 7F)
+ There are    30 symmetry adapted basis functions of A   symmetry.
+ Integral buffers will be    131072 words long.
+ Regular integral format.
+ Two-electron integral symmetry is turned off.
+    30 basis functions,   180 primitive gaussians,    30 cartesian basis functions
+    15 alpha electrons       15 beta electrons
+       nuclear repulsion energy       119.5992544929 Hartrees.
+ Do NDO integrals.
+ One-electron integrals computed using PRISM.
+ NBasis=    30 RedAO= F  NBF=    30
+ NBsUse=    30 1.00D-04 NBFU=    30
+ Initial guess read from the checkpoint file:  benzene.chk
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Overlap will be assumed to be unity.
+ Keep J ints in memory in canonical form, NReq=882346.
+ SCF Done:  E(RAM1) =  0.349527236288E-01 A.U. after    2 cycles
+             Convg  =    0.9747D-09             -V/T =  1.0019
+ Range of M.O.s used for correlation:     1    30
+ NBasis=    30 NAE=    15 NBE=    15 NFC=     0 NFV=     0
+ NROrb=     30 NOA=    15 NOB=    15 NVA=    15 NVB=    15
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ G2DrvN: will do    13 centers at a time, making    1 passes doing MaxLOS=1.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ FoFDir/FoFCou used for L=0 through L=1.
+ End of G2Drv Frequency-dependent properties file   721 does not exist.
+ End of G2Drv Frequency-dependent properties file   722 does not exist.
+          IDoAtm=111111111111
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+          Electric field/nuclear overlap derivatives assumed to be zero.
+          Keep J ints in memory in canonical form, NReq=802993.
+          There are    39 degrees of freedom in the 1st order CPHF.  IDoFFX=5.
+ LinEq1:  Iter=  0 NonCon=    39 RMS=3.83D-01 Max=3.26D+00
+ AX will form    39 AO Fock derivatives at one time.
+ LinEq1:  Iter=  1 NonCon=    39 RMS=6.01D-02 Max=4.24D-01
+ LinEq1:  Iter=  2 NonCon=    39 RMS=4.21D-03 Max=2.50D-02
+ LinEq1:  Iter=  3 NonCon=    39 RMS=2.73D-04 Max=2.20D-03
+ LinEq1:  Iter=  4 NonCon=    39 RMS=3.82D-05 Max=2.27D-04
+ LinEq1:  Iter=  5 NonCon=    39 RMS=3.54D-06 Max=2.06D-05
+ LinEq1:  Iter=  6 NonCon=    32 RMS=3.36D-07 Max=2.22D-06
+ LinEq1:  Iter=  7 NonCon=    22 RMS=4.01D-08 Max=2.33D-07
+ LinEq1:  Iter=  8 NonCon=     0 RMS=4.36D-09 Max=2.13D-08
+ Linear equations converged to 1.000D-08 1.000D-07 after     8 iterations.
+ Isotropic polarizability for W=    0.000000       48.75 Bohr**3.
+ End of Minotr Frequency-dependent properties file   721 does not exist.
+ End of Minotr Frequency-dependent properties file   722 does not exist.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+ The electronic state is 1-A.
+ Alpha  occ. eigenvalues --   -1.43860  -1.15283  -1.15283  -0.84745  -0.84745
+ Alpha  occ. eigenvalues --   -0.65619  -0.59250  -0.56596  -0.52041  -0.52040
+ Alpha  occ. eigenvalues --   -0.49175  -0.43689  -0.43689  -0.35474  -0.35474
+ Alpha virt. eigenvalues --    0.02039   0.02039   0.10944   0.14833   0.14833
+ Alpha virt. eigenvalues --    0.14875   0.15409   0.16900   0.16900   0.18827
+ Alpha virt. eigenvalues --    0.18827   0.20624   0.20624   0.21054   0.22540
+          Condensed to atoms (all electrons):
+              1          2          3          4          5          6
+     1  C    4.130119   0.000000   0.000000   0.000000   0.000000   0.000000
+     2  C    0.000000   4.130119   0.000000   0.000000   0.000000   0.000000
+     3  C    0.000000   0.000000   4.130119   0.000000   0.000000   0.000000
+     4  C    0.000000   0.000000   0.000000   4.130120   0.000000   0.000000
+     5  C    0.000000   0.000000   0.000000   0.000000   4.130120   0.000000
+     6  C    0.000000   0.000000   0.000000   0.000000   0.000000   4.130119
+     7  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     8  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     9  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+    10  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+    11  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+    12  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+              7          8          9         10         11         12
+     1  C    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     2  C    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     3  C    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     4  C    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     5  C    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     6  C    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     7  H    0.869882   0.000000   0.000000   0.000000   0.000000   0.000000
+     8  H    0.000000   0.869879   0.000000   0.000000   0.000000   0.000000
+     9  H    0.000000   0.000000   0.869881   0.000000   0.000000   0.000000
+    10  H    0.000000   0.000000   0.000000   0.869881   0.000000   0.000000
+    11  H    0.000000   0.000000   0.000000   0.000000   0.869879   0.000000
+    12  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.869882
+ Mulliken atomic charges:
+              1
+     1  C   -0.130119
+     2  C   -0.130119
+     3  C   -0.130119
+     4  C   -0.130120
+     5  C   -0.130120
+     6  C   -0.130119
+     7  H    0.130118
+     8  H    0.130121
+     9  H    0.130119
+    10  H    0.130119
+    11  H    0.130121
+    12  H    0.130118
+ Sum of Mulliken atomic charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+              1
+     1  C   -0.000002
+     2  C    0.000002
+     3  C    0.000000
+     4  C   -0.000001
+     5  C    0.000002
+     6  C   -0.000001
+ Sum of Mulliken charges with hydrogens summed into heavy atoms =   0.00000
+ APT atomic charges:
+              1
+     1  C   -0.120326
+     2  C   -0.120325
+     3  C   -0.120325
+     4  C   -0.120326
+     5  C   -0.120325
+     6  C   -0.120325
+     7  H    0.120322
+     8  H    0.120327
+     9  H    0.120324
+    10  H    0.120323
+    11  H    0.120327
+    12  H    0.120324
+ Sum of APT charges=   0.00000
+ APT Atomic charges with hydrogens summed into heavy atoms:
+              1
+     1  C   -0.000004
+     2  C    0.000001
+     3  C    0.000000
+     4  C   -0.000002
+     5  C    0.000002
+     6  C   -0.000002
+     7  H    0.000000
+     8  H    0.000000
+     9  H    0.000000
+    10  H    0.000000
+    11  H    0.000000
+    12  H    0.000000
+ Sum of APT charges=   0.00000
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=              0.0000    Z=              0.0000  Tot=              0.0000
+ N-N= 1.195992544929D+02 E-N=-1.995926004615D+02  KE=-1.879673789111D+01
+  Exact polarizability:  68.607   0.000  68.606   0.000   0.000   9.031
+ Approx polarizability:  58.286   0.000  58.285   0.000   0.000   6.910
+ Calling FoFJK, ICntrl=    100127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ Full mass-weighted force constant matrix:
+ Low frequencies ---   -0.0016   -0.0011   -0.0004    2.2872    2.3715    2.8121
+ Low frequencies ---  370.7936  370.7987  618.0103
+ Harmonic frequencies (cm**-1), IR intensities (KM/Mole), Raman scattering
+ activities (A**4/AMU), depolarization ratios for plane and unpolarized
+ incident light, reduced masses (AMU), force constants (mDyne/A),
+ and normal coordinates:
+                           1         2         3         4         5
+                           A         A         A         A         A
+       Frequencies ---   370.7936  370.7987  618.0103  647.7864  647.7895
+    Reduced masses ---     2.3022    2.3023    1.9355    6.4600    6.4600
+   Force constants ---     0.1865    0.1865    0.4355    1.5971    1.5972
+    IR Intensities ---     0.0000    0.0000    0.0000    0.0000    0.0000
+ Coord Atom Element:
+   1     1     6          0.00000   0.00000   0.00000  -0.18677   0.05592
+   2     1     6          0.00000   0.00000   0.00000   0.28440   0.21550
+   3     1     6         -0.04497   0.19296   0.11859   0.00000   0.00000
+   1     2     6          0.00000   0.00000   0.00000   0.03243   0.37351
+   2     2     6          0.00000   0.00000   0.00000   0.14503  -0.06117
+   3     2     6          0.18959  -0.05753  -0.11859   0.00000   0.00000
+   1     3     6          0.00000   0.00000   0.00000   0.26230  -0.02513
+   2     3     6          0.00000   0.00000   0.00001   0.20334  -0.23356
+   3     3     6         -0.14462  -0.13542   0.11860  -0.00001   0.00001
+   1     4     6          0.00000   0.00000   0.00000   0.18677  -0.05592
+   2     4     6          0.00000   0.00000   0.00000  -0.28440  -0.21550
+   3     4     6         -0.04497   0.19295  -0.11860   0.00000   0.00000
+   1     5     6          0.00000   0.00000   0.00000  -0.03243  -0.37351
+   2     5     6          0.00000   0.00000   0.00000  -0.14503   0.06116
+   3     5     6          0.18958  -0.05753   0.11860   0.00000   0.00000
+   1     6     6          0.00000   0.00000   0.00000  -0.26230   0.02514
+   2     6     6          0.00000   0.00000   0.00000  -0.20335   0.23357
+   3     6     6         -0.14462  -0.13543  -0.11859   0.00000   0.00000
+   1     7     1          0.00000   0.00000   0.00000  -0.03089  -0.21936
+   2     7     1          0.00000  -0.00001  -0.00001   0.33005   0.09997
+   3     7     1         -0.12310   0.52815   0.39062  -0.00001   0.00000
+   1     8     1          0.00000   0.00000   0.00000  -0.01933   0.35904
+   2     8     1          0.00000   0.00000   0.00000  -0.19037  -0.04978
+   3     8     1          0.51893  -0.15749  -0.39065   0.00001  -0.00002
+   1     9     1          0.00000  -0.00001   0.00000   0.11520  -0.24572
+   2     9     1         -0.00001   0.00000   0.00001   0.30368  -0.04610
+   3     9     1         -0.39582  -0.37066   0.39064   0.00000   0.00000
+   1    10     1          0.00000   0.00000   0.00000   0.03088   0.21934
+   2    10     1          0.00000   0.00000   0.00000  -0.33005  -0.09998
+   3    10     1         -0.12308   0.52812  -0.39065   0.00002  -0.00002
+   1    11     1          0.00000   0.00000   0.00000   0.01932  -0.35904
+   2    11     1          0.00000   0.00000   0.00000   0.19037   0.04976
+   3    11     1          0.51893  -0.15746   0.39066   0.00000   0.00001
+   1    12     1          0.00000   0.00000  -0.00001  -0.11520   0.24572
+   2    12     1          0.00000   0.00000   0.00000  -0.30369   0.04609
+   3    12     1         -0.39584  -0.37067  -0.39063   0.00000  -0.00001
+                           6         7         8         9        10
+                           A         A         A         A         A
+       Frequencies ---   744.1046  891.2303  891.2439  989.3457  989.3560
+    Reduced masses ---     1.0848    1.2503    1.2503    1.5596    1.5595
+   Force constants ---     0.3539    0.5851    0.5851    0.8994    0.8994
+    IR Intensities ---   127.6266    0.0000    0.0000    0.0000    0.0000
+ Coord Atom Element:
+   1     1     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   2     1     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   3     1     6          0.03417   0.03626  -0.07770   0.05283  -0.11808
+   1     2     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   2     2     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   3     2     6          0.03417   0.08544  -0.00744  -0.12866   0.01331
+   1     3     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   2     3     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   3     3     6          0.03416   0.04914   0.07026   0.07585   0.10476
+   1     4     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   2     4     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   3     4     6          0.03416  -0.03626   0.07770   0.05283  -0.11805
+   1     5     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   2     5     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   3     5     6          0.03417  -0.08543   0.00745  -0.12866   0.01327
+   1     6     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   2     6     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   3     6     6          0.03417  -0.04915  -0.07026   0.07584   0.10479
+   1     7     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   2     7     1          0.00001   0.00001  -0.00001   0.00000  -0.00001
+   3     7     1         -0.40683  -0.24150   0.51734  -0.22981   0.51366
+   1     8     1          0.00000  -0.00001   0.00000   0.00001   0.00000
+   2     8     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   3     8     1         -0.40684  -0.56882   0.04951   0.55967  -0.05787
+   1     9     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   2     9     1         -0.00001  -0.00001  -0.00001   0.00000  -0.00001
+   3     9     1         -0.40679  -0.32725  -0.46785  -0.32995  -0.45576
+   1    10     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   2    10     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   3    10     1         -0.40678   0.24147  -0.51736  -0.22981   0.51358
+   1    11     1          0.00001  -0.00001   0.00000  -0.00001   0.00000
+   2    11     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   3    11     1         -0.40683   0.56881  -0.04956   0.55968  -0.05772
+   1    12     1          0.00000   0.00000   0.00000  -0.00001   0.00000
+   2    12     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   3    12     1         -0.40683   0.32730   0.46781  -0.32990  -0.45585
+                          11        12        13        14        15
+                           A         A         A         A         A
+       Frequencies ---  1011.9492 1028.1894 1145.8312 1145.8472 1178.7041
+    Reduced masses ---     1.7892    6.8008    1.2184    1.2184    1.1529
+   Force constants ---     1.0795    4.2360    0.9425    0.9425    0.9437
+    IR Intensities ---     0.0000    0.0000    1.0879    1.0881    0.0000
+ Coord Atom Element:
+   1     1     6          0.00000  -0.10765  -0.03595  -0.01681  -0.04368
+   2     1     6          0.00000   0.27613   0.05866  -0.03699  -0.01705
+   3     1     6         -0.10883   0.00000   0.00000   0.00000   0.00000
+   1     2     6          0.00000   0.29296  -0.01393   0.07138   0.00710
+   2     2     6          0.00000  -0.04483  -0.02952  -0.01496   0.04636
+   3     2     6          0.10884   0.00000   0.00000   0.00000   0.00000
+   1     3     6          0.00000  -0.18531   0.05144   0.00822   0.03660
+   2     3     6          0.00000  -0.23130   0.03364   0.05039  -0.02933
+   3     3     6         -0.10887   0.00000   0.00000   0.00000   0.00000
+   1     4     6          0.00000  -0.10766  -0.03595  -0.01681  -0.04369
+   2     4     6          0.00000   0.27613   0.05867  -0.03699  -0.01704
+   3     4     6          0.10887   0.00000   0.00000   0.00000   0.00000
+   1     5     6          0.00000   0.29296  -0.01393   0.07138   0.00708
+   2     5     6          0.00000  -0.04483  -0.02952  -0.01496   0.04637
+   3     5     6         -0.10885   0.00000   0.00000   0.00000   0.00000
+   1     6     6          0.00000  -0.18530   0.05143   0.00822   0.03659
+   2     6     6          0.00000  -0.23130   0.03364   0.05039  -0.02934
+   3     6     6          0.10884   0.00000   0.00000   0.00000   0.00000
+   1     7     1          0.00000  -0.10199  -0.22735  -0.47808   0.37793
+   2     7     1          0.00000   0.26159  -0.02030  -0.21502   0.14734
+   3     7     1          0.39341   0.00001   0.00000   0.00000   0.00000
+   1     8     1          0.00000   0.27754  -0.09383   0.05680  -0.06134
+   2     8     1          0.00000  -0.04247  -0.55528  -0.08151  -0.40082
+   3     8     1         -0.39340   0.00002   0.00000   0.00000   0.00000
+   1     9     1          0.00000  -0.17554   0.30261  -0.32636  -0.31649
+   2     9     1          0.00000  -0.21913  -0.17204   0.31504   0.25354
+   3     9     1          0.39356   0.00002   0.00000   0.00000   0.00000
+   1    10     1          0.00000  -0.10198  -0.22732  -0.47810   0.37787
+   2    10     1          0.00000   0.26159  -0.02027  -0.21502   0.14732
+   3    10     1         -0.39359   0.00001   0.00000   0.00000   0.00000
+   1    11     1          0.00000   0.27754  -0.09381   0.05682  -0.06133
+   2    11     1          0.00000  -0.04244  -0.55529  -0.08147  -0.40081
+   3    11     1          0.39344  -0.00001   0.00000   0.00000   0.00000
+   1    12     1          0.00000  -0.17554   0.30263  -0.32634  -0.31653
+   2    12     1          0.00000  -0.21913  -0.17208   0.31504   0.25357
+   3    12     1         -0.39342   0.00000   0.00000   0.00000   0.00000
+                          16        17        18        19        20
+                           A         A         A         A         A
+       Frequencies ---  1221.6470 1221.6522 1276.2049 1328.3798 1366.6677
+    Reduced masses ---     1.0296    1.0296    6.2557    1.2503    4.8034
+   Force constants ---     0.9054    0.9054    6.0029    1.2999    5.2860
+    IR Intensities ---     0.0000    0.0000    0.0000    0.0000    0.0000
+ Coord Atom Element:
+   1     1     6         -0.01062   0.01733   0.10244  -0.05649  -0.22351
+   2     1     6          0.01110   0.01118  -0.26282  -0.02203  -0.08711
+   3     1     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     2     6          0.00659   0.01343   0.27884  -0.00917   0.03625
+   2     2     6          0.01966  -0.00714  -0.04264  -0.05994   0.23714
+   3     2     6          0.00000   0.00000   0.00001   0.00000   0.00000
+   1     3     6          0.01805   0.00545   0.17639   0.04732   0.18721
+   2     3     6         -0.00078  -0.01748   0.22012  -0.03791  -0.15001
+   3     3     6          0.00000   0.00000  -0.00001   0.00000   0.00000
+   1     4     6          0.01062  -0.01734  -0.10249   0.05649  -0.22351
+   2     4     6         -0.01110  -0.01118   0.26280   0.02202  -0.08718
+   3     4     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     5     6         -0.00658  -0.01343  -0.27883   0.00917   0.03632
+   2     5     6         -0.01966   0.00714   0.04269   0.05994   0.23714
+   3     5     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     6     6         -0.01805  -0.00545  -0.17634  -0.04732   0.18723
+   2     6     6          0.00079   0.01748  -0.22016   0.03791  -0.14997
+   3     6     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     7     1         -0.15579   0.51404   0.10712   0.37616  -0.30781
+   2     7     1         -0.04256   0.20570  -0.27500   0.14667  -0.11998
+   3     7     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     8     1          0.08886  -0.00390   0.29174   0.06107   0.04993
+   2     8     1          0.55275  -0.13875  -0.04453   0.39903   0.32651
+   3     8     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     9     1          0.31948   0.31702   0.18454  -0.31509   0.25779
+   2     9     1         -0.23963  -0.26962   0.23031   0.25243  -0.20656
+   3     9     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   1    10     1          0.15577  -0.51409  -0.10728  -0.37617  -0.30774
+   2    10     1          0.04255  -0.20571   0.27493  -0.14666  -0.12002
+   3    10     1          0.00000   0.00000   0.00000   0.00000  -0.00001
+   1    11     1         -0.08884   0.00390  -0.29170  -0.06105   0.05000
+   2    11     1         -0.55276   0.13876   0.04479  -0.39903   0.32647
+   3    11     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   1    12     1         -0.31949  -0.31695  -0.18446   0.31508   0.25786
+   2    12     1          0.23965   0.26958  -0.23037  -0.25243  -0.20654
+   3    12     1          0.00000   0.00000   0.00000   0.00000   0.00000
+                          21        22        23        24        25
+                           A         A         A         A         A
+       Frequencies ---  1579.0362 1579.0444 1767.5723 1767.5887 3183.7401
+    Reduced masses ---     3.9663    3.9663   10.4958   10.4956    1.0770
+   Force constants ---     5.8267    5.8268   19.3205   19.3206    6.4318
+    IR Intensities ---    12.1818   12.1827    0.0000    0.0000    0.0003
+ Coord Atom Element:
+   1     1     6          0.10856   0.20336   0.20520   0.42520   0.01175
+   2     1     6         -0.15060   0.11787   0.24960   0.05041  -0.03013
+   3     1     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     2     6          0.09203  -0.16015  -0.08950  -0.18281  -0.03190
+   2     2     6          0.21291   0.10130  -0.49197   0.06530   0.00489
+   3     2     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     3     6         -0.21455   0.03593  -0.06254   0.40415   0.02032
+   2     3     6          0.01684  -0.20522   0.27061  -0.21732   0.02536
+   3     3     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     4     6          0.10859   0.20337  -0.20520  -0.42512   0.01182
+   2     4     6         -0.15059   0.11786  -0.24961  -0.05043  -0.03032
+   3     4     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     5     6          0.09200  -0.16016   0.08950   0.18281  -0.03194
+   2     5     6          0.21292   0.10132   0.49195  -0.06525   0.00488
+   3     5     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     6     6         -0.21452   0.03595   0.06253  -0.40422   0.02021
+   2     6     6          0.01682  -0.20524  -0.27058   0.21730   0.02523
+   3     6     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     7     1         -0.02094  -0.43344  -0.12532  -0.08938  -0.14762
+   2     7     1         -0.19486  -0.13167   0.08156  -0.12360   0.37860
+   3     7     1          0.00000   0.00000   0.00000   0.00000   0.00001
+   1     8     1         -0.00980  -0.18842   0.01271  -0.14662   0.40097
+   2     8     1         -0.43988  -0.12049   0.15440   0.01086  -0.06136
+   3     8     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     9     1          0.19684  -0.32059   0.13537  -0.06896  -0.25536
+   2     9     1         -0.30772   0.08610   0.06114   0.13711  -0.31876
+   3     9     1          0.00000   0.00000   0.00000   0.00000   0.00001
+   1    10     1         -0.02097  -0.43345   0.12536   0.08936  -0.14856
+   2    10     1         -0.19486  -0.13167  -0.08156   0.12353   0.38105
+   3    10     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   1    11     1         -0.00980  -0.18842  -0.01267   0.14660   0.40146
+   2    11     1         -0.43988  -0.12050  -0.15441  -0.01095  -0.06143
+   3    11     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   1    12     1          0.19680  -0.32059  -0.13534   0.06892  -0.25398
+   2    12     1         -0.30771   0.08612  -0.06113  -0.13718  -0.31701
+   3    12     1          0.00000   0.00000   0.00000   0.00000   0.00000
+                          26        27        28        29        30
+                           A         A         A         A         A
+       Frequencies ---  3186.7932 3186.8212 3194.5388 3194.5679 3205.1325
+    Reduced masses ---     1.0754    1.0754    1.0817    1.0817    1.0920
+   Force constants ---     6.4350    6.4351    6.5038    6.5039    6.6097
+    IR Intensities ---     0.0000    0.0000   88.4261   88.4340    0.0000
+ Coord Atom Element:
+   1     1     6          0.01618   0.00412  -0.01531   0.00781  -0.01298
+   2     1     6         -0.03796  -0.01837   0.04021  -0.01799   0.03329
+   3     1     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     2     6         -0.00501  -0.04434  -0.00431   0.04664  -0.03538
+   2     2     6         -0.00237   0.00710   0.00148  -0.00706   0.00541
+   3     2     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     3     6         -0.02431   0.01456   0.02374   0.01763  -0.02232
+   2     3     6         -0.02744   0.02222   0.03039   0.02095  -0.02785
+   3     3     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     4     6         -0.01613  -0.00413  -0.01532   0.00779   0.01296
+   2     4     6          0.03785   0.01840   0.04022  -0.01795  -0.03323
+   3     4     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     5     6          0.00478   0.04436  -0.00442   0.04662   0.03536
+   2     5     6          0.00240  -0.00710   0.00149  -0.00705  -0.00541
+   3     5     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     6     6          0.02439  -0.01451   0.02372   0.01768   0.02235
+   2     6     6          0.02754  -0.02215   0.03037   0.02100   0.02790
+   3     6     6          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     7     1         -0.18995  -0.08822   0.19098  -0.08457   0.14772
+   2     7     1          0.48995   0.22009  -0.48712   0.22277  -0.37886
+   3     7     1          0.00001   0.00000  -0.00001   0.00000  -0.00001
+   1     8     1          0.05741   0.56563   0.05428  -0.56703   0.40271
+   2     8     1         -0.01127  -0.08631  -0.00594   0.08700  -0.06163
+   3     8     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   1     9     1          0.29051  -0.21212  -0.29424  -0.20657   0.25393
+   2     9     1          0.36493  -0.26158  -0.36510  -0.26091   0.31696
+   3     9     1         -0.00001   0.00001   0.00001   0.00001  -0.00001
+   1    10     1          0.18937   0.08834   0.19103  -0.08438  -0.14743
+   2    10     1         -0.48851  -0.22039  -0.48729   0.22230   0.37816
+   3    10     1          0.00000   0.00000   0.00000   0.00000   0.00000
+   1    11     1         -0.05463  -0.56586   0.05556  -0.56673  -0.40253
+   2    11     1          0.01084   0.08633  -0.00614   0.08694   0.06159
+   3    11     1          0.00000  -0.00001   0.00000  -0.00001   0.00000
+   1    12     1         -0.29156   0.21154  -0.29406  -0.20717  -0.25437
+   2    12     1         -0.36621   0.26084  -0.36486  -0.26165  -0.31749
+   3    12     1          0.00000   0.00000   0.00000   0.00000   0.00000
+ Harmonic frequencies (cm**-1), IR intensities (KM/Mole), Raman scattering
+ activities (A**4/AMU), depolarization ratios for plane and unpolarized
+ incident light, reduced masses (AMU), force constants (mDyne/A),
+ and normal coordinates:
+                     1                      2                      3
+                     A                      A                      A
+ Frequencies --   370.7936               370.7987               618.0103
+ Red. masses --     2.3022                 2.3023                 1.9355
+ Frc consts  --     0.1865                 0.1865                 0.4355
+ IR Inten    --     0.0000                 0.0000                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.00   0.00  -0.04     0.00   0.00   0.19     0.00   0.00   0.12
+     2   6     0.00   0.00   0.19     0.00   0.00  -0.06     0.00   0.00  -0.12
+     3   6     0.00   0.00  -0.14     0.00   0.00  -0.14     0.00   0.00   0.12
+     4   6     0.00   0.00  -0.04     0.00   0.00   0.19     0.00   0.00  -0.12
+     5   6     0.00   0.00   0.19     0.00   0.00  -0.06     0.00   0.00   0.12
+     6   6     0.00   0.00  -0.14     0.00   0.00  -0.14     0.00   0.00  -0.12
+     7   1     0.00   0.00  -0.12     0.00   0.00   0.53     0.00   0.00   0.39
+     8   1     0.00   0.00   0.52     0.00   0.00  -0.16     0.00   0.00  -0.39
+     9   1     0.00   0.00  -0.40     0.00   0.00  -0.37     0.00   0.00   0.39
+    10   1     0.00   0.00  -0.12     0.00   0.00   0.53     0.00   0.00  -0.39
+    11   1     0.00   0.00   0.52     0.00   0.00  -0.16     0.00   0.00   0.39
+    12   1     0.00   0.00  -0.40     0.00   0.00  -0.37     0.00   0.00  -0.39
+                     4                      5                      6
+                     A                      A                      A
+ Frequencies --   647.7864               647.7895               744.1046
+ Red. masses --     6.4600                 6.4600                 1.0848
+ Frc consts  --     1.5971                 1.5972                 0.3539
+ IR Inten    --     0.0000                 0.0000               127.6266
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.19   0.28   0.00     0.06   0.22   0.00     0.00   0.00   0.03
+     2   6     0.03   0.15   0.00     0.37  -0.06   0.00     0.00   0.00   0.03
+     3   6     0.26   0.20   0.00    -0.03  -0.23   0.00     0.00   0.00   0.03
+     4   6     0.19  -0.28   0.00    -0.06  -0.22   0.00     0.00   0.00   0.03
+     5   6    -0.03  -0.15   0.00    -0.37   0.06   0.00     0.00   0.00   0.03
+     6   6    -0.26  -0.20   0.00     0.03   0.23   0.00     0.00   0.00   0.03
+     7   1    -0.03   0.33   0.00    -0.22   0.10   0.00     0.00   0.00  -0.41
+     8   1    -0.02  -0.19   0.00     0.36  -0.05   0.00     0.00   0.00  -0.41
+     9   1     0.12   0.30   0.00    -0.25  -0.05   0.00     0.00   0.00  -0.41
+    10   1     0.03  -0.33   0.00     0.22  -0.10   0.00     0.00   0.00  -0.41
+    11   1     0.02   0.19   0.00    -0.36   0.05   0.00     0.00   0.00  -0.41
+    12   1    -0.12  -0.30   0.00     0.25   0.05   0.00     0.00   0.00  -0.41
+                     7                      8                      9
+                     A                      A                      A
+ Frequencies --   891.2303               891.2439               989.3457
+ Red. masses --     1.2503                 1.2503                 1.5596
+ Frc consts  --     0.5851                 0.5851                 0.8994
+ IR Inten    --     0.0000                 0.0000                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.00   0.00   0.04     0.00   0.00  -0.08     0.00   0.00   0.05
+     2   6     0.00   0.00   0.09     0.00   0.00  -0.01     0.00   0.00  -0.13
+     3   6     0.00   0.00   0.05     0.00   0.00   0.07     0.00   0.00   0.08
+     4   6     0.00   0.00  -0.04     0.00   0.00   0.08     0.00   0.00   0.05
+     5   6     0.00   0.00  -0.09     0.00   0.00   0.01     0.00   0.00  -0.13
+     6   6     0.00   0.00  -0.05     0.00   0.00  -0.07     0.00   0.00   0.08
+     7   1     0.00   0.00  -0.24     0.00   0.00   0.52     0.00   0.00  -0.23
+     8   1     0.00   0.00  -0.57     0.00   0.00   0.05     0.00   0.00   0.56
+     9   1     0.00   0.00  -0.33     0.00   0.00  -0.47     0.00   0.00  -0.33
+    10   1     0.00   0.00   0.24     0.00   0.00  -0.52     0.00   0.00  -0.23
+    11   1     0.00   0.00   0.57     0.00   0.00  -0.05     0.00   0.00   0.56
+    12   1     0.00   0.00   0.33     0.00   0.00   0.47     0.00   0.00  -0.33
+                    10                     11                     12
+                     A                      A                      A
+ Frequencies --   989.3560              1011.9492              1028.1894
+ Red. masses --     1.5595                 1.7892                 6.8008
+ Frc consts  --     0.8994                 1.0795                 4.2360
+ IR Inten    --     0.0000                 0.0000                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.00   0.00  -0.12     0.00   0.00  -0.11    -0.11   0.28   0.00
+     2   6     0.00   0.00   0.01     0.00   0.00   0.11     0.29  -0.04   0.00
+     3   6     0.00   0.00   0.10     0.00   0.00  -0.11    -0.19  -0.23   0.00
+     4   6     0.00   0.00  -0.12     0.00   0.00   0.11    -0.11   0.28   0.00
+     5   6     0.00   0.00   0.01     0.00   0.00  -0.11     0.29  -0.04   0.00
+     6   6     0.00   0.00   0.10     0.00   0.00   0.11    -0.19  -0.23   0.00
+     7   1     0.00   0.00   0.51     0.00   0.00   0.39    -0.10   0.26   0.00
+     8   1     0.00   0.00  -0.06     0.00   0.00  -0.39     0.28  -0.04   0.00
+     9   1     0.00   0.00  -0.46     0.00   0.00   0.39    -0.18  -0.22   0.00
+    10   1     0.00   0.00   0.51     0.00   0.00  -0.39    -0.10   0.26   0.00
+    11   1     0.00   0.00  -0.06     0.00   0.00   0.39     0.28  -0.04   0.00
+    12   1     0.00   0.00  -0.46     0.00   0.00  -0.39    -0.18  -0.22   0.00
+                    13                     14                     15
+                     A                      A                      A
+ Frequencies --  1145.8312              1145.8472              1178.7041
+ Red. masses --     1.2184                 1.2184                 1.1529
+ Frc consts  --     0.9425                 0.9425                 0.9437
+ IR Inten    --     1.0879                 1.0881                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.04   0.06   0.00    -0.02  -0.04   0.00    -0.04  -0.02   0.00
+     2   6    -0.01  -0.03   0.00     0.07  -0.01   0.00     0.01   0.05   0.00
+     3   6     0.05   0.03   0.00     0.01   0.05   0.00     0.04  -0.03   0.00
+     4   6    -0.04   0.06   0.00    -0.02  -0.04   0.00    -0.04  -0.02   0.00
+     5   6    -0.01  -0.03   0.00     0.07  -0.01   0.00     0.01   0.05   0.00
+     6   6     0.05   0.03   0.00     0.01   0.05   0.00     0.04  -0.03   0.00
+     7   1    -0.23  -0.02   0.00    -0.48  -0.22   0.00     0.38   0.15   0.00
+     8   1    -0.09  -0.56   0.00     0.06  -0.08   0.00    -0.06  -0.40   0.00
+     9   1     0.30  -0.17   0.00    -0.33   0.32   0.00    -0.32   0.25   0.00
+    10   1    -0.23  -0.02   0.00    -0.48  -0.22   0.00     0.38   0.15   0.00
+    11   1    -0.09  -0.56   0.00     0.06  -0.08   0.00    -0.06  -0.40   0.00
+    12   1     0.30  -0.17   0.00    -0.33   0.32   0.00    -0.32   0.25   0.00
+                    16                     17                     18
+                     A                      A                      A
+ Frequencies --  1221.6470              1221.6522              1276.2049
+ Red. masses --     1.0296                 1.0296                 6.2557
+ Frc consts  --     0.9054                 0.9054                 6.0029
+ IR Inten    --     0.0000                 0.0000                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.01   0.01   0.00     0.02   0.01   0.00     0.10  -0.26   0.00
+     2   6     0.01   0.02   0.00     0.01  -0.01   0.00     0.28  -0.04   0.00
+     3   6     0.02   0.00   0.00     0.01  -0.02   0.00     0.18   0.22   0.00
+     4   6     0.01  -0.01   0.00    -0.02  -0.01   0.00    -0.10   0.26   0.00
+     5   6    -0.01  -0.02   0.00    -0.01   0.01   0.00    -0.28   0.04   0.00
+     6   6    -0.02   0.00   0.00    -0.01   0.02   0.00    -0.18  -0.22   0.00
+     7   1    -0.16  -0.04   0.00     0.51   0.21   0.00     0.11  -0.27   0.00
+     8   1     0.09   0.55   0.00     0.00  -0.14   0.00     0.29  -0.04   0.00
+     9   1     0.32  -0.24   0.00     0.32  -0.27   0.00     0.18   0.23   0.00
+    10   1     0.16   0.04   0.00    -0.51  -0.21   0.00    -0.11   0.27   0.00
+    11   1    -0.09  -0.55   0.00     0.00   0.14   0.00    -0.29   0.04   0.00
+    12   1    -0.32   0.24   0.00    -0.32   0.27   0.00    -0.18  -0.23   0.00
+                    19                     20                     21
+                     A                      A                      A
+ Frequencies --  1328.3798              1366.6677              1579.0362
+ Red. masses --     1.2503                 4.8034                 3.9663
+ Frc consts  --     1.2999                 5.2860                 5.8267
+ IR Inten    --     0.0000                 0.0000                12.1818
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.06  -0.02   0.00    -0.22  -0.09   0.00     0.11  -0.15   0.00
+     2   6    -0.01  -0.06   0.00     0.04   0.24   0.00     0.09   0.21   0.00
+     3   6     0.05  -0.04   0.00     0.19  -0.15   0.00    -0.21   0.02   0.00
+     4   6     0.06   0.02   0.00    -0.22  -0.09   0.00     0.11  -0.15   0.00
+     5   6     0.01   0.06   0.00     0.04   0.24   0.00     0.09   0.21   0.00
+     6   6    -0.05   0.04   0.00     0.19  -0.15   0.00    -0.21   0.02   0.00
+     7   1     0.38   0.15   0.00    -0.31  -0.12   0.00    -0.02  -0.19   0.00
+     8   1     0.06   0.40   0.00     0.05   0.33   0.00    -0.01  -0.44   0.00
+     9   1    -0.32   0.25   0.00     0.26  -0.21   0.00     0.20  -0.31   0.00
+    10   1    -0.38  -0.15   0.00    -0.31  -0.12   0.00    -0.02  -0.19   0.00
+    11   1    -0.06  -0.40   0.00     0.05   0.33   0.00    -0.01  -0.44   0.00
+    12   1     0.32  -0.25   0.00     0.26  -0.21   0.00     0.20  -0.31   0.00
+                    22                     23                     24
+                     A                      A                      A
+ Frequencies --  1579.0444              1767.5723              1767.5887
+ Red. masses --     3.9663                10.4958                10.4956
+ Frc consts  --     5.8268                19.3205                19.3206
+ IR Inten    --    12.1827                 0.0000                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.20   0.12   0.00     0.21   0.25   0.00     0.43   0.05   0.00
+     2   6    -0.16   0.10   0.00    -0.09  -0.49   0.00    -0.18   0.07   0.00
+     3   6     0.04  -0.21   0.00    -0.06   0.27   0.00     0.40  -0.22   0.00
+     4   6     0.20   0.12   0.00    -0.21  -0.25   0.00    -0.43  -0.05   0.00
+     5   6    -0.16   0.10   0.00     0.09   0.49   0.00     0.18  -0.07   0.00
+     6   6     0.04  -0.21   0.00     0.06  -0.27   0.00    -0.40   0.22   0.00
+     7   1    -0.43  -0.13   0.00    -0.13   0.08   0.00    -0.09  -0.12   0.00
+     8   1    -0.19  -0.12   0.00     0.01   0.15   0.00    -0.15   0.01   0.00
+     9   1    -0.32   0.09   0.00     0.14   0.06   0.00    -0.07   0.14   0.00
+    10   1    -0.43  -0.13   0.00     0.13  -0.08   0.00     0.09   0.12   0.00
+    11   1    -0.19  -0.12   0.00    -0.01  -0.15   0.00     0.15  -0.01   0.00
+    12   1    -0.32   0.09   0.00    -0.14  -0.06   0.00     0.07  -0.14   0.00
+                    25                     26                     27
+                     A                      A                      A
+ Frequencies --  3183.7401              3186.7932              3186.8212
+ Red. masses --     1.0770                 1.0754                 1.0754
+ Frc consts  --     6.4318                 6.4350                 6.4351
+ IR Inten    --     0.0003                 0.0000                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.01  -0.03   0.00     0.02  -0.04   0.00     0.00  -0.02   0.00
+     2   6    -0.03   0.00   0.00    -0.01   0.00   0.00    -0.04   0.01   0.00
+     3   6     0.02   0.03   0.00    -0.02  -0.03   0.00     0.01   0.02   0.00
+     4   6     0.01  -0.03   0.00    -0.02   0.04   0.00     0.00   0.02   0.00
+     5   6    -0.03   0.00   0.00     0.00   0.00   0.00     0.04  -0.01   0.00
+     6   6     0.02   0.03   0.00     0.02   0.03   0.00    -0.01  -0.02   0.00
+     7   1    -0.15   0.38   0.00    -0.19   0.49   0.00    -0.09   0.22   0.00
+     8   1     0.40  -0.06   0.00     0.06  -0.01   0.00     0.57  -0.09   0.00
+     9   1    -0.26  -0.32   0.00     0.29   0.36   0.00    -0.21  -0.26   0.00
+    10   1    -0.15   0.38   0.00     0.19  -0.49   0.00     0.09  -0.22   0.00
+    11   1     0.40  -0.06   0.00    -0.05   0.01   0.00    -0.57   0.09   0.00
+    12   1    -0.25  -0.32   0.00    -0.29  -0.37   0.00     0.21   0.26   0.00
+                    28                     29                     30
+                     A                      A                      A
+ Frequencies --  3194.5388              3194.5679              3205.1325
+ Red. masses --     1.0817                 1.0817                 1.0920
+ Frc consts  --     6.5038                 6.5039                 6.6097
+ IR Inten    --    88.4261                88.4340                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.02   0.04   0.00     0.01  -0.02   0.00    -0.01   0.03   0.00
+     2   6     0.00   0.00   0.00     0.05  -0.01   0.00    -0.04   0.01   0.00
+     3   6     0.02   0.03   0.00     0.02   0.02   0.00    -0.02  -0.03   0.00
+     4   6    -0.02   0.04   0.00     0.01  -0.02   0.00     0.01  -0.03   0.00
+     5   6     0.00   0.00   0.00     0.05  -0.01   0.00     0.04  -0.01   0.00
+     6   6     0.02   0.03   0.00     0.02   0.02   0.00     0.02   0.03   0.00
+     7   1     0.19  -0.49   0.00    -0.08   0.22   0.00     0.15  -0.38   0.00
+     8   1     0.05  -0.01   0.00    -0.57   0.09   0.00     0.40  -0.06   0.00
+     9   1    -0.29  -0.37   0.00    -0.21  -0.26   0.00     0.25   0.32   0.00
+    10   1     0.19  -0.49   0.00    -0.08   0.22   0.00    -0.15   0.38   0.00
+    11   1     0.06  -0.01   0.00    -0.57   0.09   0.00    -0.40   0.06   0.00
+    12   1    -0.29  -0.36   0.00    -0.21  -0.26   0.00    -0.25  -0.32   0.00
+
+ -------------------
+ - Thermochemistry -
+ -------------------
+ Temperature   298.150 Kelvin.  Pressure   1.00000 Atm.
+ Atom     1 has atomic number  6 and mass  12.00000
+ Atom     2 has atomic number  6 and mass  12.00000
+ Atom     3 has atomic number  6 and mass  12.00000
+ Atom     4 has atomic number  6 and mass  12.00000
+ Atom     5 has atomic number  6 and mass  12.00000
+ Atom     6 has atomic number  6 and mass  12.00000
+ Atom     7 has atomic number  1 and mass   1.00783
+ Atom     8 has atomic number  1 and mass   1.00783
+ Atom     9 has atomic number  1 and mass   1.00783
+ Atom    10 has atomic number  1 and mass   1.00783
+ Atom    11 has atomic number  1 and mass   1.00783
+ Atom    12 has atomic number  1 and mass   1.00783
+ Molecular mass:    78.04695 amu.
+ Principal axes and moments of inertia in atomic units:
+                           1         2         3
+     Eigenvalues --   317.39231 317.39727 634.78958
+           X            0.99989  -0.01501   0.00000
+           Y            0.01501   0.99989   0.00000
+           Z            0.00000   0.00000   1.00000
+ This molecule is an asymmetric top.
+ Rotational symmetry number  1.
+ Rotational temperatures (Kelvin)      0.27289     0.27289     0.13644
+ Rotational constants (GHZ):           5.68615     5.68606     2.84305
+ Zero-point vibrational energy     268743.3 (Joules/Mol)
+                                   64.23118 (Kcal/Mol)
+ Warning -- explicit consideration of   3 degrees of freedom as
+           vibrations may cause significant error
+ Vibrational temperatures:    533.49   533.50   889.18   932.02   932.02
+          (Kelvin)           1070.60  1282.28  1282.30  1423.45  1423.46
+                             1455.97  1479.33  1648.59  1648.62  1695.89
+                             1757.68  1757.68  1836.17  1911.24  1966.33
+                             2271.88  2271.89  2543.14  2543.16  4580.69
+                             4585.08  4585.12  4596.22  4596.26  4611.47
+ 
+ Zero-point correction=                           0.102359 (Hartree/Particle)
+ Thermal correction to Energy=                    0.106775
+ Thermal correction to Enthalpy=                  0.107719
+ Thermal correction to Gibbs Free Energy=         0.074840
+ Sum of electronic and zero-point Energies=              0.137312
+ Sum of electronic and thermal Energies=                 0.141728
+ Sum of electronic and thermal Enthalpies=               0.142672
+ Sum of electronic and thermal Free Energies=            0.109792
+ 
+                     E (Thermal)             CV                S
+                      KCal/Mol        Cal/Mol-Kelvin    Cal/Mol-Kelvin
+ Total                   67.002             16.818             69.201
+ Electronic               0.000              0.000              0.000
+ Translational            0.889              2.981             38.979
+ Rotational               0.889              2.981             25.662
+ Vibrational             65.225             10.856              4.560
+ Vibration     1          0.743              1.532              1.077
+ Vibration     2          0.743              1.532              1.076
+ Vibration     3          0.978              0.994              0.420
+                       Q            Log10(Q)             Ln(Q)
+ Total Bot       0.376914D-34        -34.423758        -79.263631
+ Total V=0       0.454958D+13         12.657971         29.146055
+ Vib (Bot)       0.153636D-46        -46.813508       -107.792085
+ Vib (Bot)    1  0.490732D+00         -0.309155         -0.711857
+ Vib (Bot)    2  0.490724D+00         -0.309163         -0.711874
+ Vib (Bot)    3  0.237128D+00         -0.625017         -1.439154
+ Vib (V=0)       0.185447D+01          0.268221          0.617601
+ Vib (V=0)    1  0.120058D+01          0.079393          0.182808
+ Vib (V=0)    2  0.120058D+01          0.079390          0.182803
+ Vib (V=0)    3  0.105338D+01          0.022585          0.052004
+ Electronic      0.100000D+01          0.000000          0.000000
+ Translational   0.271012D+08          7.432989         17.115090
+ Rotational      0.905235D+05          4.956761         11.413364
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000005945   -0.000003588   -0.000000880
+      2        6          -0.000006106    0.000011944    0.000004648
+      3        6          -0.000006500    0.000005028   -0.000002854
+      4        6          -0.000005170   -0.000004376    0.000001564
+      5        6           0.000010709   -0.000013750    0.000001165
+      6        6           0.000003297    0.000007461   -0.000001903
+      7        1          -0.000002108    0.000003071   -0.000000581
+      8        1           0.000001758   -0.000000269   -0.000000971
+      9        1          -0.000003166   -0.000000686   -0.000000305
+     10        1          -0.000001761   -0.000003616   -0.000000037
+     11        1           0.000002154    0.000001495   -0.000000920
+     12        1           0.000000945   -0.000002714    0.000001073
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000013750 RMS     0.000004749
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Internal  Forces:  Max     0.000013903 RMS     0.000003686
+ Search for a local minimum.
+ Step number   1 out of a maximum of    2
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- analytic derivatives used.
+ ITU=  0
+     Eigenvalues ---    0.01286   0.01286   0.01385   0.02578   0.02578
+     Eigenvalues ---    0.02867   0.03155   0.03188   0.03188   0.09908
+     Eigenvalues ---    0.11435   0.11435   0.11455   0.11743   0.11743
+     Eigenvalues ---    0.19037   0.19038   0.19376   0.32647   0.35246
+     Eigenvalues ---    0.35247   0.35882   0.36820   0.36821   0.36983
+     Eigenvalues ---    0.58236   0.58237   0.61999   0.62000   0.80762
+ Angle between quadratic step and forces=  59.08 degrees.
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00001749 RMS(Int)=  0.00000001
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000001
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.63628  -0.00001   0.00000  -0.00001  -0.00001   2.63626
+    R2        2.63626   0.00000   0.00000   0.00001   0.00001   2.63626
+    R3        2.07808   0.00000   0.00000  -0.00001  -0.00001   2.07808
+    R4        2.63627  -0.00001   0.00000  -0.00001  -0.00001   2.63626
+    R5        2.07807   0.00000   0.00000   0.00001   0.00001   2.07808
+    R6        2.63628  -0.00001   0.00000  -0.00002  -0.00002   2.63626
+    R7        2.07808   0.00000   0.00000  -0.00001  -0.00001   2.07808
+    R8        2.63628  -0.00001   0.00000  -0.00002  -0.00002   2.63626
+    R9        2.07809   0.00000   0.00000  -0.00001  -0.00001   2.07808
+   R10        2.63628  -0.00001   0.00000  -0.00002  -0.00002   2.63626
+   R11        2.07807   0.00000   0.00000   0.00000   0.00000   2.07808
+   R12        2.07808   0.00000   0.00000   0.00000   0.00000   2.07808
+    A1        2.09441   0.00000   0.00000  -0.00001  -0.00001   2.09440
+    A2        2.09436   0.00001   0.00000   0.00004   0.00004   2.09440
+    A3        2.09442   0.00000   0.00000  -0.00003  -0.00003   2.09440
+    A4        2.09438   0.00000   0.00000   0.00001   0.00001   2.09440
+    A5        2.09439   0.00000   0.00000   0.00001   0.00001   2.09440
+    A6        2.09442   0.00000   0.00000  -0.00002  -0.00002   2.09440
+    A7        2.09440   0.00000   0.00000   0.00000   0.00000   2.09440
+    A8        2.09440   0.00000   0.00000  -0.00001  -0.00001   2.09440
+    A9        2.09438   0.00000   0.00000   0.00001   0.00001   2.09440
+   A10        2.09440   0.00000   0.00000  -0.00001  -0.00001   2.09440
+   A11        2.09439   0.00000   0.00000   0.00000   0.00000   2.09440
+   A12        2.09439   0.00000   0.00000   0.00000   0.00000   2.09440
+   A13        2.09438   0.00000   0.00000   0.00002   0.00002   2.09440
+   A14        2.09443   0.00000   0.00000  -0.00003  -0.00003   2.09440
+   A15        2.09438   0.00000   0.00000   0.00001   0.00001   2.09440
+   A16        2.09440   0.00000   0.00000  -0.00001  -0.00001   2.09440
+   A17        2.09442   0.00000   0.00000  -0.00002  -0.00002   2.09440
+   A18        2.09437   0.00000   0.00000   0.00003   0.00003   2.09440
+    D1        0.00003   0.00000   0.00000  -0.00003  -0.00003   0.00000
+    D2        3.14158   0.00000   0.00000   0.00001   0.00001   3.14159
+    D3       -3.14156   0.00000   0.00000  -0.00003  -0.00003  -3.14159
+    D4       -0.00001   0.00000   0.00000   0.00001   0.00001   0.00000
+    D5       -0.00001   0.00000   0.00000   0.00001   0.00001   0.00000
+    D6        3.14157   0.00000   0.00000   0.00003   0.00003   3.14159
+    D7        3.14158   0.00000   0.00000   0.00001   0.00001   3.14159
+    D8       -0.00003   0.00000   0.00000   0.00003   0.00003   0.00000
+    D9       -0.00004   0.00000   0.00000   0.00004   0.00004   0.00000
+   D10        3.14156   0.00000   0.00000   0.00003   0.00003   3.14159
+   D11       -3.14159   0.00000   0.00000   0.00000   0.00000   3.14159
+   D12        0.00001   0.00000   0.00000  -0.00001  -0.00001   0.00000
+   D13        0.00003   0.00000   0.00000  -0.00003  -0.00003   0.00000
+   D14       -3.14158   0.00000   0.00000  -0.00002  -0.00002  -3.14159
+   D15       -3.14157   0.00000   0.00000  -0.00002  -0.00002  -3.14159
+   D16        0.00001   0.00000   0.00000  -0.00001  -0.00001   0.00000
+   D17       -0.00001   0.00000   0.00000   0.00001   0.00001   0.00000
+   D18        3.14157   0.00000   0.00000   0.00003   0.00003   3.14159
+   D19       -3.14159   0.00000   0.00000  -0.00001  -0.00001  -3.14159
+   D20       -0.00001   0.00000   0.00000   0.00001   0.00001   0.00000
+   D21       -0.00001   0.00000   0.00000   0.00001   0.00001   0.00000
+   D22       -3.14158   0.00000   0.00000  -0.00002  -0.00002   3.14159
+   D23       -3.14158   0.00000   0.00000  -0.00002  -0.00002   3.14159
+   D24        0.00004   0.00000   0.00000  -0.00004  -0.00004   0.00000
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000014     0.000450     YES
+ RMS     Force            0.000004     0.000300     YES
+ Maximum Displacement     0.000052     0.001800     YES
+ RMS     Displacement     0.000017     0.001200     YES
+ Predicted change in Energy=-9.530697D-10
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.3951         -DE/DX =    0.0                 !
+ ! R2    R(1,6)                  1.395          -DE/DX =    0.0                 !
+ ! R3    R(1,7)                  1.0997         -DE/DX =    0.0                 !
+ ! R4    R(2,3)                  1.3951         -DE/DX =    0.0                 !
+ ! R5    R(2,8)                  1.0997         -DE/DX =    0.0                 !
+ ! R6    R(3,4)                  1.3951         -DE/DX =    0.0                 !
+ ! R7    R(3,9)                  1.0997         -DE/DX =    0.0                 !
+ ! R8    R(4,5)                  1.3951         -DE/DX =    0.0                 !
+ ! R9    R(4,10)                 1.0997         -DE/DX =    0.0                 !
+ ! R10   R(5,6)                  1.3951         -DE/DX =    0.0                 !
+ ! R11   R(5,11)                 1.0997         -DE/DX =    0.0                 !
+ ! R12   R(6,12)                 1.0997         -DE/DX =    0.0                 !
+ ! A1    A(2,1,6)              120.0008         -DE/DX =    0.0                 !
+ ! A2    A(2,1,7)              119.9978         -DE/DX =    0.0                 !
+ ! A3    A(6,1,7)              120.0014         -DE/DX =    0.0                 !
+ ! A4    A(1,2,3)              119.9992         -DE/DX =    0.0                 !
+ ! A5    A(1,2,8)              119.9996         -DE/DX =    0.0                 !
+ ! A6    A(3,2,8)              120.0012         -DE/DX =    0.0                 !
+ ! A7    A(2,3,4)              120.0001         -DE/DX =    0.0                 !
+ ! A8    A(2,3,9)              120.0006         -DE/DX =    0.0                 !
+ ! A9    A(4,3,9)              119.9993         -DE/DX =    0.0                 !
+ ! A10   A(3,4,5)              120.0005         -DE/DX =    0.0                 !
+ ! A11   A(3,4,10)             119.9998         -DE/DX =    0.0                 !
+ ! A12   A(5,4,10)             119.9997         -DE/DX =    0.0                 !
+ ! A13   A(4,5,6)              119.999          -DE/DX =    0.0                 !
+ ! A14   A(4,5,11)             120.0018         -DE/DX =    0.0                 !
+ ! A15   A(6,5,11)             119.9992         -DE/DX =    0.0                 !
+ ! A16   A(1,6,5)              120.0004         -DE/DX =    0.0                 !
+ ! A17   A(1,6,12)             120.0013         -DE/DX =    0.0                 !
+ ! A18   A(5,6,12)             119.9983         -DE/DX =    0.0                 !
+ ! D1    D(6,1,2,3)              0.0016         -DE/DX =    0.0                 !
+ ! D2    D(6,1,2,8)            179.9992         -DE/DX =    0.0                 !
+ ! D3    D(7,1,2,3)           -179.9981         -DE/DX =    0.0                 !
+ ! D4    D(7,1,2,8)             -0.0005         -DE/DX =    0.0                 !
+ ! D5    D(2,1,6,5)             -0.0003         -DE/DX =    0.0                 !
+ ! D6    D(2,1,6,12)           179.9985         -DE/DX =    0.0                 !
+ ! D7    D(7,1,6,5)            179.9994         -DE/DX =    0.0                 !
+ ! D8    D(7,1,6,12)            -0.0018         -DE/DX =    0.0                 !
+ ! D9    D(1,2,3,4)             -0.0023         -DE/DX =    0.0                 !
+ ! D10   D(1,2,3,9)            179.9983         -DE/DX =    0.0                 !
+ ! D11   D(8,2,3,4)            180.0002         -DE/DX =    0.0                 !
+ ! D12   D(8,2,3,9)              0.0007         -DE/DX =    0.0                 !
+ ! D13   D(2,3,4,5)              0.0016         -DE/DX =    0.0                 !
+ ! D14   D(2,3,4,10)          -179.9991         -DE/DX =    0.0                 !
+ ! D15   D(9,3,4,5)           -179.9989         -DE/DX =    0.0                 !
+ ! D16   D(9,3,4,10)             0.0003         -DE/DX =    0.0                 !
+ ! D17   D(3,4,5,6)             -0.0004         -DE/DX =    0.0                 !
+ ! D18   D(3,4,5,11)           179.9985         -DE/DX =    0.0                 !
+ ! D19   D(10,4,5,6)          -179.9996         -DE/DX =    0.0                 !
+ ! D20   D(10,4,5,11)           -0.0008         -DE/DX =    0.0                 !
+ ! D21   D(4,5,6,1)             -0.0003         -DE/DX =    0.0                 !
+ ! D22   D(4,5,6,12)           180.0009         -DE/DX =    0.0                 !
+ ! D23   D(11,5,6,1)           180.0009         -DE/DX =    0.0                 !
+ ! D24   D(11,5,6,12)            0.0021         -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ 1\1\ SIUV- VIVES\Freq\RAM1\ZDO\C6H6\MIKE\05-Aug-2015\0\\# AM1 freq=HPm
+ odes geom=check guess=read\\Benzene frequency calculation printing out
+  normal mode displacements in higher precision\\0,1\C,-0.318996994,1.9
+ 256612966,0.000058544\C,1.0760606099,1.9255751224,0.0004857433\C,1.773
+ 6449418,3.1336925304,-0.0000452677\C,1.0761756697,4.3418853264,-0.0010
+ 517012\C,-0.318882027,4.3419677736,-0.0014924252\C,-1.0164619031,3.133
+ 840281,-0.00093409\H,-0.8688554649,0.9733291622,0.0005086263\H,1.62582
+ 8445,0.9731977218,0.0012816161\H,2.8733191108,3.1336505628,0.000320104
+ 8\H,1.626065422,5.2942021326,-0.0014852623\H,-0.8686896202,5.294323033
+ 1,-0.0022605138\H,-2.1161335499,3.1339184171,-0.0012963743\\Version=EM
+ 64L-G09RevC.01\State=1-A\HF=0.0349527\RMSD=9.747e-10\RMSF=4.749e-06\Ze
+ roPoint=0.1023589\Thermal=0.1067749\Dipole=0.0000019,0.000003,0.000012
+ 8\DipoleDeriv=-0.1300928,0.0360801,-0.0000236,0.0360685,-0.088456,-0.0
+ 00024,-0.0000231,-0.0000222,-0.1424293,-0.1300961,-0.0360666,0.0000273
+ ,-0.0360565,-0.0884483,-0.0000453,0.0000305,-0.0000508,-0.1424313,-0.0
+ 676216,-0.0000057,0.0000273,-0.0000156,-0.1509236,0.000007,0.0000208,0
+ .0000072,-0.1424294,-0.1300978,0.036071,-0.0000187,0.0360757,-0.088449
+ 4,-0.0000248,-0.0000182,-0.0000242,-0.1424299,-0.1300998,-0.0360575,0.
+ 0000241,-0.0360631,-0.0884444,-0.0000447,0.0000225,-0.0000423,-0.14243
+ 21,-0.0676236,-0.0000068,0.0000263,0.0000026,-0.1509228,0.0000047,0.00
+ 00316,0.0000047,-0.142429,0.0759791,0.0576652,-0.0000572,0.0576665,0.1
+ 425604,0.0000173,-0.0000578,0.0000162,0.1424278,0.0759705,-0.0576664,0
+ .0000154,-0.0576653,0.1425781,-0.0000185,0.0000131,-0.0000136,0.142430
+ 9,0.1758588,-0.000005,0.0000108,-0.0000052,0.0426853,0.0000633,0.00001
+ 41,0.0000633,0.1424293,0.0759836,0.057668,-0.0000588,0.0576701,0.14255
+ 74,0.0000184,-0.0000592,0.0000162,0.1424288,0.0759761,-0.0576692,0.000
+ 016,-0.0576697,0.1425739,-0.0000177,0.0000164,-0.0000183,0.1424316,0.1
+ 758571,-0.0000098,0.000011,-0.0000106,0.0426851,0.0000642,0.0000096,0.
+ 0000639,0.1424286\Polar=68.606661,-0.0003249,68.6068993,0.0189209,-0.0
+ 381165,9.0314051\HyperPolar=0.0001214,0.0024497,-0.0000607,-0.0025236,
+ 0.0003758,0.0001727,-0.0002194,-0.0000494,-0.0000422,-0.0000931\PG=C01
+  [X(C6H6)]\NImag=0\\0.78281838,0.00131431,0.78438210,0.00019386,-0.000
+ 40816,0.15077761,-0.39683205,-0.06069507,-0.00006017,0.78281542,0.0607
+ 3305,-0.10539701,0.00004130,-0.00133476,0.78437763,-0.00013778,0.00000
+ 278,-0.07110191,0.00020109,-0.00040316,0.15077798,-0.05956505,-0.04324
+ 660,0.00000617,-0.17827212,-0.18692168,0.00008256,0.78512622,-0.139698
+ 44,0.04608413,-0.00006899,-0.06549234,-0.32397247,0.00013633,0.0000154
+ 8,0.78204924,0.00006799,-0.00003844,0.00759895,0.00000487,0.00009749,-
+ 0.07110121,0.00021032,-0.00040214,0.15078069,-0.08604129,0.04677061,-0
+ .00005556,0.09888814,0.04821421,-0.00000169,-0.17824237,0.06546933,-0.
+ 00007792,0.78281570,0.04677088,-0.03204918,0.00003241,-0.04823656,-0.1
+ 1236709,0.00006137,0.18689693,-0.32397934,0.00022420,0.00133610,0.7843
+ 4669,-0.00005623,0.00003280,-0.00429111,0.00006016,0.00009169,0.007598
+ 15,-0.00015541,0.00018522,-0.07110254,0.00020079,-0.00040720,0.1507822
+ 9,0.09888816,-0.04823602,0.00005939,-0.08604991,-0.04676435,0.00000378
+ ,-0.05954249,0.13970537,-0.00011071,-0.39683201,-0.06069605,-0.0000636
+ 2,0.78281646,0.04821533,-0.11236854,0.00009209,-0.04676539,-0.03203761
+ ,0.00000280,0.04325524,0.04606515,-0.00001051,0.06073255,-0.10540026,0
+ .00004126,-0.00134659,0.78435948,-0.00000220,0.00006168,0.00759836,0.0
+ 0000414,0.00000297,-0.00429129,-0.00004924,0.00001998,0.00759782,-0.00
+ 014146,0.00000255,-0.07110255,0.00019852,-0.00040423,0.15078003,-0.178
+ 25090,0.18691451,-0.00015341,-0.05954463,0.04325618,-0.00004863,-0.005
+ 04213,-0.00000473,-0.00000018,-0.05956368,-0.04324656,0.00000662,-0.17
+ 826536,-0.18691335,0.00008647,0.78513237,0.06548535,-0.32400581,0.0001
+ 8272,0.13970760,0.04606432,0.00001977,-0.00000511,-0.11304742,0.000069
+ 39,-0.13969793,0.04608398,-0.00006927,-0.06548498,-0.32396124,0.000142
+ 16,-0.00002120,0.78206553,-0.00007568,0.00022089,-0.07109970,-0.000110
+ 23,-0.00001125,0.00759826,-0.00000020,0.00006977,-0.00429113,0.0000684
+ 9,-0.00003838,0.00759880,0.00000859,0.00010379,-0.07110227,0.00020257,
+ -0.00040494,0.15077784,-0.10695260,-0.11925431,0.00005772,-0.02822659,
+ -0.02834203,0.00000785,-0.00360707,0.00097747,-0.00000351,0.00026050,0
+ .00007976,0.00000002,-0.00132417,0.00165206,-0.00000322,0.00792331,0.0
+ 1166459,-0.00000680,0.13232782,-0.11925362,-0.24463910,0.00009464,-0.0
+ 0920270,-0.00170394,0.00000194,0.00033430,0.00019369,0.00000378,0.0000
+ 7971,0.00035270,-0.00000017,0.00229527,-0.00208898,0.00000582,-0.00747
+ 547,-0.03785180,0.00002577,0.13314460,0.28604839,0.00005778,0.00009468
+ ,-0.04248633,-0.00000461,-0.00000396,0.00565547,-0.00000315,0.00000404
+ ,0.00582067,0.00000012,-0.00000026,0.00005287,-0.00000382,0.00000554,0
+ .00582103,0.00000561,0.00003169,0.00565466,-0.00005324,-0.00012904,0.0
+ 2408390,-0.02822149,0.02834429,-0.00002892,-0.10693224,0.11924563,-0.0
+ 0009809,0.00792288,-0.01166887,0.00000816,-0.00132412,-0.00165226,-0.0
+ 0000127,0.00026019,-0.00007972,0.00000012,-0.00360696,-0.00097676,-0.0
+ 0000235,-0.00055501,0.00010093,0.00000025,0.13230332,0.00920451,-0.001
+ 70733,0.00000768,0.11924572,-0.24466815,0.00016945,0.00747093,-0.03785
+ 145,0.00003023,-0.00229551,-0.00208853,0.00000428,-0.00007938,0.000352
+ 71,-0.00000022,-0.00033381,0.00019358,0.00000352,-0.00010076,0.0004392
+ 8,-0.00000128,-0.13313434,0.28608027,-0.00001637,0.00001361,0.00565495
+ ,-0.00009845,0.00016982,-0.04248488,-0.00000405,0.00002399,0.00565466,
+ -0.00000081,0.00000438,0.00582098,0.,-0.00000024,0.00005286,-0.0000026
+ 6,0.00000342,0.00582074,0.00000035,-0.00000122,-0.00149288,0.00012093,
+ -0.00021216,0.02408283,-0.00018866,-0.00163966,-0.00000100,-0.02459441
+ ,-0.01129842,-0.00000280,-0.31349297,0.00001037,-0.00009007,-0.0245910
+ 1,0.01130053,-0.00001720,-0.00018831,0.00163939,-0.00000308,0.00039872
+ ,-0.00000005,0.00000010,-0.00027293,0.00000946,0.00000002,0.00019068,-
+ 0.00032961,0.00000076,0.36292279,-0.00099654,-0.00322461,0.00000543,-0
+ .03043824,-0.00533422,-0.00000305,0.00001061,-0.03809798,-0.00000283,0
+ .03044006,-0.00533821,0.00001706,0.00099618,-0.00322490,0.00000609,-0.
+ 00000002,0.00021443,-0.00000011,-0.00063011,0.00008548,-0.00000044,-0.
+ 00053115,-0.00030614,-0.00000094,-0.00001220,0.05545136,-0.00000138,0.
+ 00000522,0.00582097,0.00000930,0.00000330,0.00565484,-0.00008990,-0.00
+ 000286,-0.04248642,-0.00002956,0.00001075,0.00565481,-0.00000254,0.000
+ 00639,0.00582072,0.00000015,-0.00000018,0.00005285,0.00000039,-0.00000
+ 026,-0.00032634,0.00000088,-0.00000088,-0.00149297,0.00011260,-0.00001
+ 995,0.02408440,0.00026048,0.00007978,0.00000001,-0.00132413,0.00165206
+ ,-0.00000337,0.00792316,0.01166374,-0.00000673,-0.10695953,-0.11925635
+ ,0.00005565,-0.02822576,-0.02834121,0.00000736,-0.00360700,0.00097744,
+ -0.00000364,-0.00002889,-0.00004210,0.00000033,0.00026465,0.00031974,0
+ .,0.00019082,0.00053111,0.00000020,0.13233363,0.00007968,0.00035272,-0
+ .00000016,0.00229534,-0.00208906,0.00000586,-0.00747586,-0.03785206,0.
+ 00002550,-0.11925635,-0.24462953,0.00009131,-0.00920156,-0.00170320,0.
+ 00000179,0.00033436,0.00019361,0.00000372,-0.00004210,-0.00007753,-0.0
+ 0000058,-0.00031981,-0.00045207,-0.00000004,0.00032960,-0.00030622,-0.
+ 00000065,0.13314646,0.28603870,-0.00000019,-0.00000007,0.00005285,-0.0
+ 0000360,0.00000575,0.00582073,0.00000561,0.00003144,0.00565472,0.00005
+ 540,0.00009136,-0.04248666,-0.00000471,-0.00000423,0.00565489,-0.00000
+ 319,0.00000371,0.00582094,0.00000031,-0.00000059,-0.00096366,0.0000004
+ 0,0.00000019,-0.00032633,0.00000035,-0.00000057,-0.00149292,-0.0000506
+ 2,-0.00012527,0.02408469,-0.00132404,-0.00165227,-0.00000112,0.0002601
+ 6,-0.00007974,0.00000011,-0.00360685,-0.00097676,-0.00000233,-0.028220
+ 89,0.02834328,-0.00002859,-0.10694166,0.11925021,-0.00009491,0.0079228
+ 7,-0.01166778,0.00000817,0.00026465,-0.00031979,0.00000039,-0.00002897
+ ,0.00004197,0.00000026,-0.00027288,0.00063014,-0.00000041,-0.00055462,
+ 0.00010087,0.00000023,0.13231166,-0.00229561,-0.00208863,0.00000431,-0
+ .00007933,0.00035274,-0.00000020,-0.00033391,0.00019348,0.00000342,0.0
+ 0920312,-0.00170625,0.00000751,0.11925102,-0.24465810,0.00016406,0.007
+ 47162,-0.03785254,0.00002998,0.00031975,-0.00045208,0.00000019,0.00004
+ 197,-0.00007751,-0.00000055,-0.00000942,0.00008543,-0.00000027,-0.0001
+ 0071,0.00043923,-0.00000125,-0.13313872,0.28607072,-0.00000080,0.00000
+ 459,0.00582073,0.00000016,-0.00000017,0.00005285,-0.00000280,0.0000032
+ 2,0.00582097,-0.00001662,0.00001354,0.00565433,-0.00009475,0.00016379,
+ -0.04248491,-0.00000395,0.00002417,0.00565503,-0.00000002,-0.00000002,
+ -0.00032633,0.00000027,-0.00000055,-0.00096367,0.00000003,-0.00000007,
+ -0.00032632,0.00000037,-0.00000121,-0.00149296,0.00011735,-0.00020633,
+ 0.02408310,-0.02459014,0.01130036,-0.00001697,-0.00018830,0.00163930,-
+ 0.00000302,0.00039872,-0.00000001,0.00000011,-0.00018864,-0.00163976,-
+ 0.00000091,-0.02459580,-0.01129907,-0.00000249,-0.31349670,0.00001944,
+ -0.00008899,0.00019086,0.00032951,0.00000034,-0.00027288,-0.00000941,0
+ .00000004,-0.00010186,0.,0.00000027,-0.00027294,0.00000947,0.00000001,
+ 0.00019064,-0.00032974,0.00000076,0.36292703,0.03044041,-0.00533841,0.
+ 00001673,0.00099616,-0.00322488,0.00000611,-0.00000002,0.00021443,-0.0
+ 0000010,-0.00099656,-0.00322463,0.00000551,-0.03043847,-0.00533426,-0.
+ 00000265,0.00001878,-0.03809725,-0.00000276,0.00053094,-0.00030602,-0.
+ 00000058,0.00063014,0.00008541,-0.00000008,0.00000001,-0.00000458,-0.0
+ 0000062,-0.00063010,0.00008550,-0.00000046,-0.00053137,-0.00030641,-0.
+ 00000094,-0.00002007,0.05545096,-0.00002900,0.00001041,0.00565467,-0.0
+ 0000264,0.00000622,0.00582105,0.00000011,0.,0.00005286,-0.00000119,0.0
+ 0000529,0.00582067,0.00000988,0.00000354,0.00565534,-0.00008939,-0.000
+ 00265,-0.04248596,0.00000016,-0.00000066,-0.00149309,-0.00000038,-0.00
+ 000027,-0.00032633,0.00000030,-0.00000061,-0.00096367,0.00000044,-0.00
+ 000026,-0.00032634,0.00000084,-0.00000086,-0.00149285,0.00011086,-0.00
+ 002015,0.02408361\\-0.00000595,0.00000359,0.00000088,0.00000611,-0.000
+ 01194,-0.00000465,0.00000650,-0.00000503,0.00000285,0.00000517,0.00000
+ 438,-0.00000156,-0.00001071,0.00001375,-0.00000117,-0.00000330,-0.0000
+ 0746,0.00000190,0.00000211,-0.00000307,0.00000058,-0.00000176,0.000000
+ 27,0.00000097,0.00000317,0.00000069,0.00000030,0.00000176,0.00000362,0
+ .00000004,-0.00000215,-0.00000149,0.00000092,-0.00000095,0.00000271,-0
+ .00000107\\\@
+
+
+ REALITY IS FOR PEOPLE WHO CAN'T FACE SCIENCE FICTION.
+ Job cpu time:  0 days  0 hours  0 minutes  1.5 seconds.
+ File lengths (MBytes):  RWF=      7 Int=      0 D2E=      0 Chk=      2 Scr=      1
+ Normal termination of Gaussian 09 at Wed Aug  5 13:34:50 2015.

--- a/Gaussian/Gaussian09/benzene_freq.log
+++ b/Gaussian/Gaussian09/benzene_freq.log
@@ -1,0 +1,1009 @@
+ Entering Gaussian System, Link 0=g09
+ Input=benzene.com
+ Output=benzene.log
+ Initial command:
+ /software/G09_RevC01/g09/l1.exe /scratch/Gau-44901.inp -scrdir=/scratch/
+ Entering Link 1 = /software/G09_RevC01/g09/l1.exe PID=     44903.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2011,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 09 program.  It is based on
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 09, Revision C.01,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, B. Mennucci, 
+ G. A. Petersson, H. Nakatsuji, M. Caricato, X. Li, H. P. Hratchian, 
+ A. F. Izmaylov, J. Bloino, G. Zheng, J. L. Sonnenberg, M. Hada, 
+ M. Ehara, K. Toyota, R. Fukuda, J. Hasegawa, M. Ishida, T. Nakajima, 
+ Y. Honda, O. Kitao, H. Nakai, T. Vreven, J. A. Montgomery, Jr., 
+ J. E. Peralta, F. Ogliaro, M. Bearpark, J. J. Heyd, E. Brothers, 
+ K. N. Kudin, V. N. Staroverov, T. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. Rendell, J. C. Burant, S. S. Iyengar, J. Tomasi, 
+ M. Cossi, N. Rega, J. M. Millam, M. Klene, J. E. Knox, J. B. Cross, 
+ V. Bakken, C. Adamo, J. Jaramillo, R. Gomperts, R. E. Stratmann, 
+ O. Yazyev, A. J. Austin, R. Cammi, C. Pomelli, J. W. Ochterski, 
+ R. L. Martin, K. Morokuma, V. G. Zakrzewski, G. A. Voth, 
+ P. Salvador, J. J. Dannenberg, S. Dapprich, A. D. Daniels, 
+ O. Farkas, J. B. Foresman, J. V. Ortiz, J. Cioslowski, 
+ and D. J. Fox, Gaussian, Inc., Wallingford CT, 2010.
+ 
+ ******************************************
+ Gaussian 09:  EM64L-G09RevC.01 23-Sep-2011
+                 5-Aug-2015 
+ ******************************************
+ %chk=benzene.chk
+ %mem=200mb
+ Default route:  CacheSize=87000
+ --------------------------------
+ # AM1 freq geom=check guess=read
+ --------------------------------
+ 1/4=87000,10=4,29=2,30=1,38=1/1,3;
+ 2/4=87000,12=2,40=1/2;
+ 3/4=87000,5=2,14=-4,16=1,25=1,41=700000,71=2,116=-2/1,2,3;
+ 4/4=87000,5=1,35=1/1;
+ 5/4=87000,5=2,35=1,38=6,98=1/2;
+ 8/4=87000,6=4,10=90,11=11/1;
+ 11/4=87000,6=1,8=1,9=11,15=111,16=1/1,2,10;
+ 10/4=87000,6=1/2;
+ 6/4=87000,7=2,8=2,9=2,10=2,18=1,28=1/1;
+ 7/4=87000,8=1,10=1,25=1/1,2,3,16;
+ 1/4=87000,10=4,30=1/3;
+ 99/4=87000/99;
+ ----------------------------------------------------------------------
+ Benzene frequency calculation printing out normal mode displacements i
+ n higher precision
+ ----------------------------------------------------------------------
+ Structure from the checkpoint file:  benzene.chk
+ Charge =  0 Multiplicity = 1
+ Redundant internal coordinates found in file.
+ C,0,-0.318996994,1.9256612966,0.000058544
+ C,0,1.0760606099,1.9255751224,0.0004857433
+ C,0,1.7736449418,3.1336925304,-0.0000452677
+ C,0,1.0761756697,4.3418853264,-0.0010517012
+ C,0,-0.318882027,4.3419677736,-0.0014924252
+ C,0,-1.0164619031,3.133840281,-0.00093409
+ H,0,-0.8688554649,0.9733291622,0.0005086263
+ H,0,1.625828445,0.9731977218,0.0012816161
+ H,0,2.8733191108,3.1336505628,0.0003201048
+ H,0,1.626065422,5.2942021326,-0.0014852623
+ H,0,-0.8686896202,5.2943230331,-0.0022605138
+ H,0,-2.1161335499,3.1339184171,-0.0012963743
+ Recover connectivity data from disk.
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.3951         calculate D2E/DX2 analytically  !
+ ! R2    R(1,6)                  1.395          calculate D2E/DX2 analytically  !
+ ! R3    R(1,7)                  1.0997         calculate D2E/DX2 analytically  !
+ ! R4    R(2,3)                  1.3951         calculate D2E/DX2 analytically  !
+ ! R5    R(2,8)                  1.0997         calculate D2E/DX2 analytically  !
+ ! R6    R(3,4)                  1.3951         calculate D2E/DX2 analytically  !
+ ! R7    R(3,9)                  1.0997         calculate D2E/DX2 analytically  !
+ ! R8    R(4,5)                  1.3951         calculate D2E/DX2 analytically  !
+ ! R9    R(4,10)                 1.0997         calculate D2E/DX2 analytically  !
+ ! R10   R(5,6)                  1.3951         calculate D2E/DX2 analytically  !
+ ! R11   R(5,11)                 1.0997         calculate D2E/DX2 analytically  !
+ ! R12   R(6,12)                 1.0997         calculate D2E/DX2 analytically  !
+ ! A1    A(2,1,6)              120.0008         calculate D2E/DX2 analytically  !
+ ! A2    A(2,1,7)              119.9978         calculate D2E/DX2 analytically  !
+ ! A3    A(6,1,7)              120.0014         calculate D2E/DX2 analytically  !
+ ! A4    A(1,2,3)              119.9992         calculate D2E/DX2 analytically  !
+ ! A5    A(1,2,8)              119.9996         calculate D2E/DX2 analytically  !
+ ! A6    A(3,2,8)              120.0012         calculate D2E/DX2 analytically  !
+ ! A7    A(2,3,4)              120.0001         calculate D2E/DX2 analytically  !
+ ! A8    A(2,3,9)              120.0006         calculate D2E/DX2 analytically  !
+ ! A9    A(4,3,9)              119.9993         calculate D2E/DX2 analytically  !
+ ! A10   A(3,4,5)              120.0005         calculate D2E/DX2 analytically  !
+ ! A11   A(3,4,10)             119.9998         calculate D2E/DX2 analytically  !
+ ! A12   A(5,4,10)             119.9997         calculate D2E/DX2 analytically  !
+ ! A13   A(4,5,6)              119.999          calculate D2E/DX2 analytically  !
+ ! A14   A(4,5,11)             120.0018         calculate D2E/DX2 analytically  !
+ ! A15   A(6,5,11)             119.9992         calculate D2E/DX2 analytically  !
+ ! A16   A(1,6,5)              120.0004         calculate D2E/DX2 analytically  !
+ ! A17   A(1,6,12)             120.0013         calculate D2E/DX2 analytically  !
+ ! A18   A(5,6,12)             119.9983         calculate D2E/DX2 analytically  !
+ ! D1    D(6,1,2,3)              0.0016         calculate D2E/DX2 analytically  !
+ ! D2    D(6,1,2,8)            179.9992         calculate D2E/DX2 analytically  !
+ ! D3    D(7,1,2,3)           -179.9981         calculate D2E/DX2 analytically  !
+ ! D4    D(7,1,2,8)             -0.0005         calculate D2E/DX2 analytically  !
+ ! D5    D(2,1,6,5)             -0.0003         calculate D2E/DX2 analytically  !
+ ! D6    D(2,1,6,12)           179.9985         calculate D2E/DX2 analytically  !
+ ! D7    D(7,1,6,5)            179.9994         calculate D2E/DX2 analytically  !
+ ! D8    D(7,1,6,12)            -0.0018         calculate D2E/DX2 analytically  !
+ ! D9    D(1,2,3,4)             -0.0023         calculate D2E/DX2 analytically  !
+ ! D10   D(1,2,3,9)            179.9983         calculate D2E/DX2 analytically  !
+ ! D11   D(8,2,3,4)           -179.9998         calculate D2E/DX2 analytically  !
+ ! D12   D(8,2,3,9)              0.0007         calculate D2E/DX2 analytically  !
+ ! D13   D(2,3,4,5)              0.0016         calculate D2E/DX2 analytically  !
+ ! D14   D(2,3,4,10)          -179.9991         calculate D2E/DX2 analytically  !
+ ! D15   D(9,3,4,5)           -179.9989         calculate D2E/DX2 analytically  !
+ ! D16   D(9,3,4,10)             0.0003         calculate D2E/DX2 analytically  !
+ ! D17   D(3,4,5,6)             -0.0004         calculate D2E/DX2 analytically  !
+ ! D18   D(3,4,5,11)           179.9985         calculate D2E/DX2 analytically  !
+ ! D19   D(10,4,5,6)          -179.9996         calculate D2E/DX2 analytically  !
+ ! D20   D(10,4,5,11)           -0.0008         calculate D2E/DX2 analytically  !
+ ! D21   D(4,5,6,1)             -0.0003         calculate D2E/DX2 analytically  !
+ ! D22   D(4,5,6,12)          -179.9991         calculate D2E/DX2 analytically  !
+ ! D23   D(11,5,6,1)          -179.9991         calculate D2E/DX2 analytically  !
+ ! D24   D(11,5,6,12)            0.0021         calculate D2E/DX2 analytically  !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07
+ Number of steps in this run=      2 maximum allowed number of steps=      2.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -0.318997    1.925661    0.000059
+      2          6           0        1.076061    1.925575    0.000486
+      3          6           0        1.773645    3.133693   -0.000045
+      4          6           0        1.076176    4.341885   -0.001052
+      5          6           0       -0.318882    4.341968   -0.001492
+      6          6           0       -1.016462    3.133840   -0.000934
+      7          1           0       -0.868855    0.973329    0.000509
+      8          1           0        1.625828    0.973198    0.001282
+      9          1           0        2.873319    3.133651    0.000320
+     10          1           0        1.626065    5.294202   -0.001485
+     11          1           0       -0.868690    5.294323   -0.002261
+     12          1           0       -2.116134    3.133918   -0.001296
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.395058   0.000000
+     3  C    2.416297   1.395053   0.000000
+     4  C    2.790098   2.416311   1.395061   0.000000
+     5  C    2.416307   2.790129   2.416320   1.395058   0.000000
+     6  C    1.395047   2.416311   2.790107   2.416300   1.395059
+     7  H    1.099673   2.165519   3.413206   3.889771   3.413239
+     8  H    2.165533   1.099667   2.165546   3.413236   3.889797
+     9  H    3.413227   2.165545   1.099674   2.165539   3.413236
+    10  H    3.889773   3.413233   2.165545   1.099676   2.165542
+    11  H    3.413217   3.889797   3.413248   2.165558   1.099668
+    12  H    2.165545   3.413239   3.889779   3.413213   2.165524
+                    6          7          8          9         10
+     6  C    0.000000
+     7  H    2.165548   0.000000
+     8  H    3.413221   2.494684   0.000000
+     9  H    3.889781   4.320979   2.494753   0.000000
+    10  H    3.413226   4.989447   4.321005   2.494720   0.000000
+    11  H    2.165531   4.320995   4.989465   4.321012   2.494755
+    12  H    1.099672   2.494765   4.320995   4.989453   4.320981
+                   11         12
+    11  H    0.000000
+    12  H    2.494687   0.000000
+ Stoichiometry    C6H6
+ Framework group  C1[X(C6H6)]
+ Deg. of freedom    30
+ Full point group                 C1      NOp   1
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -0.506751    1.299753    0.000002
+      2          6           0       -1.379012    0.211017   -0.000013
+      3          6           0       -0.872253   -1.088740    0.000008
+      4          6           0        0.506756   -1.299756   -0.000005
+      5          6           0        1.379014   -0.211017   -0.000003
+      6          6           0        0.872244    1.088742    0.000004
+      7          1           0       -0.906238    2.324298    0.000018
+      8          1           0       -2.466023    0.377372   -0.000001
+      9          1           0       -1.559805   -1.946968    0.000024
+     10          1           0        0.906212   -2.324315   -0.000004
+     11          1           0        2.466033   -0.377328    0.000012
+     12          1           0        1.559823    1.946946   -0.000010
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):      5.6861529      5.6860641      2.8430542
+ Standard basis: VSTO-6G (5D, 7F)
+ There are    30 symmetry adapted basis functions of A   symmetry.
+ Integral buffers will be    131072 words long.
+ Regular integral format.
+ Two-electron integral symmetry is turned off.
+    30 basis functions,   180 primitive gaussians,    30 cartesian basis functions
+    15 alpha electrons       15 beta electrons
+       nuclear repulsion energy       119.5992544929 Hartrees.
+ Do NDO integrals.
+ One-electron integrals computed using PRISM.
+ NBasis=    30 RedAO= F  NBF=    30
+ NBsUse=    30 1.00D-04 NBFU=    30
+ Initial guess read from the checkpoint file:  benzene.chk
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Overlap will be assumed to be unity.
+ Keep J ints in memory in canonical form, NReq=882346.
+ SCF Done:  E(RAM1) =  0.349527236288E-01 A.U. after    2 cycles
+             Convg  =    0.4884D-09             -V/T =  1.0019
+ Range of M.O.s used for correlation:     1    30
+ NBasis=    30 NAE=    15 NBE=    15 NFC=     0 NFV=     0
+ NROrb=     30 NOA=    15 NOB=    15 NVA=    15 NVB=    15
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ G2DrvN: will do    13 centers at a time, making    1 passes doing MaxLOS=1.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ FoFDir/FoFCou used for L=0 through L=1.
+ End of G2Drv Frequency-dependent properties file   721 does not exist.
+ End of G2Drv Frequency-dependent properties file   722 does not exist.
+          IDoAtm=111111111111
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+          Electric field/nuclear overlap derivatives assumed to be zero.
+          Keep J ints in memory in canonical form, NReq=802993.
+          There are    39 degrees of freedom in the 1st order CPHF.  IDoFFX=5.
+ LinEq1:  Iter=  0 NonCon=    39 RMS=3.83D-01 Max=3.26D+00
+ AX will form    39 AO Fock derivatives at one time.
+ LinEq1:  Iter=  1 NonCon=    39 RMS=6.01D-02 Max=4.24D-01
+ LinEq1:  Iter=  2 NonCon=    39 RMS=4.21D-03 Max=2.50D-02
+ LinEq1:  Iter=  3 NonCon=    39 RMS=2.73D-04 Max=2.20D-03
+ LinEq1:  Iter=  4 NonCon=    39 RMS=3.82D-05 Max=2.27D-04
+ LinEq1:  Iter=  5 NonCon=    39 RMS=3.54D-06 Max=2.06D-05
+ LinEq1:  Iter=  6 NonCon=    32 RMS=3.36D-07 Max=2.22D-06
+ LinEq1:  Iter=  7 NonCon=    22 RMS=4.01D-08 Max=2.33D-07
+ LinEq1:  Iter=  8 NonCon=     0 RMS=4.36D-09 Max=2.13D-08
+ Linear equations converged to 1.000D-08 1.000D-07 after     8 iterations.
+ Isotropic polarizability for W=    0.000000       48.75 Bohr**3.
+ End of Minotr Frequency-dependent properties file   721 does not exist.
+ End of Minotr Frequency-dependent properties file   722 does not exist.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A)
+ The electronic state is 1-A.
+ Alpha  occ. eigenvalues --   -1.43860  -1.15283  -1.15283  -0.84745  -0.84745
+ Alpha  occ. eigenvalues --   -0.65619  -0.59250  -0.56596  -0.52041  -0.52040
+ Alpha  occ. eigenvalues --   -0.49175  -0.43689  -0.43689  -0.35474  -0.35474
+ Alpha virt. eigenvalues --    0.02039   0.02039   0.10944   0.14833   0.14833
+ Alpha virt. eigenvalues --    0.14875   0.15409   0.16900   0.16900   0.18827
+ Alpha virt. eigenvalues --    0.18827   0.20624   0.20624   0.21054   0.22540
+          Condensed to atoms (all electrons):
+              1          2          3          4          5          6
+     1  C    4.130119   0.000000   0.000000   0.000000   0.000000   0.000000
+     2  C    0.000000   4.130119   0.000000   0.000000   0.000000   0.000000
+     3  C    0.000000   0.000000   4.130119   0.000000   0.000000   0.000000
+     4  C    0.000000   0.000000   0.000000   4.130120   0.000000   0.000000
+     5  C    0.000000   0.000000   0.000000   0.000000   4.130120   0.000000
+     6  C    0.000000   0.000000   0.000000   0.000000   0.000000   4.130119
+     7  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     8  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     9  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+    10  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+    11  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+    12  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+              7          8          9         10         11         12
+     1  C    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     2  C    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     3  C    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     4  C    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     5  C    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     6  C    0.000000   0.000000   0.000000   0.000000   0.000000   0.000000
+     7  H    0.869882   0.000000   0.000000   0.000000   0.000000   0.000000
+     8  H    0.000000   0.869879   0.000000   0.000000   0.000000   0.000000
+     9  H    0.000000   0.000000   0.869881   0.000000   0.000000   0.000000
+    10  H    0.000000   0.000000   0.000000   0.869881   0.000000   0.000000
+    11  H    0.000000   0.000000   0.000000   0.000000   0.869879   0.000000
+    12  H    0.000000   0.000000   0.000000   0.000000   0.000000   0.869882
+ Mulliken atomic charges:
+              1
+     1  C   -0.130119
+     2  C   -0.130119
+     3  C   -0.130119
+     4  C   -0.130120
+     5  C   -0.130120
+     6  C   -0.130119
+     7  H    0.130118
+     8  H    0.130121
+     9  H    0.130119
+    10  H    0.130119
+    11  H    0.130121
+    12  H    0.130118
+ Sum of Mulliken atomic charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+              1
+     1  C   -0.000002
+     2  C    0.000002
+     3  C    0.000000
+     4  C   -0.000001
+     5  C    0.000002
+     6  C   -0.000001
+ Sum of Mulliken charges with hydrogens summed into heavy atoms =   0.00000
+ APT atomic charges:
+              1
+     1  C   -0.120326
+     2  C   -0.120325
+     3  C   -0.120325
+     4  C   -0.120326
+     5  C   -0.120325
+     6  C   -0.120325
+     7  H    0.120322
+     8  H    0.120327
+     9  H    0.120324
+    10  H    0.120323
+    11  H    0.120327
+    12  H    0.120324
+ Sum of APT charges=   0.00000
+ APT Atomic charges with hydrogens summed into heavy atoms:
+              1
+     1  C   -0.000004
+     2  C    0.000001
+     3  C    0.000000
+     4  C   -0.000002
+     5  C    0.000002
+     6  C   -0.000002
+     7  H    0.000000
+     8  H    0.000000
+     9  H    0.000000
+    10  H    0.000000
+    11  H    0.000000
+    12  H    0.000000
+ Sum of APT charges=   0.00000
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=              0.0000    Z=              0.0000  Tot=              0.0000
+ N-N= 1.195992544929D+02 E-N=-1.995926004544D+02  KE=-1.879673789223D+01
+  Exact polarizability:  68.607   0.000  68.606   0.000   0.000   9.031
+ Approx polarizability:  58.286   0.000  58.285   0.000   0.000   6.910
+ Calling FoFJK, ICntrl=    100127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ Full mass-weighted force constant matrix:
+ Low frequencies ---   -0.0016   -0.0011   -0.0004    2.2872    2.3716    2.8121
+ Low frequencies ---  370.7936  370.7987  618.0103
+ Harmonic frequencies (cm**-1), IR intensities (KM/Mole), Raman scattering
+ activities (A**4/AMU), depolarization ratios for plane and unpolarized
+ incident light, reduced masses (AMU), force constants (mDyne/A),
+ and normal coordinates:
+                     1                      2                      3
+                     A                      A                      A
+ Frequencies --   370.7936               370.7987               618.0103
+ Red. masses --     2.3022                 2.3023                 1.9355
+ Frc consts  --     0.1865                 0.1865                 0.4355
+ IR Inten    --     0.0000                 0.0000                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.00   0.00  -0.04     0.00   0.00   0.19     0.00   0.00   0.12
+     2   6     0.00   0.00   0.19     0.00   0.00  -0.06     0.00   0.00  -0.12
+     3   6     0.00   0.00  -0.14     0.00   0.00  -0.14     0.00   0.00   0.12
+     4   6     0.00   0.00  -0.04     0.00   0.00   0.19     0.00   0.00  -0.12
+     5   6     0.00   0.00   0.19     0.00   0.00  -0.06     0.00   0.00   0.12
+     6   6     0.00   0.00  -0.14     0.00   0.00  -0.14     0.00   0.00  -0.12
+     7   1     0.00   0.00  -0.12     0.00   0.00   0.53     0.00   0.00   0.39
+     8   1     0.00   0.00   0.52     0.00   0.00  -0.16     0.00   0.00  -0.39
+     9   1     0.00   0.00  -0.40     0.00   0.00  -0.37     0.00   0.00   0.39
+    10   1     0.00   0.00  -0.12     0.00   0.00   0.53     0.00   0.00  -0.39
+    11   1     0.00   0.00   0.52     0.00   0.00  -0.16     0.00   0.00   0.39
+    12   1     0.00   0.00  -0.40     0.00   0.00  -0.37     0.00   0.00  -0.39
+                     4                      5                      6
+                     A                      A                      A
+ Frequencies --   647.7864               647.7895               744.1046
+ Red. masses --     6.4600                 6.4600                 1.0848
+ Frc consts  --     1.5971                 1.5972                 0.3539
+ IR Inten    --     0.0000                 0.0000               127.6266
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.19   0.28   0.00     0.06   0.22   0.00     0.00   0.00   0.03
+     2   6     0.03   0.15   0.00     0.37  -0.06   0.00     0.00   0.00   0.03
+     3   6     0.26   0.20   0.00    -0.03  -0.23   0.00     0.00   0.00   0.03
+     4   6     0.19  -0.28   0.00    -0.06  -0.22   0.00     0.00   0.00   0.03
+     5   6    -0.03  -0.15   0.00    -0.37   0.06   0.00     0.00   0.00   0.03
+     6   6    -0.26  -0.20   0.00     0.03   0.23   0.00     0.00   0.00   0.03
+     7   1    -0.03   0.33   0.00    -0.22   0.10   0.00     0.00   0.00  -0.41
+     8   1    -0.02  -0.19   0.00     0.36  -0.05   0.00     0.00   0.00  -0.41
+     9   1     0.12   0.30   0.00    -0.25  -0.05   0.00     0.00   0.00  -0.41
+    10   1     0.03  -0.33   0.00     0.22  -0.10   0.00     0.00   0.00  -0.41
+    11   1     0.02   0.19   0.00    -0.36   0.05   0.00     0.00   0.00  -0.41
+    12   1    -0.12  -0.30   0.00     0.25   0.05   0.00     0.00   0.00  -0.41
+                     7                      8                      9
+                     A                      A                      A
+ Frequencies --   891.2303               891.2439               989.3457
+ Red. masses --     1.2503                 1.2503                 1.5596
+ Frc consts  --     0.5851                 0.5851                 0.8994
+ IR Inten    --     0.0000                 0.0000                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.00   0.00   0.04     0.00   0.00  -0.08     0.00   0.00   0.05
+     2   6     0.00   0.00   0.09     0.00   0.00  -0.01     0.00   0.00  -0.13
+     3   6     0.00   0.00   0.05     0.00   0.00   0.07     0.00   0.00   0.08
+     4   6     0.00   0.00  -0.04     0.00   0.00   0.08     0.00   0.00   0.05
+     5   6     0.00   0.00  -0.09     0.00   0.00   0.01     0.00   0.00  -0.13
+     6   6     0.00   0.00  -0.05     0.00   0.00  -0.07     0.00   0.00   0.08
+     7   1     0.00   0.00  -0.24     0.00   0.00   0.52     0.00   0.00  -0.23
+     8   1     0.00   0.00  -0.57     0.00   0.00   0.05     0.00   0.00   0.56
+     9   1     0.00   0.00  -0.33     0.00   0.00  -0.47     0.00   0.00  -0.33
+    10   1     0.00   0.00   0.24     0.00   0.00  -0.52     0.00   0.00  -0.23
+    11   1     0.00   0.00   0.57     0.00   0.00  -0.05     0.00   0.00   0.56
+    12   1     0.00   0.00   0.33     0.00   0.00   0.47     0.00   0.00  -0.33
+                    10                     11                     12
+                     A                      A                      A
+ Frequencies --   989.3560              1011.9492              1028.1894
+ Red. masses --     1.5595                 1.7892                 6.8008
+ Frc consts  --     0.8994                 1.0795                 4.2360
+ IR Inten    --     0.0000                 0.0000                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.00   0.00  -0.12     0.00   0.00  -0.11    -0.11   0.28   0.00
+     2   6     0.00   0.00   0.01     0.00   0.00   0.11     0.29  -0.04   0.00
+     3   6     0.00   0.00   0.10     0.00   0.00  -0.11    -0.19  -0.23   0.00
+     4   6     0.00   0.00  -0.12     0.00   0.00   0.11    -0.11   0.28   0.00
+     5   6     0.00   0.00   0.01     0.00   0.00  -0.11     0.29  -0.04   0.00
+     6   6     0.00   0.00   0.10     0.00   0.00   0.11    -0.19  -0.23   0.00
+     7   1     0.00   0.00   0.51     0.00   0.00   0.39    -0.10   0.26   0.00
+     8   1     0.00   0.00  -0.06     0.00   0.00  -0.39     0.28  -0.04   0.00
+     9   1     0.00   0.00  -0.46     0.00   0.00   0.39    -0.18  -0.22   0.00
+    10   1     0.00   0.00   0.51     0.00   0.00  -0.39    -0.10   0.26   0.00
+    11   1     0.00   0.00  -0.06     0.00   0.00   0.39     0.28  -0.04   0.00
+    12   1     0.00   0.00  -0.46     0.00   0.00  -0.39    -0.18  -0.22   0.00
+                    13                     14                     15
+                     A                      A                      A
+ Frequencies --  1145.8312              1145.8472              1178.7041
+ Red. masses --     1.2184                 1.2184                 1.1529
+ Frc consts  --     0.9425                 0.9425                 0.9437
+ IR Inten    --     1.0879                 1.0881                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.04   0.06   0.00    -0.02  -0.04   0.00    -0.04  -0.02   0.00
+     2   6    -0.01  -0.03   0.00     0.07  -0.01   0.00     0.01   0.05   0.00
+     3   6     0.05   0.03   0.00     0.01   0.05   0.00     0.04  -0.03   0.00
+     4   6    -0.04   0.06   0.00    -0.02  -0.04   0.00    -0.04  -0.02   0.00
+     5   6    -0.01  -0.03   0.00     0.07  -0.01   0.00     0.01   0.05   0.00
+     6   6     0.05   0.03   0.00     0.01   0.05   0.00     0.04  -0.03   0.00
+     7   1    -0.23  -0.02   0.00    -0.48  -0.22   0.00     0.38   0.15   0.00
+     8   1    -0.09  -0.56   0.00     0.06  -0.08   0.00    -0.06  -0.40   0.00
+     9   1     0.30  -0.17   0.00    -0.33   0.32   0.00    -0.32   0.25   0.00
+    10   1    -0.23  -0.02   0.00    -0.48  -0.22   0.00     0.38   0.15   0.00
+    11   1    -0.09  -0.56   0.00     0.06  -0.08   0.00    -0.06  -0.40   0.00
+    12   1     0.30  -0.17   0.00    -0.33   0.32   0.00    -0.32   0.25   0.00
+                    16                     17                     18
+                     A                      A                      A
+ Frequencies --  1221.6470              1221.6522              1276.2049
+ Red. masses --     1.0296                 1.0296                 6.2557
+ Frc consts  --     0.9054                 0.9054                 6.0029
+ IR Inten    --     0.0000                 0.0000                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.01   0.01   0.00     0.02   0.01   0.00     0.10  -0.26   0.00
+     2   6     0.01   0.02   0.00     0.01  -0.01   0.00     0.28  -0.04   0.00
+     3   6     0.02   0.00   0.00     0.01  -0.02   0.00     0.18   0.22   0.00
+     4   6     0.01  -0.01   0.00    -0.02  -0.01   0.00    -0.10   0.26   0.00
+     5   6    -0.01  -0.02   0.00    -0.01   0.01   0.00    -0.28   0.04   0.00
+     6   6    -0.02   0.00   0.00    -0.01   0.02   0.00    -0.18  -0.22   0.00
+     7   1    -0.16  -0.04   0.00     0.51   0.21   0.00     0.11  -0.27   0.00
+     8   1     0.09   0.55   0.00     0.00  -0.14   0.00     0.29  -0.04   0.00
+     9   1     0.32  -0.24   0.00     0.32  -0.27   0.00     0.18   0.23   0.00
+    10   1     0.16   0.04   0.00    -0.51  -0.21   0.00    -0.11   0.27   0.00
+    11   1    -0.09  -0.55   0.00     0.00   0.14   0.00    -0.29   0.04   0.00
+    12   1    -0.32   0.24   0.00    -0.32   0.27   0.00    -0.18  -0.23   0.00
+                    19                     20                     21
+                     A                      A                      A
+ Frequencies --  1328.3798              1366.6677              1579.0362
+ Red. masses --     1.2503                 4.8034                 3.9663
+ Frc consts  --     1.2999                 5.2860                 5.8267
+ IR Inten    --     0.0000                 0.0000                12.1818
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.06  -0.02   0.00    -0.22  -0.09   0.00     0.11  -0.15   0.00
+     2   6    -0.01  -0.06   0.00     0.04   0.24   0.00     0.09   0.21   0.00
+     3   6     0.05  -0.04   0.00     0.19  -0.15   0.00    -0.21   0.02   0.00
+     4   6     0.06   0.02   0.00    -0.22  -0.09   0.00     0.11  -0.15   0.00
+     5   6     0.01   0.06   0.00     0.04   0.24   0.00     0.09   0.21   0.00
+     6   6    -0.05   0.04   0.00     0.19  -0.15   0.00    -0.21   0.02   0.00
+     7   1     0.38   0.15   0.00    -0.31  -0.12   0.00    -0.02  -0.19   0.00
+     8   1     0.06   0.40   0.00     0.05   0.33   0.00    -0.01  -0.44   0.00
+     9   1    -0.32   0.25   0.00     0.26  -0.21   0.00     0.20  -0.31   0.00
+    10   1    -0.38  -0.15   0.00    -0.31  -0.12   0.00    -0.02  -0.19   0.00
+    11   1    -0.06  -0.40   0.00     0.05   0.33   0.00    -0.01  -0.44   0.00
+    12   1     0.32  -0.25   0.00     0.26  -0.21   0.00     0.20  -0.31   0.00
+                    22                     23                     24
+                     A                      A                      A
+ Frequencies --  1579.0444              1767.5723              1767.5887
+ Red. masses --     3.9663                10.4958                10.4956
+ Frc consts  --     5.8268                19.3205                19.3206
+ IR Inten    --    12.1827                 0.0000                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.20   0.12   0.00     0.21   0.25   0.00     0.43   0.05   0.00
+     2   6    -0.16   0.10   0.00    -0.09  -0.49   0.00    -0.18   0.07   0.00
+     3   6     0.04  -0.21   0.00    -0.06   0.27   0.00     0.40  -0.22   0.00
+     4   6     0.20   0.12   0.00    -0.21  -0.25   0.00    -0.43  -0.05   0.00
+     5   6    -0.16   0.10   0.00     0.09   0.49   0.00     0.18  -0.07   0.00
+     6   6     0.04  -0.21   0.00     0.06  -0.27   0.00    -0.40   0.22   0.00
+     7   1    -0.43  -0.13   0.00    -0.13   0.08   0.00    -0.09  -0.12   0.00
+     8   1    -0.19  -0.12   0.00     0.01   0.15   0.00    -0.15   0.01   0.00
+     9   1    -0.32   0.09   0.00     0.14   0.06   0.00    -0.07   0.14   0.00
+    10   1    -0.43  -0.13   0.00     0.13  -0.08   0.00     0.09   0.12   0.00
+    11   1    -0.19  -0.12   0.00    -0.01  -0.15   0.00     0.15  -0.01   0.00
+    12   1    -0.32   0.09   0.00    -0.14  -0.06   0.00     0.07  -0.14   0.00
+                    25                     26                     27
+                     A                      A                      A
+ Frequencies --  3183.7401              3186.7932              3186.8212
+ Red. masses --     1.0770                 1.0754                 1.0754
+ Frc consts  --     6.4318                 6.4350                 6.4351
+ IR Inten    --     0.0003                 0.0000                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6     0.01  -0.03   0.00     0.02  -0.04   0.00     0.00  -0.02   0.00
+     2   6    -0.03   0.00   0.00    -0.01   0.00   0.00    -0.04   0.01   0.00
+     3   6     0.02   0.03   0.00    -0.02  -0.03   0.00     0.01   0.02   0.00
+     4   6     0.01  -0.03   0.00    -0.02   0.04   0.00     0.00   0.02   0.00
+     5   6    -0.03   0.00   0.00     0.00   0.00   0.00     0.04  -0.01   0.00
+     6   6     0.02   0.03   0.00     0.02   0.03   0.00    -0.01  -0.02   0.00
+     7   1    -0.15   0.38   0.00    -0.19   0.49   0.00    -0.09   0.22   0.00
+     8   1     0.40  -0.06   0.00     0.06  -0.01   0.00     0.57  -0.09   0.00
+     9   1    -0.26  -0.32   0.00     0.29   0.36   0.00    -0.21  -0.26   0.00
+    10   1    -0.15   0.38   0.00     0.19  -0.49   0.00     0.09  -0.22   0.00
+    11   1     0.40  -0.06   0.00    -0.05   0.01   0.00    -0.57   0.09   0.00
+    12   1    -0.25  -0.32   0.00    -0.29  -0.37   0.00     0.21   0.26   0.00
+                    28                     29                     30
+                     A                      A                      A
+ Frequencies --  3194.5388              3194.5679              3205.1325
+ Red. masses --     1.0817                 1.0817                 1.0920
+ Frc consts  --     6.5038                 6.5039                 6.6097
+ IR Inten    --    88.4261                88.4340                 0.0000
+  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
+     1   6    -0.02   0.04   0.00     0.01  -0.02   0.00    -0.01   0.03   0.00
+     2   6     0.00   0.00   0.00     0.05  -0.01   0.00    -0.04   0.01   0.00
+     3   6     0.02   0.03   0.00     0.02   0.02   0.00    -0.02  -0.03   0.00
+     4   6    -0.02   0.04   0.00     0.01  -0.02   0.00     0.01  -0.03   0.00
+     5   6     0.00   0.00   0.00     0.05  -0.01   0.00     0.04  -0.01   0.00
+     6   6     0.02   0.03   0.00     0.02   0.02   0.00     0.02   0.03   0.00
+     7   1     0.19  -0.49   0.00    -0.08   0.22   0.00     0.15  -0.38   0.00
+     8   1     0.05  -0.01   0.00    -0.57   0.09   0.00     0.40  -0.06   0.00
+     9   1    -0.29  -0.37   0.00    -0.21  -0.26   0.00     0.25   0.32   0.00
+    10   1     0.19  -0.49   0.00    -0.08   0.22   0.00    -0.15   0.38   0.00
+    11   1     0.06  -0.01   0.00    -0.57   0.09   0.00    -0.40   0.06   0.00
+    12   1    -0.29  -0.36   0.00    -0.21  -0.26   0.00    -0.25  -0.32   0.00
+
+ -------------------
+ - Thermochemistry -
+ -------------------
+ Temperature   298.150 Kelvin.  Pressure   1.00000 Atm.
+ Atom     1 has atomic number  6 and mass  12.00000
+ Atom     2 has atomic number  6 and mass  12.00000
+ Atom     3 has atomic number  6 and mass  12.00000
+ Atom     4 has atomic number  6 and mass  12.00000
+ Atom     5 has atomic number  6 and mass  12.00000
+ Atom     6 has atomic number  6 and mass  12.00000
+ Atom     7 has atomic number  1 and mass   1.00783
+ Atom     8 has atomic number  1 and mass   1.00783
+ Atom     9 has atomic number  1 and mass   1.00783
+ Atom    10 has atomic number  1 and mass   1.00783
+ Atom    11 has atomic number  1 and mass   1.00783
+ Atom    12 has atomic number  1 and mass   1.00783
+ Molecular mass:    78.04695 amu.
+ Principal axes and moments of inertia in atomic units:
+                           1         2         3
+     Eigenvalues --   317.39231 317.39727 634.78958
+           X            0.99989  -0.01501   0.00000
+           Y            0.01501   0.99989   0.00000
+           Z            0.00000   0.00000   1.00000
+ This molecule is an asymmetric top.
+ Rotational symmetry number  1.
+ Rotational temperatures (Kelvin)      0.27289     0.27289     0.13644
+ Rotational constants (GHZ):           5.68615     5.68606     2.84305
+ Zero-point vibrational energy     268743.3 (Joules/Mol)
+                                   64.23118 (Kcal/Mol)
+ Warning -- explicit consideration of   3 degrees of freedom as
+           vibrations may cause significant error
+ Vibrational temperatures:    533.49   533.50   889.18   932.02   932.02
+          (Kelvin)           1070.60  1282.28  1282.30  1423.45  1423.46
+                             1455.97  1479.33  1648.59  1648.62  1695.89
+                             1757.68  1757.68  1836.17  1911.24  1966.33
+                             2271.88  2271.89  2543.14  2543.16  4580.69
+                             4585.08  4585.12  4596.22  4596.26  4611.47
+ 
+ Zero-point correction=                           0.102359 (Hartree/Particle)
+ Thermal correction to Energy=                    0.106775
+ Thermal correction to Enthalpy=                  0.107719
+ Thermal correction to Gibbs Free Energy=         0.074840
+ Sum of electronic and zero-point Energies=              0.137312
+ Sum of electronic and thermal Energies=                 0.141728
+ Sum of electronic and thermal Enthalpies=               0.142672
+ Sum of electronic and thermal Free Energies=            0.109792
+ 
+                     E (Thermal)             CV                S
+                      KCal/Mol        Cal/Mol-Kelvin    Cal/Mol-Kelvin
+ Total                   67.002             16.818             69.201
+ Electronic               0.000              0.000              0.000
+ Translational            0.889              2.981             38.979
+ Rotational               0.889              2.981             25.662
+ Vibrational             65.225             10.856              4.560
+ Vibration     1          0.743              1.532              1.077
+ Vibration     2          0.743              1.532              1.076
+ Vibration     3          0.978              0.994              0.420
+                       Q            Log10(Q)             Ln(Q)
+ Total Bot       0.376914D-34        -34.423758        -79.263631
+ Total V=0       0.454958D+13         12.657971         29.146055
+ Vib (Bot)       0.153636D-46        -46.813508       -107.792085
+ Vib (Bot)    1  0.490732D+00         -0.309155         -0.711857
+ Vib (Bot)    2  0.490724D+00         -0.309163         -0.711874
+ Vib (Bot)    3  0.237128D+00         -0.625017         -1.439154
+ Vib (V=0)       0.185447D+01          0.268221          0.617601
+ Vib (V=0)    1  0.120058D+01          0.079393          0.182808
+ Vib (V=0)    2  0.120058D+01          0.079390          0.182803
+ Vib (V=0)    3  0.105338D+01          0.022585          0.052004
+ Electronic      0.100000D+01          0.000000          0.000000
+ Translational   0.271012D+08          7.432989         17.115090
+ Rotational      0.905235D+05          4.956761         11.413364
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000005946   -0.000003588   -0.000000881
+      2        6          -0.000006107    0.000011944    0.000004651
+      3        6          -0.000006500    0.000005029   -0.000002856
+      4        6          -0.000005169   -0.000004377    0.000001565
+      5        6           0.000010708   -0.000013751    0.000001166
+      6        6           0.000003298    0.000007462   -0.000001904
+      7        1          -0.000002108    0.000003071   -0.000000581
+      8        1           0.000001758   -0.000000269   -0.000000971
+      9        1          -0.000003166   -0.000000686   -0.000000305
+     10        1          -0.000001761   -0.000003616   -0.000000038
+     11        1           0.000002154    0.000001494   -0.000000920
+     12        1           0.000000945   -0.000002714    0.000001073
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000013751 RMS     0.000004750
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Internal  Forces:  Max     0.000013903 RMS     0.000003686
+ Search for a local minimum.
+ Step number   1 out of a maximum of    2
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- analytic derivatives used.
+ ITU=  0
+     Eigenvalues ---    0.01286   0.01286   0.01385   0.02578   0.02578
+     Eigenvalues ---    0.02867   0.03155   0.03188   0.03188   0.09908
+     Eigenvalues ---    0.11435   0.11435   0.11455   0.11743   0.11743
+     Eigenvalues ---    0.19037   0.19038   0.19376   0.32647   0.35246
+     Eigenvalues ---    0.35247   0.35882   0.36820   0.36821   0.36983
+     Eigenvalues ---    0.58236   0.58237   0.61999   0.62000   0.80762
+ Angle between quadratic step and forces=  59.09 degrees.
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00001749 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000001
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.63628  -0.00001   0.00000  -0.00001  -0.00001   2.63626
+    R2        2.63626   0.00000   0.00000   0.00001   0.00001   2.63626
+    R3        2.07808   0.00000   0.00000  -0.00001  -0.00001   2.07808
+    R4        2.63627  -0.00001   0.00000  -0.00001  -0.00001   2.63626
+    R5        2.07807   0.00000   0.00000   0.00001   0.00001   2.07808
+    R6        2.63628  -0.00001   0.00000  -0.00002  -0.00002   2.63626
+    R7        2.07808   0.00000   0.00000  -0.00001  -0.00001   2.07808
+    R8        2.63628  -0.00001   0.00000  -0.00002  -0.00002   2.63626
+    R9        2.07809   0.00000   0.00000  -0.00001  -0.00001   2.07808
+   R10        2.63628  -0.00001   0.00000  -0.00002  -0.00002   2.63626
+   R11        2.07807   0.00000   0.00000   0.00000   0.00000   2.07808
+   R12        2.07808   0.00000   0.00000   0.00000   0.00000   2.07808
+    A1        2.09441   0.00000   0.00000  -0.00001  -0.00001   2.09440
+    A2        2.09436   0.00001   0.00000   0.00004   0.00004   2.09440
+    A3        2.09442   0.00000   0.00000  -0.00003  -0.00003   2.09440
+    A4        2.09438   0.00000   0.00000   0.00001   0.00001   2.09440
+    A5        2.09439   0.00000   0.00000   0.00001   0.00001   2.09440
+    A6        2.09442   0.00000   0.00000  -0.00002  -0.00002   2.09440
+    A7        2.09440   0.00000   0.00000   0.00000   0.00000   2.09440
+    A8        2.09440   0.00000   0.00000  -0.00001  -0.00001   2.09440
+    A9        2.09438   0.00000   0.00000   0.00001   0.00001   2.09440
+   A10        2.09440   0.00000   0.00000  -0.00001  -0.00001   2.09440
+   A11        2.09439   0.00000   0.00000   0.00000   0.00000   2.09440
+   A12        2.09439   0.00000   0.00000   0.00000   0.00000   2.09440
+   A13        2.09438   0.00000   0.00000   0.00002   0.00002   2.09440
+   A14        2.09443   0.00000   0.00000  -0.00003  -0.00003   2.09440
+   A15        2.09438   0.00000   0.00000   0.00001   0.00001   2.09440
+   A16        2.09440   0.00000   0.00000  -0.00001  -0.00001   2.09440
+   A17        2.09442   0.00000   0.00000  -0.00002  -0.00002   2.09440
+   A18        2.09437   0.00000   0.00000   0.00003   0.00003   2.09440
+    D1        0.00003   0.00000   0.00000  -0.00003  -0.00003   0.00000
+    D2        3.14158   0.00000   0.00000   0.00001   0.00001   3.14159
+    D3       -3.14156   0.00000   0.00000  -0.00003  -0.00003  -3.14159
+    D4       -0.00001   0.00000   0.00000   0.00001   0.00001   0.00000
+    D5       -0.00001   0.00000   0.00000   0.00001   0.00001   0.00000
+    D6        3.14157   0.00000   0.00000   0.00003   0.00003   3.14159
+    D7        3.14158   0.00000   0.00000   0.00001   0.00001   3.14159
+    D8       -0.00003   0.00000   0.00000   0.00003   0.00003   0.00000
+    D9       -0.00004   0.00000   0.00000   0.00004   0.00004   0.00000
+   D10        3.14156   0.00000   0.00000   0.00003   0.00003   3.14159
+   D11       -3.14159   0.00000   0.00000   0.00000   0.00000  -3.14159
+   D12        0.00001   0.00000   0.00000  -0.00001  -0.00001   0.00000
+   D13        0.00003   0.00000   0.00000  -0.00003  -0.00003   0.00000
+   D14       -3.14158   0.00000   0.00000  -0.00002  -0.00002   3.14159
+   D15       -3.14157   0.00000   0.00000  -0.00002  -0.00002  -3.14159
+   D16        0.00001   0.00000   0.00000  -0.00001  -0.00001   0.00000
+   D17       -0.00001   0.00000   0.00000   0.00001   0.00001   0.00000
+   D18        3.14157   0.00000   0.00000   0.00003   0.00003  -3.14159
+   D19       -3.14159   0.00000   0.00000  -0.00001  -0.00001  -3.14159
+   D20       -0.00001   0.00000   0.00000   0.00001   0.00001   0.00000
+   D21       -0.00001   0.00000   0.00000   0.00001   0.00001   0.00000
+   D22       -3.14158   0.00000   0.00000  -0.00002  -0.00002   3.14159
+   D23       -3.14158   0.00000   0.00000  -0.00002  -0.00002   3.14159
+   D24        0.00004   0.00000   0.00000  -0.00004  -0.00004   0.00000
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000014     0.000450     YES
+ RMS     Force            0.000004     0.000300     YES
+ Maximum Displacement     0.000052     0.001800     YES
+ RMS     Displacement     0.000017     0.001200     YES
+ Predicted change in Energy=-9.531961D-10
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.3951         -DE/DX =    0.0                 !
+ ! R2    R(1,6)                  1.395          -DE/DX =    0.0                 !
+ ! R3    R(1,7)                  1.0997         -DE/DX =    0.0                 !
+ ! R4    R(2,3)                  1.3951         -DE/DX =    0.0                 !
+ ! R5    R(2,8)                  1.0997         -DE/DX =    0.0                 !
+ ! R6    R(3,4)                  1.3951         -DE/DX =    0.0                 !
+ ! R7    R(3,9)                  1.0997         -DE/DX =    0.0                 !
+ ! R8    R(4,5)                  1.3951         -DE/DX =    0.0                 !
+ ! R9    R(4,10)                 1.0997         -DE/DX =    0.0                 !
+ ! R10   R(5,6)                  1.3951         -DE/DX =    0.0                 !
+ ! R11   R(5,11)                 1.0997         -DE/DX =    0.0                 !
+ ! R12   R(6,12)                 1.0997         -DE/DX =    0.0                 !
+ ! A1    A(2,1,6)              120.0008         -DE/DX =    0.0                 !
+ ! A2    A(2,1,7)              119.9978         -DE/DX =    0.0                 !
+ ! A3    A(6,1,7)              120.0014         -DE/DX =    0.0                 !
+ ! A4    A(1,2,3)              119.9992         -DE/DX =    0.0                 !
+ ! A5    A(1,2,8)              119.9996         -DE/DX =    0.0                 !
+ ! A6    A(3,2,8)              120.0012         -DE/DX =    0.0                 !
+ ! A7    A(2,3,4)              120.0001         -DE/DX =    0.0                 !
+ ! A8    A(2,3,9)              120.0006         -DE/DX =    0.0                 !
+ ! A9    A(4,3,9)              119.9993         -DE/DX =    0.0                 !
+ ! A10   A(3,4,5)              120.0005         -DE/DX =    0.0                 !
+ ! A11   A(3,4,10)             119.9998         -DE/DX =    0.0                 !
+ ! A12   A(5,4,10)             119.9997         -DE/DX =    0.0                 !
+ ! A13   A(4,5,6)              119.999          -DE/DX =    0.0                 !
+ ! A14   A(4,5,11)             120.0018         -DE/DX =    0.0                 !
+ ! A15   A(6,5,11)             119.9992         -DE/DX =    0.0                 !
+ ! A16   A(1,6,5)              120.0004         -DE/DX =    0.0                 !
+ ! A17   A(1,6,12)             120.0013         -DE/DX =    0.0                 !
+ ! A18   A(5,6,12)             119.9983         -DE/DX =    0.0                 !
+ ! D1    D(6,1,2,3)              0.0016         -DE/DX =    0.0                 !
+ ! D2    D(6,1,2,8)            179.9992         -DE/DX =    0.0                 !
+ ! D3    D(7,1,2,3)           -179.9981         -DE/DX =    0.0                 !
+ ! D4    D(7,1,2,8)             -0.0005         -DE/DX =    0.0                 !
+ ! D5    D(2,1,6,5)             -0.0003         -DE/DX =    0.0                 !
+ ! D6    D(2,1,6,12)           179.9985         -DE/DX =    0.0                 !
+ ! D7    D(7,1,6,5)            179.9994         -DE/DX =    0.0                 !
+ ! D8    D(7,1,6,12)            -0.0018         -DE/DX =    0.0                 !
+ ! D9    D(1,2,3,4)             -0.0023         -DE/DX =    0.0                 !
+ ! D10   D(1,2,3,9)            179.9983         -DE/DX =    0.0                 !
+ ! D11   D(8,2,3,4)           -179.9998         -DE/DX =    0.0                 !
+ ! D12   D(8,2,3,9)              0.0007         -DE/DX =    0.0                 !
+ ! D13   D(2,3,4,5)              0.0016         -DE/DX =    0.0                 !
+ ! D14   D(2,3,4,10)           180.0009         -DE/DX =    0.0                 !
+ ! D15   D(9,3,4,5)           -179.9989         -DE/DX =    0.0                 !
+ ! D16   D(9,3,4,10)             0.0003         -DE/DX =    0.0                 !
+ ! D17   D(3,4,5,6)             -0.0004         -DE/DX =    0.0                 !
+ ! D18   D(3,4,5,11)          -180.0015         -DE/DX =    0.0                 !
+ ! D19   D(10,4,5,6)          -179.9996         -DE/DX =    0.0                 !
+ ! D20   D(10,4,5,11)           -0.0008         -DE/DX =    0.0                 !
+ ! D21   D(4,5,6,1)             -0.0003         -DE/DX =    0.0                 !
+ ! D22   D(4,5,6,12)           180.0009         -DE/DX =    0.0                 !
+ ! D23   D(11,5,6,1)           180.0009         -DE/DX =    0.0                 !
+ ! D24   D(11,5,6,12)            0.0021         -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ 1\1\ SIUV- VIVES\Freq\RAM1\ZDO\C6H6\MIKE\05-Aug-2015\0\\# AM1 freq geo
+ m=check guess=read\\Benzene frequency calculation printing out normal 
+ mode displacements in higher precision\\0,1\C,-0.318996994,1.925661296
+ 6,0.000058544\C,1.0760606099,1.9255751224,0.0004857433\C,1.7736449418,
+ 3.1336925304,-0.0000452677\C,1.0761756697,4.3418853264,-0.0010517012\C
+ ,-0.318882027,4.3419677736,-0.0014924252\C,-1.0164619031,3.133840281,-
+ 0.00093409\H,-0.8688554649,0.9733291622,0.0005086263\H,1.625828445,0.9
+ 731977218,0.0012816161\H,2.8733191108,3.1336505628,0.0003201048\H,1.62
+ 6065422,5.2942021326,-0.0014852623\H,-0.8686896202,5.2943230331,-0.002
+ 2605138\H,-2.1161335499,3.1339184171,-0.0012963743\\Version=EM64L-G09R
+ evC.01\State=1-A\HF=0.0349527\RMSD=4.884e-10\RMSF=4.750e-06\ZeroPoint=
+ 0.1023589\Thermal=0.1067749\Dipole=0.0000019,0.000003,0.0000128\Dipole
+ Deriv=-0.1300928,0.0360801,-0.0000236,0.0360685,-0.088456,-0.000024,-0
+ .0000231,-0.0000222,-0.1424293,-0.130096,-0.0360666,0.0000273,-0.03605
+ 65,-0.0884483,-0.0000453,0.0000305,-0.0000508,-0.1424313,-0.0676216,-0
+ .0000057,0.0000273,-0.0000156,-0.1509236,0.000007,0.0000208,0.0000072,
+ -0.1424294,-0.1300978,0.036071,-0.0000187,0.0360757,-0.0884494,-0.0000
+ 248,-0.0000182,-0.0000242,-0.1424299,-0.1300998,-0.0360575,0.0000241,-
+ 0.0360631,-0.0884444,-0.0000447,0.0000225,-0.0000423,-0.1424321,-0.067
+ 6236,-0.0000068,0.0000263,0.0000026,-0.1509228,0.0000047,0.0000316,0.0
+ 000047,-0.142429,0.0759791,0.0576652,-0.0000572,0.0576665,0.1425604,0.
+ 0000173,-0.0000579,0.0000162,0.1424278,0.0759705,-0.0576664,0.0000154,
+ -0.0576653,0.1425781,-0.0000185,0.0000131,-0.0000136,0.1424309,0.17585
+ 88,-0.000005,0.0000108,-0.0000052,0.0426853,0.0000633,0.0000141,0.0000
+ 633,0.1424293,0.0759836,0.057668,-0.0000588,0.0576701,0.1425574,0.0000
+ 184,-0.0000592,0.0000162,0.1424288,0.0759761,-0.0576692,0.000016,-0.05
+ 76697,0.1425739,-0.0000177,0.0000164,-0.0000183,0.1424316,0.1758571,-0
+ .0000098,0.000011,-0.0000106,0.0426851,0.0000642,0.0000096,0.0000639,0
+ .1424286\Polar=68.6066611,-0.0003249,68.6068993,0.0189209,-0.0381165,9
+ .0314051\HyperPolar=0.000122,0.0024495,-0.0000612,-0.0025236,0.0003759
+ ,0.0001729,-0.0002193,-0.0000494,-0.0000422,-0.0000931\PG=C01 [X(C6H6)
+ ]\NImag=0\\0.78281838,0.00131431,0.78438210,0.00019386,-0.00040816,0.1
+ 5077761,-0.39683205,-0.06069507,-0.00006017,0.78281542,0.06073305,-0.1
+ 0539701,0.00004130,-0.00133476,0.78437763,-0.00013778,0.00000278,-0.07
+ 110191,0.00020109,-0.00040316,0.15077798,-0.05956505,-0.04324660,0.000
+ 00617,-0.17827212,-0.18692168,0.00008256,0.78512622,-0.13969844,0.0460
+ 8413,-0.00006899,-0.06549234,-0.32397247,0.00013633,0.00001548,0.78204
+ 924,0.00006799,-0.00003844,0.00759895,0.00000487,0.00009749,-0.0711012
+ 1,0.00021032,-0.00040214,0.15078069,-0.08604129,0.04677061,-0.00005556
+ ,0.09888814,0.04821421,-0.00000169,-0.17824237,0.06546933,-0.00007792,
+ 0.78281570,0.04677088,-0.03204918,0.00003241,-0.04823656,-0.11236709,0
+ .00006137,0.18689692,-0.32397934,0.00022420,0.00133610,0.78434669,-0.0
+ 0005623,0.00003280,-0.00429111,0.00006016,0.00009169,0.00759815,-0.000
+ 15541,0.00018522,-0.07110254,0.00020079,-0.00040720,0.15078229,0.09888
+ 816,-0.04823602,0.00005939,-0.08604991,-0.04676435,0.00000378,-0.05954
+ 249,0.13970537,-0.00011071,-0.39683201,-0.06069605,-0.00006362,0.78281
+ 646,0.04821533,-0.11236854,0.00009209,-0.04676539,-0.03203761,0.000002
+ 80,0.04325524,0.04606515,-0.00001051,0.06073255,-0.10540026,0.00004126
+ ,-0.00134659,0.78435948,-0.00000220,0.00006168,0.00759836,0.00000414,0
+ .00000297,-0.00429129,-0.00004924,0.00001998,0.00759782,-0.00014146,0.
+ 00000255,-0.07110255,0.00019852,-0.00040423,0.15078003,-0.17825090,0.1
+ 8691451,-0.00015341,-0.05954463,0.04325618,-0.00004863,-0.00504213,-0.
+ 00000473,-0.00000018,-0.05956368,-0.04324656,0.00000662,-0.17826536,-0
+ .18691335,0.00008647,0.78513237,0.06548535,-0.32400581,0.00018272,0.13
+ 970760,0.04606432,0.00001977,-0.00000511,-0.11304742,0.00006939,-0.139
+ 69793,0.04608398,-0.00006927,-0.06548498,-0.32396124,0.00014216,-0.000
+ 02120,0.78206553,-0.00007568,0.00022089,-0.07109970,-0.00011023,-0.000
+ 01125,0.00759826,-0.00000020,0.00006977,-0.00429113,0.00006849,-0.0000
+ 3838,0.00759880,0.00000859,0.00010379,-0.07110228,0.00020257,-0.000404
+ 94,0.15077784,-0.10695260,-0.11925431,0.00005772,-0.02822659,-0.028342
+ 03,0.00000785,-0.00360707,0.00097747,-0.00000351,0.00026050,0.00007976
+ ,0.00000002,-0.00132417,0.00165206,-0.00000322,0.00792331,0.01166459,-
+ 0.00000680,0.13232782,-0.11925362,-0.24463910,0.00009464,-0.00920270,-
+ 0.00170394,0.00000194,0.00033430,0.00019369,0.00000378,0.00007971,0.00
+ 035270,-0.00000017,0.00229527,-0.00208898,0.00000582,-0.00747547,-0.03
+ 785180,0.00002577,0.13314460,0.28604839,0.00005778,0.00009468,-0.04248
+ 633,-0.00000461,-0.00000396,0.00565547,-0.00000315,0.00000404,0.005820
+ 67,0.00000012,-0.00000026,0.00005287,-0.00000382,0.00000554,0.00582103
+ ,0.00000561,0.00003169,0.00565466,-0.00005324,-0.00012904,0.02408390,-
+ 0.02822149,0.02834429,-0.00002892,-0.10693224,0.11924563,-0.00009809,0
+ .00792288,-0.01166887,0.00000816,-0.00132412,-0.00165226,-0.00000127,0
+ .00026019,-0.00007972,0.00000012,-0.00360696,-0.00097676,-0.00000235,-
+ 0.00055501,0.00010093,0.00000025,0.13230332,0.00920451,-0.00170733,0.0
+ 0000768,0.11924572,-0.24466815,0.00016945,0.00747093,-0.03785145,0.000
+ 03023,-0.00229551,-0.00208853,0.00000428,-0.00007938,0.00035271,-0.000
+ 00022,-0.00033381,0.00019358,0.00000352,-0.00010076,0.00043928,-0.0000
+ 0128,-0.13313434,0.28608027,-0.00001637,0.00001361,0.00565495,-0.00009
+ 845,0.00016982,-0.04248488,-0.00000405,0.00002399,0.00565466,-0.000000
+ 81,0.00000438,0.00582098,0.,-0.00000024,0.00005286,-0.00000266,0.00000
+ 342,0.00582074,0.00000035,-0.00000122,-0.00149288,0.00012093,-0.000212
+ 16,0.02408283,-0.00018866,-0.00163966,-0.00000100,-0.02459441,-0.01129
+ 842,-0.00000280,-0.31349297,0.00001037,-0.00009007,-0.02459101,0.01130
+ 053,-0.00001720,-0.00018831,0.00163939,-0.00000308,0.00039872,-0.00000
+ 005,0.00000010,-0.00027293,0.00000946,0.00000002,0.00019068,-0.0003296
+ 1,0.00000076,0.36292279,-0.00099654,-0.00322461,0.00000543,-0.03043824
+ ,-0.00533422,-0.00000305,0.00001061,-0.03809798,-0.00000283,0.03044006
+ ,-0.00533821,0.00001706,0.00099618,-0.00322490,0.00000609,-0.00000002,
+ 0.00021443,-0.00000011,-0.00063011,0.00008548,-0.00000044,-0.00053115,
+ -0.00030614,-0.00000094,-0.00001220,0.05545136,-0.00000138,0.00000522,
+ 0.00582097,0.00000930,0.00000330,0.00565484,-0.00008990,-0.00000286,-0
+ .04248642,-0.00002956,0.00001075,0.00565481,-0.00000254,0.00000639,0.0
+ 0582072,0.00000015,-0.00000018,0.00005285,0.00000039,-0.00000026,-0.00
+ 032634,0.00000088,-0.00000088,-0.00149297,0.00011260,-0.00001995,0.024
+ 08440,0.00026048,0.00007978,0.00000001,-0.00132413,0.00165206,-0.00000
+ 337,0.00792316,0.01166374,-0.00000673,-0.10695953,-0.11925635,0.000055
+ 65,-0.02822576,-0.02834121,0.00000736,-0.00360700,0.00097744,-0.000003
+ 64,-0.00002889,-0.00004210,0.00000033,0.00026465,0.00031974,0.,0.00019
+ 082,0.00053111,0.00000020,0.13233363,0.00007968,0.00035272,-0.00000016
+ ,0.00229534,-0.00208906,0.00000586,-0.00747586,-0.03785206,0.00002550,
+ -0.11925635,-0.24462953,0.00009131,-0.00920156,-0.00170320,0.00000179,
+ 0.00033436,0.00019361,0.00000372,-0.00004210,-0.00007753,-0.00000058,-
+ 0.00031981,-0.00045207,-0.00000004,0.00032960,-0.00030622,-0.00000065,
+ 0.13314646,0.28603870,-0.00000019,-0.00000007,0.00005285,-0.00000360,0
+ .00000575,0.00582073,0.00000561,0.00003144,0.00565472,0.00005540,0.000
+ 09136,-0.04248666,-0.00000471,-0.00000423,0.00565489,-0.00000319,0.000
+ 00371,0.00582094,0.00000031,-0.00000059,-0.00096366,0.00000040,0.00000
+ 019,-0.00032633,0.00000035,-0.00000057,-0.00149292,-0.00005062,-0.0001
+ 2527,0.02408469,-0.00132404,-0.00165227,-0.00000112,0.00026016,-0.0000
+ 7974,0.00000011,-0.00360685,-0.00097676,-0.00000233,-0.02822089,0.0283
+ 4328,-0.00002859,-0.10694166,0.11925021,-0.00009491,0.00792287,-0.0116
+ 6778,0.00000817,0.00026465,-0.00031979,0.00000039,-0.00002897,0.000041
+ 97,0.00000026,-0.00027288,0.00063014,-0.00000041,-0.00055462,0.0001008
+ 7,0.00000023,0.13231166,-0.00229561,-0.00208863,0.00000431,-0.00007933
+ ,0.00035274,-0.00000020,-0.00033391,0.00019348,0.00000342,0.00920312,-
+ 0.00170625,0.00000751,0.11925102,-0.24465810,0.00016406,0.00747162,-0.
+ 03785254,0.00002998,0.00031975,-0.00045208,0.00000019,0.00004197,-0.00
+ 007751,-0.00000055,-0.00000942,0.00008543,-0.00000027,-0.00010071,0.00
+ 043923,-0.00000125,-0.13313872,0.28607072,-0.00000080,0.00000459,0.005
+ 82073,0.00000016,-0.00000017,0.00005285,-0.00000280,0.00000322,0.00582
+ 097,-0.00001662,0.00001354,0.00565433,-0.00009475,0.00016379,-0.042484
+ 91,-0.00000395,0.00002417,0.00565503,-0.00000002,-0.00000002,-0.000326
+ 33,0.00000027,-0.00000055,-0.00096367,0.00000003,-0.00000007,-0.000326
+ 32,0.00000037,-0.00000121,-0.00149296,0.00011735,-0.00020633,0.0240831
+ 0,-0.02459014,0.01130036,-0.00001697,-0.00018830,0.00163930,-0.0000030
+ 2,0.00039872,-0.00000001,0.00000011,-0.00018864,-0.00163976,-0.0000009
+ 1,-0.02459580,-0.01129907,-0.00000249,-0.31349670,0.00001944,-0.000088
+ 99,0.00019086,0.00032951,0.00000034,-0.00027288,-0.00000941,0.00000004
+ ,-0.00010186,0.,0.00000027,-0.00027294,0.00000947,0.00000001,0.0001906
+ 4,-0.00032974,0.00000076,0.36292703,0.03044041,-0.00533841,0.00001673,
+ 0.00099616,-0.00322488,0.00000611,-0.00000002,0.00021443,-0.00000010,-
+ 0.00099656,-0.00322463,0.00000551,-0.03043847,-0.00533426,-0.00000265,
+ 0.00001878,-0.03809725,-0.00000276,0.00053094,-0.00030602,-0.00000058,
+ 0.00063014,0.00008541,-0.00000008,0.00000001,-0.00000458,-0.00000062,-
+ 0.00063010,0.00008550,-0.00000046,-0.00053137,-0.00030641,-0.00000094,
+ -0.00002007,0.05545096,-0.00002900,0.00001041,0.00565467,-0.00000264,0
+ .00000622,0.00582105,0.00000011,0.,0.00005286,-0.00000119,0.00000529,0
+ .00582067,0.00000988,0.00000354,0.00565534,-0.00008939,-0.00000265,-0.
+ 04248596,0.00000016,-0.00000066,-0.00149309,-0.00000038,-0.00000027,-0
+ .00032633,0.00000030,-0.00000061,-0.00096367,0.00000044,-0.00000026,-0
+ .00032634,0.00000084,-0.00000086,-0.00149285,0.00011086,-0.00002015,0.
+ 02408361\\-0.00000595,0.00000359,0.00000088,0.00000611,-0.00001194,-0.
+ 00000465,0.00000650,-0.00000503,0.00000286,0.00000517,0.00000438,-0.00
+ 000156,-0.00001071,0.00001375,-0.00000117,-0.00000330,-0.00000746,0.00
+ 000190,0.00000211,-0.00000307,0.00000058,-0.00000176,0.00000027,0.0000
+ 0097,0.00000317,0.00000069,0.00000031,0.00000176,0.00000362,0.00000004
+ ,-0.00000215,-0.00000149,0.00000092,-0.00000095,0.00000271,-0.00000107
+ \\\@
+
+
+ We find comfort among those who agree with us -- growth among those who don't.
+ -- Frank A. Clark
+ Job cpu time:  0 days  0 hours  0 minutes  2.4 seconds.
+ File lengths (MBytes):  RWF=      7 Int=      0 D2E=      0 Chk=      2 Scr=      1
+ Normal termination of Gaussian 09 at Wed Aug  5 15:15:41 2015.

--- a/regression.py
+++ b/regression.py
@@ -304,6 +304,15 @@ def testGaussian_Gaussian09_Ru2bpyen2_H2_freq3_log(logfile):
     """Here atomnos wans't added to the gaussian parser before."""
     assert len(logfile.data.atomnos) == 69
 
+def testGaussian_Gaussian09_benzene_HPfreq_log(logfile):
+    """Check that higher precision vib displacements obtained with freq=hpmodes) are parsed correctly."""
+    assert abs(logfile.data.vibdisps[0,0,2] - (-0.04497)) < 0.00001
+
+def testGaussian_Gaussian09_benzene_freq_log(logfile):
+    """Check that default precision vib displacements are parsed correctly."""
+    assert abs(logfile.data.vibdisps[0,0,2] - (-0.04)) < 0.00001
+
+
 # Jaguar #
 
 # It would be good to have an unconverged geometry optimization so that

--- a/regressionfiles.txt
+++ b/regressionfiles.txt
@@ -162,6 +162,8 @@ Gaussian/Gaussian09/OPT_td_g09.out
 Gaussian/Gaussian09/OPT_td.out
 Gaussian/Gaussian09/Ru2bpyen2_H2_freq3.log
 Gaussian/Gaussian09/water_gaussian.inp.log
+Gaussian/Gaussian09/benzene_freq.log
+Gaussian/Gaussian09/benzene_HPfreq.log
 Gaussian/Gaussian98/C_bigmult.log
 Gaussian/Gaussian98/oo-LAN.out
 Gaussian/Gaussian98/test_Cu2.log


### PR DESCRIPTION
Added two separate regression tests, one testing for correct parsing of high-precision vib displacements from Gaussian09 (freq=hpmodes keyword), and another checking for correct parsing of low-precision vib displacements which are always printed in a freq calculation. cclib master can't currently parse high-precision displacements so will fail the tests, but the commits in https://github.com/cclib/cclib/pull/207/commits fix this. 