### PR TITLE
Q-Chem: fix charge/mult and fragment/supsersystem parsing

### DIFF
--- a/QChem/QChem4.2/CH3---Na+_RS_SCF_noprint.out
+++ b/QChem/QChem4.2/CH3---Na+_RS_SCF_noprint.out
@@ -1,0 +1,513 @@
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe .CH3---Na+_RS_SCF_noprint.in.1849.qcin.1 /tmp/qchem/qchem1849/
+
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2014)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Sun Jan 24 11:12:54 2016  
+
+Host: osmium
+0
+
+     Scratch files written to /tmp/qchem/qchem1849//
+ Jun1415 |home|eric|data|opt|apps|qchem|trunk_RNUM -1
+
+Checking the input file for inconsistencies...	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$molecule
+1 2
+--
+0 2
+C -1.447596 -0.000023  0.000019
+H -1.562749  0.330361 -1.023835
+H -1.561982  0.721445  0.798205
+H -1.561187 -1.052067  0.225866
+--
+1 1
+Na 1.215591  0.000036 -0.000032
+$end
+
+$rem
+jobtype              eda
+exchange             b3lyp
+basis                6-31g*
+unrestricted         true
+scf_guess            fragmo
+frgm_method          stoll
+frgm_lpcorr          rs_exact_scf
+eda_bsse             true
+diis_separate_errvec 1
+scf_print_frgm       false
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      C      -1.4475963500    -0.0000229678     0.0000191465
+    2      H      -1.5627494575     0.3344866290    -1.0224943770
+    3      H      -1.5619822935     0.7182207953     0.8011077030
+    4      H      -1.5611872989    -1.0529690576     0.2216223708
+    5      Na      1.2155906500     0.0000363127    -0.0000318705
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    28.6321722722 hartrees
+ There are       10 alpha and        9 beta electrons
+ Requested basis set is 6-31G(d)
+ There are 15 shells and 40 basis functions
+
+Total QAlloc Memory Limit   2000 MB
+Mega-Array Size        61 MB
+MEM_STATIC part        62 MB
+
+                       Distance Matrix (Angstroms)
+             C (  1)   H (  2)   H (  3)   H (  4)
+   H (  2)  1.081985
+   H (  3)  1.081989  1.863539
+   H (  4)  1.081992  1.863562  1.863577
+   Na(  5)  2.663187  2.979339  2.978678  2.977994
+ 
+ A cutoff of  1.0D-08 yielded    116 shell pairs
+ There are       876 function pairs
+ 
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is             15166112
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                         15
+ number of basis is                          40
+ number of cartesian basis is                40
+ number of contracted shell pairs           116
+ number of primitive shell pairs            658
+ maxK2 (contraction) of shell pair           36
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair             12
+ max number of PS2 of shell pair             72
+ mem total for path MDJ                   10660
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 9.36E-03
+
+  Scale SEOQF with 1.000000e-01/1.000000e-01/1.000000e-01
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000012 hartrees
+ Guess MOs from converged MOs on fragments
+
+-----------------------------------------------------------------
+ SCF on fragment 1 out of 2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh  /tmp/qchem/qchem1849/Frg1.input  /dev/null  Frg1
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh /tmp/qchem/qchem1849/Frg1.input /dev/null Frg1
+QCSCRATCH is /tmp/qchem/qchem1849/Frg1
+QCFILEPREF is /tmp/qchem/qchem1849/Frg1/
+-- Serial fragment SCF job
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe /tmp/qchem/qchem1849/Frg1.input /tmp/qchem/qchem1849/Frg1/
+ SCF on fragment 2 out of 2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh  /tmp/qchem/qchem1849/Frg2.input  /dev/null  Frg2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh /tmp/qchem/qchem1849/Frg2.input /dev/null Frg2
+QCSCRATCH is /tmp/qchem/qchem1849/Frg2
+QCFILEPREF is /tmp/qchem/qchem1849/Frg2/
+-- Serial fragment SCF job
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe /tmp/qchem/qchem1849/Frg2.input /tmp/qchem/qchem1849/Frg2/
+-----------------------------------------------------------------
+ Done with SCF on isolated fragments
+-----------------------------------------------------------------
+
+ User-specified occupied guess orbitals will be used
+ An unrestricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Stoll
+ with single Roothaan step correction
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.15 s  wall 0.15 s
+
+ Total DFTman time = 0.15 CPUs 0.15 Wall
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -201.9268311993      4.17E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.14 s  wall 0.14 s
+
+ Total DFTman time = 0.14 CPUs 0.14 Wall
+    2    -201.9309276895      1.67E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.12 s  wall 0.12 s
+
+ Total DFTman time = 0.12 CPUs 0.12 Wall
+    3    -201.9314291296      4.42E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+
+ Total DFTman time = 0.10 CPUs 0.10 Wall
+    4    -201.9314721935      1.72E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.10 s
+
+ Total DFTman time = 0.09 CPUs 0.10 Wall
+    5    -201.9314799739      2.45E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.11 s
+
+ Total DFTman time = 0.11 CPUs 0.11 Wall
+Last iteration: RS correction
+SCF MI energy: -201.9314799308
+SCF MI(RS) energy: -201.9388582085
+    6    -201.9388582085      5.72E-06 Convergence criterion met
+ ---------------------------------------
+ <S^2> = 0.7482
+ SCF time:  CPU 0.95 s  wall 0.95 s
+-----------------------------------------------------
+ full SCF correction to the locally projected method
+-----------------------------------------------------
+ An unrestricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.11 s
+
+ Total DFTman time = 0.11 CPUs 0.11 Wall
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -201.9394119424      5.42E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.11 s
+
+ Total DFTman time = 0.11 CPUs 0.11 Wall
+    2    -201.9395649788      4.59E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.11 s
+
+ Total DFTman time = 0.11 CPUs 0.11 Wall
+    3    -201.9396930350      6.82E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+
+ Total DFTman time = 0.10 CPUs 0.10 Wall
+    4    -201.9396972311      1.34E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+
+ Total DFTman time = 0.10 CPUs 0.10 Wall
+    5    -201.9396979324      3.06E-06 Convergence criterion met
+ ---------------------------------------
+ <S^2> = 0.7528
+ SCF time:  CPU 0.73 s  wall 0.73 s
+
+-----------------------------------------------------------------
+ RS CP correction for fragment 1 out of 2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh  /tmp/qchem/qchem1849/Frg1.input  /dev/null  Frg1ARSBSSE
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh /tmp/qchem/qchem1849/Frg1.input /dev/null Frg1ARSBSSE
+QCSCRATCH is /tmp/qchem/qchem1849/Frg1ARSBSSE
+QCFILEPREF is /tmp/qchem/qchem1849/Frg1ARSBSSE/
+-- Serial fragment SCF job
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe /tmp/qchem/qchem1849/Frg1.input /tmp/qchem/qchem1849/Frg1ARSBSSE/
+ RS CP correction for fragment 2 out of 2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh  /tmp/qchem/qchem1849/Frg2.input  /dev/null  Frg2ARSBSSE
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh /tmp/qchem/qchem1849/Frg2.input /dev/null Frg2ARSBSSE
+QCSCRATCH is /tmp/qchem/qchem1849/Frg2ARSBSSE
+QCFILEPREF is /tmp/qchem/qchem1849/Frg2ARSBSSE/
+-- Serial fragment SCF job
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe /tmp/qchem/qchem1849/Frg2.input /tmp/qchem/qchem1849/Frg2ARSBSSE/
+-----------------------------------------------------------------
+ Done with counterpoise correction on fragments
+-----------------------------------------------------------------
+
+
+-----------------------------------------------------------------
+ SCF CP correction for fragment 1 out of 2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh  /tmp/qchem/qchem1849/Frg1.input  /dev/null  Frg1BSSE
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh /tmp/qchem/qchem1849/Frg1.input /dev/null Frg1BSSE
+QCSCRATCH is /tmp/qchem/qchem1849/Frg1BSSE
+QCFILEPREF is /tmp/qchem/qchem1849/Frg1BSSE/
+-- Serial fragment SCF job
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe /tmp/qchem/qchem1849/Frg1.input /tmp/qchem/qchem1849/Frg1BSSE/
+ SCF CP correction for fragment 2 out of 2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh  /tmp/qchem/qchem1849/Frg2.input  /dev/null  Frg2BSSE
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh /tmp/qchem/qchem1849/Frg2.input /dev/null Frg2BSSE
+QCSCRATCH is /tmp/qchem/qchem1849/Frg2BSSE
+QCFILEPREF is /tmp/qchem/qchem1849/Frg2BSSE/
+-- Serial fragment SCF job
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe /tmp/qchem/qchem1849/Frg2.input /tmp/qchem/qchem1849/Frg2BSSE/
+-----------------------------------------------------------------
+ Done with counterpoise correction on fragments
+-----------------------------------------------------------------
+
+ SCF   energy in the final basis set = -201.9396979324
+ Total energy in the final basis set = -201.9396979324
+ Analysis of SCF Wavefunction
+ 
+ --------------------------------------------------------------
+ 
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+ 
+ Alpha MOs
+ -- Occupied --
+-38.755 -10.394  -2.487  -1.419  -1.419  -1.419  -0.882  -0.611
+ -0.611  -0.446
+ -- Virtual --
+ -0.230  -0.148  -0.148  -0.135  -0.062  -0.029  -0.029  -0.020
+  0.011   0.011   0.036   0.134   0.134   0.155   0.156   0.200
+  0.334   0.418   0.418   0.449   0.736   0.736   0.781   0.974
+  1.463   1.463   1.801   2.019   2.019   3.973
+ 
+ Beta MOs
+ -- Occupied --
+-38.755 -10.381  -2.487  -1.419  -1.419  -1.418  -0.844  -0.601
+ -0.601
+ -- Virtual --
+ -0.298  -0.217  -0.147  -0.147  -0.131  -0.055  -0.029  -0.029
+ -0.008   0.016   0.016   0.047   0.139   0.139   0.152   0.152
+  0.219   0.342   0.424   0.424   0.496   0.741   0.741   0.798
+  0.997   1.525   1.525   1.879   2.030   2.030   4.006
+ --------------------------------------------------------------
+ 
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)    Spin (a.u.)
+  --------------------------------------------------------
+      1 C                    -0.551137       0.988912
+      2 H                     0.235637      -0.038899
+      3 H                     0.235588      -0.038891
+      4 H                     0.235586      -0.038885
+      5 Na                    0.844326       0.127764
+  --------------------------------------------------------
+  Sum of atomic charges =     1.000000
+  Sum of spin   charges =     1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                 4.8032
+    Dipole Moment (Debye)
+         X       4.2696      Y       0.0001      Z       0.0001
+       Tot       4.2696
+    Quadrupole Moments (Debye-Ang)
+        XX      -1.1284     XY      -0.0006     YY      -9.9209
+        XZ       0.0006     YZ      -0.0001     ZZ      -9.9209
+    Octopole Moments (Debye-Ang^2)
+       XXX      27.2407    XXY       0.0034    XYY       5.5826
+       YYY      -0.8406    XXZ      -0.0030    XYZ       0.0001
+       YYZ       0.6031    XZZ       5.5808    YZZ       0.8409
+       ZZZ      -0.6031
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -118.6695   XXXY      -0.0067   XXYY     -22.0119
+      XYYY       1.3521   YYYY     -14.9008   XXXZ       0.0063
+      XXYZ      -0.0004   XYYZ      -0.9700   YYYZ      -0.0003
+      XXZZ     -22.0061   XYZZ      -1.3531   YYZZ      -4.9670
+      XZZZ       0.9712   YZZZ       0.0001   ZZZZ     -14.9006
+ -----------------------------------------------------------------
+
+ ---------------------------------------------------------------------
+ *                   Energy decomposition analysis                   *
+ *  R.Z.Khaliullin, E.A.Cobar, R.C.Lochan, A.T.Bell, M.Head-Gordon   *
+ *              J. Phys. Chem. A, 2007, 111, 8753-8765.              *
+ ---------------------------------------------------------------------
+   Fragment           E(TOTAL)      E(RS CP-CORR)     E(SCF CP-CORR)
+ ---------------------------------------------------------------------
+          1     -39.8377833972     -39.8396233371     -39.8398496612
+          2    -162.0812279270    -162.0812296529    -162.0812300003
+ ---------------------------------------------------------------------
+   initial     -201.9268311993
+    SCF MI     -201.9314799308
+        RS     -201.9388582085
+       SCF     -201.9396979324
+ ---------------------------------------------------------------------
+                                       Energy term         DE, kJ/mol
+ ---------------------------------------------------------------------
+                            Frozen Density ( FRZ )          -20.53133
+                              Polarization ( POL )          -12.20539
+                       RS Delocalization ( P-DEL )          -19.37190
+       RS Basis set superposition error ( P-BSSE )            4.83535
+      RS Charge-transfer ( P-CT = P-DEL + P-BSSE )          -14.53655
+                      SCF Delocalization ( V-DEL )          -21.57662
+      SCF Basis set superposition error ( V-BSSE )            5.43048
+     SCF Charge-transfer ( V-CT = V-DEL + V-BSSE )          -16.14614
+ ---------------------------------------------------------------------
+             RS Total ( P-TOT = FRZ + POL + P-CT )          -47.27326
+            SCF Total ( V-TOT = FRZ + POL + V-CT )          -48.88285
+    Higher order relaxation ( HO = V-TOT - P-TOT )           -1.60959
+
+ *-------------------------------------------------------------------* 
+ *      Energy decomposition of the delocalization term, kJ/mol      * 
+ *-------------------------------------------------------------------* 
+                DEL from fragment(row) to fragment(col)                
+  -------------------------------------------------------------------    
+             1           2
+    1    -0.00299   -19.26957
+    2    -0.09786    -0.00024
+  -------------------------------------------------------------------  
+                BSSE from fragment(row) to fragment(col)               
+                  Grid superposition error: -0.05519
+  -------------------------------------------------------------------    
+             1           2
+    1     0.00001     4.82375
+    2     0.06675     0.00003
+  -------------------------------------------------------------------  
+                 CT from fragment(row) to fragment(col)                
+                  Grid superposition error: -0.05641
+  -------------------------------------------------------------------    
+             1           2
+    1    -0.00299   -14.44583
+    2    -0.03111    -0.00021
+ ---------------------------------------------------------------------
+
+
+ --------------------------------------------------------------------- 
+ *                     Charge transfer analysis                      * 
+ *             R.Z.Khaliullin, A.T. Bell, M.Head-Gordon              * 
+ *                J. Chem. Phys., 2008, 128, 184112                  * 
+ *-------------------------------------------------------------------* 
+                       Fragment population, a.u.                       
+ --------------------------------------------------------------------- 
+    Method   Fragment         Occ         Vir     Occ+Vir    Isolated
+ --------------------------------------------------------------------- 
+    SCF MI          1    9.000000    0.000000    9.000000    9.000000
+                    2   10.000000    0.000000   10.000000   10.000000
+ --------------------------------------------------------------------- 
+        RS          1    8.978345   -0.003092    8.975253    9.000000
+                    2    9.999990    0.024757   10.024747   10.000000
+ --------------------------------------------------------------------- 
+       SCF          1    8.972580   -0.003623    8.968958    9.000000
+                    2    9.999987    0.031055   10.031042   10.000000
+ --------------------------------------------------------------------- 
+   BSSE RS          1    8.995570   -0.000332    8.995238    9.000000
+                    2    9.999994    0.004768   10.004762   10.000000
+ --------------------------------------------------------------------- 
+  BSSE SCF          1    8.994155   -0.000425    8.993730    9.000000
+                    2    9.999993    0.006276   10.006270   10.000000
+ --------------------------------------------------------------------- 
+                           Total electron transfer            DQ, me-
+ --------------------------------------------------------------------- 
+                                 RS Delocalization          21.665021
+                                SCF Delocalization          27.432337
+                  RS Basis set superposition error           4.436654
+                 SCF Basis set superposition error           5.851594
+ --------------------------------------------------------------------- 
+                                RS Charge-transfer          17.228368
+                               SCF Charge-transfer          21.580743
+              Higher order relaxation ( SCF - RS )           4.352375
+
+
+ *-------------------------------------------------------------------* 
+ *      Decomposition of the total RS charge-transfer term, me-      * 
+ *-------------------------------------------------------------------* 
+           Delocalization from fragment(row) to fragment(col)          
+  -------------------------------------------------------------------    
+             1           2
+    1    -3.10413    24.75944
+    2     0.01213    -0.00242
+  -------------------------------------------------------------------  
+                BSSE from fragment(row) to fragment(col)               
+  -------------------------------------------------------------------    
+             1           2
+    1    -0.33785     4.76808
+    2     0.00633     0.00009
+  -------------------------------------------------------------------  
+         Electron transfer from fragment(row) to fragment(col)         
+  -------------------------------------------------------------------    
+             1           2
+    1    -2.76628    19.99136
+    2     0.00580    -0.00251
+  -------------------------------------------------------------------  
+
+Archival summary:
+1\1\osmium\SP\ProcedureUnspecified\6-31G*\a113(1+,2)\eric\SunJan2411:12:592016SunJan2411:12:592016\0\\#,ProcedureUnspecified,6-31G*,\\1,2\C\H,1,1.08198\H,1,1.08199,2,118.895\H,1,1.08199,2,118.897,3,-159.249,0\Na,1,2.66319,2,96.108,3,100.399,0\\\@
+
+ Total job time:  5.08s(wall), 1.80s(cpu) 
+ Sun Jan 24 11:12:59 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+

--- a/QChem/QChem4.2/CH3---Na+_RS_noprint.out
+++ b/QChem/QChem4.2/CH3---Na+_RS_noprint.out
@@ -1,0 +1,436 @@
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe .CH3---Na+_RS_noprint.in.1263.qcin.1 /tmp/qchem/qchem1263/
+
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2014)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Sun Jan 24 11:12:17 2016  
+
+Host: osmium
+0
+
+     Scratch files written to /tmp/qchem/qchem1263//
+ Jun1415 |home|eric|data|opt|apps|qchem|trunk_RNUM -1
+
+Checking the input file for inconsistencies...	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$molecule
+1 2
+--
+0 2
+C -1.447596 -0.000023  0.000019
+H -1.562749  0.330361 -1.023835
+H -1.561982  0.721445  0.798205
+H -1.561187 -1.052067  0.225866
+--
+1 1
+Na 1.215591  0.000036 -0.000032
+$end
+
+$rem
+jobtype              eda
+exchange             b3lyp
+basis                6-31g*
+unrestricted         true
+scf_guess            fragmo
+frgm_method          stoll
+frgm_lpcorr          rs
+eda_bsse             true
+diis_separate_errvec 1
+scf_print_frgm       false
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      C      -1.4475963500    -0.0000229678     0.0000191465
+    2      H      -1.5627494575     0.3344866290    -1.0224943770
+    3      H      -1.5619822935     0.7182207953     0.8011077030
+    4      H      -1.5611872989    -1.0529690576     0.2216223708
+    5      Na      1.2155906500     0.0000363127    -0.0000318705
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    28.6321722722 hartrees
+ There are       10 alpha and        9 beta electrons
+ Requested basis set is 6-31G(d)
+ There are 15 shells and 40 basis functions
+
+Total QAlloc Memory Limit   2000 MB
+Mega-Array Size        61 MB
+MEM_STATIC part        62 MB
+
+                       Distance Matrix (Angstroms)
+             C (  1)   H (  2)   H (  3)   H (  4)
+   H (  2)  1.081985
+   H (  3)  1.081989  1.863539
+   H (  4)  1.081992  1.863562  1.863577
+   Na(  5)  2.663187  2.979339  2.978678  2.977994
+ 
+ A cutoff of  1.0D-08 yielded    116 shell pairs
+ There are       876 function pairs
+ 
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is             15166112
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                         15
+ number of basis is                          40
+ number of cartesian basis is                40
+ number of contracted shell pairs           116
+ number of primitive shell pairs            658
+ maxK2 (contraction) of shell pair           36
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair             12
+ max number of PS2 of shell pair             72
+ mem total for path MDJ                   10660
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 9.36E-03
+
+  Scale SEOQF with 1.000000e-01/1.000000e-01/1.000000e-01
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000012 hartrees
+ Guess MOs from converged MOs on fragments
+
+-----------------------------------------------------------------
+ SCF on fragment 1 out of 2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh  /tmp/qchem/qchem1263/Frg1.input  /dev/null  Frg1
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh /tmp/qchem/qchem1263/Frg1.input /dev/null Frg1
+QCSCRATCH is /tmp/qchem/qchem1263/Frg1
+QCFILEPREF is /tmp/qchem/qchem1263/Frg1/
+-- Serial fragment SCF job
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe /tmp/qchem/qchem1263/Frg1.input /tmp/qchem/qchem1263/Frg1/
+ SCF on fragment 2 out of 2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh  /tmp/qchem/qchem1263/Frg2.input  /dev/null  Frg2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh /tmp/qchem/qchem1263/Frg2.input /dev/null Frg2
+QCSCRATCH is /tmp/qchem/qchem1263/Frg2
+QCFILEPREF is /tmp/qchem/qchem1263/Frg2/
+-- Serial fragment SCF job
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe /tmp/qchem/qchem1263/Frg2.input /tmp/qchem/qchem1263/Frg2/
+-----------------------------------------------------------------
+ Done with SCF on isolated fragments
+-----------------------------------------------------------------
+
+ User-specified occupied guess orbitals will be used
+ An unrestricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Stoll
+ with single Roothaan step correction
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.14 s  wall 0.14 s
+
+ Total DFTman time = 0.14 CPUs 0.14 Wall
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -201.9268311993      4.17E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+
+ Total DFTman time = 0.10 CPUs 0.10 Wall
+    2    -201.9309276895      1.67E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+
+ Total DFTman time = 0.10 CPUs 0.10 Wall
+    3    -201.9314291296      4.42E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.13 s  wall 0.13 s
+
+ Total DFTman time = 0.13 CPUs 0.13 Wall
+    4    -201.9314721935      1.72E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.12 s  wall 0.12 s
+
+ Total DFTman time = 0.12 CPUs 0.12 Wall
+    5    -201.9314799739      2.45E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+
+ Total DFTman time = 0.08 CPUs 0.08 Wall
+Last iteration: RS correction
+SCF MI energy: -201.9314799308
+SCF MI(RS) energy: -201.9388582085
+    6    -201.9388582085      5.72E-06 Convergence criterion met
+ ---------------------------------------
+ <S^2> = 0.7482
+ SCF time:  CPU 0.93 s  wall 0.93 s
+
+-----------------------------------------------------------------
+ RS CP correction for fragment 1 out of 2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh  /tmp/qchem/qchem1263/Frg1.input  /dev/null  Frg1ARSBSSE
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh /tmp/qchem/qchem1263/Frg1.input /dev/null Frg1ARSBSSE
+QCSCRATCH is /tmp/qchem/qchem1263/Frg1ARSBSSE
+QCFILEPREF is /tmp/qchem/qchem1263/Frg1ARSBSSE/
+-- Serial fragment SCF job
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe /tmp/qchem/qchem1263/Frg1.input /tmp/qchem/qchem1263/Frg1ARSBSSE/
+ RS CP correction for fragment 2 out of 2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh  /tmp/qchem/qchem1263/Frg2.input  /dev/null  Frg2ARSBSSE
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh /tmp/qchem/qchem1263/Frg2.input /dev/null Frg2ARSBSSE
+QCSCRATCH is /tmp/qchem/qchem1263/Frg2ARSBSSE
+QCFILEPREF is /tmp/qchem/qchem1263/Frg2ARSBSSE/
+-- Serial fragment SCF job
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe /tmp/qchem/qchem1263/Frg2.input /tmp/qchem/qchem1263/Frg2ARSBSSE/
+-----------------------------------------------------------------
+ Done with counterpoise correction on fragments
+-----------------------------------------------------------------
+
+ SCF   energy in the final basis set = -201.9388582085
+ Total energy in the final basis set = -201.9388582085
+ Analysis of SCF Wavefunction
+ 
+ --------------------------------------------------------------
+ 
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+ 
+ Alpha MOs
+ -- Occupied --
+-10.376  -0.870  -0.598  -0.598  -0.433 -38.769  -2.501  -1.433
+ -1.432  -1.432
+ -- Virtual --
+ -0.050   0.014   0.014   0.329   0.354   0.354   0.511   0.738
+  0.738   0.782   1.457   1.457   1.804   2.011   2.011   3.879
+ -0.226  -0.141  -0.141  -0.099  -0.050  -0.025  -0.025  -0.010
+  0.140   0.140   0.145   0.145   0.161   0.322
+ 
+ Beta MOs
+ -- Occupied --
+-10.363  -0.829  -0.588  -0.588 -38.769  -2.501  -1.432  -1.432
+ -1.432
+ -- Virtual --
+ -0.259  -0.035   0.020   0.020   0.363   0.363   0.405   0.537
+  0.744   0.744   0.808   1.523   1.523   1.887   2.024   2.024
+  3.915  -0.238  -0.141  -0.141  -0.111  -0.085  -0.038  -0.025
+ -0.025   0.138   0.142   0.142   0.144   0.144   0.324
+ --------------------------------------------------------------
+ 
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)    Spin (a.u.)
+  --------------------------------------------------------
+      1 C                    -0.534888       1.014842
+      2 H                     0.225266      -0.041886
+      3 H                     0.225212      -0.041873
+      4 H                     0.225200      -0.041867
+      5 Na                    0.859210       0.110783
+  --------------------------------------------------------
+  Sum of atomic charges =     1.000000
+  Sum of spin   charges =     1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                 4.8032
+    Dipole Moment (Debye)
+         X       4.3469      Y       0.0001      Z       0.0001
+       Tot       4.3469
+    Quadrupole Moments (Debye-Ang)
+        XX      -1.2160     XY      -0.0007     YY      -9.9973
+        XZ       0.0006     YZ      -0.0001     ZZ      -9.9972
+    Octopole Moments (Debye-Ang^2)
+       XXX      27.6937    XXY       0.0034    XYY       5.8197
+       YYY      -0.8009    XXZ      -0.0030    XYZ       0.0001
+       YYZ       0.5747    XZZ       5.8179    YZZ       0.8015
+       ZZZ      -0.5749
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -119.6612   XXXY      -0.0066   XXYY     -22.3357
+      XYYY       1.2918   YYYY     -15.0781   XXXZ       0.0061
+      XXYZ      -0.0004   XYYZ      -0.9269   YYYZ      -0.0003
+      XXZZ     -22.3301   XYZZ      -1.2930   YYZZ      -5.0261
+      XZZZ       0.9280   YZZZ       0.0001   ZZZZ     -15.0778
+ -----------------------------------------------------------------
+
+ ---------------------------------------------------------------------
+ *                   Energy decomposition analysis                   *
+ *  R.Z.Khaliullin, E.A.Cobar, R.C.Lochan, A.T.Bell, M.Head-Gordon   *
+ *              J. Phys. Chem. A, 2007, 111, 8753-8765.              *
+ ---------------------------------------------------------------------
+   Fragment           E(TOTAL)      E(RS CP-CORR)
+ ---------------------------------------------------------------------
+          1     -39.8377833972     -39.8396233371
+          2    -162.0812279270    -162.0812296529
+ ---------------------------------------------------------------------
+   initial     -201.9268311993
+    SCF MI     -201.9314799308
+        RS     -201.9388582085
+ ---------------------------------------------------------------------
+                                       Energy term         DE, kJ/mol
+ ---------------------------------------------------------------------
+                            Frozen Density ( FRZ )          -20.53133
+                              Polarization ( POL )          -12.20539
+                         RS Delocalization ( DEL )          -19.37190
+         RS Basis set superposition error ( BSSE )            4.83535
+            RS Charge-transfer ( CT = DEL + BSSE )          -14.53655
+ ---------------------------------------------------------------------
+                 RS Total ( TOT = FRZ + POL + CT )          -47.27326
+
+ *-------------------------------------------------------------------* 
+ *      Energy decomposition of the delocalization term, kJ/mol      * 
+ *-------------------------------------------------------------------* 
+                DEL from fragment(row) to fragment(col)                
+  -------------------------------------------------------------------    
+             1           2
+    1    -0.00299   -19.26957
+    2    -0.09786    -0.00024
+  -------------------------------------------------------------------  
+                BSSE from fragment(row) to fragment(col)               
+                  Grid superposition error: -0.05519
+  -------------------------------------------------------------------    
+             1           2
+    1     0.00001     4.82375
+    2     0.06675     0.00003
+  -------------------------------------------------------------------  
+                 CT from fragment(row) to fragment(col)                
+                  Grid superposition error: -0.05641
+  -------------------------------------------------------------------    
+             1           2
+    1    -0.00299   -14.44583
+    2    -0.03111    -0.00021
+ ---------------------------------------------------------------------
+
+
+ --------------------------------------------------------------------- 
+ *                     Charge transfer analysis                      * 
+ *             R.Z.Khaliullin, A.T. Bell, M.Head-Gordon              * 
+ *                J. Chem. Phys., 2008, 128, 184112                  * 
+ *-------------------------------------------------------------------* 
+                       Fragment population, a.u.                       
+ --------------------------------------------------------------------- 
+    Method   Fragment         Occ         Vir     Occ+Vir    Isolated
+ --------------------------------------------------------------------- 
+    SCF MI          1    9.000000    0.000000    9.000000    9.000000
+                    2   10.000000    0.000000   10.000000   10.000000
+ --------------------------------------------------------------------- 
+        RS          1    8.978345   -0.003092    8.975253    9.000000
+                    2    9.999990    0.024757   10.024747   10.000000
+ --------------------------------------------------------------------- 
+   BSSE RS          1    8.995570   -0.000332    8.995238    9.000000
+                    2    9.999994    0.004768   10.004762   10.000000
+ --------------------------------------------------------------------- 
+                           Total electron transfer            DQ, me-
+ --------------------------------------------------------------------- 
+                                 RS Delocalization          21.665021
+                  RS Basis set superposition error           4.436654
+ --------------------------------------------------------------------- 
+                                RS Charge-transfer          17.228368
+
+ *-------------------------------------------------------------------* 
+ *      Decomposition of the total RS charge-transfer term, me-      * 
+ *-------------------------------------------------------------------* 
+           Delocalization from fragment(row) to fragment(col)          
+  -------------------------------------------------------------------    
+             1           2
+    1    -3.10413    24.75944
+    2     0.01213    -0.00242
+  -------------------------------------------------------------------  
+                BSSE from fragment(row) to fragment(col)               
+  -------------------------------------------------------------------    
+             1           2
+    1    -0.33785     4.76808
+    2     0.00633     0.00009
+  -------------------------------------------------------------------  
+         Electron transfer from fragment(row) to fragment(col)         
+  -------------------------------------------------------------------    
+             1           2
+    1    -2.76628    19.99136
+    2     0.00580    -0.00251
+  -------------------------------------------------------------------  
+
+Archival summary:
+1\1\osmium\SP\ProcedureUnspecified\6-31G*\a113(1+,2)\eric\SunJan2411:12:212016SunJan2411:12:212016\0\\#,ProcedureUnspecified,6-31G*,\\1,2\C\H,1,1.08198\H,1,1.08199,2,118.895\H,1,1.08199,2,118.897,3,-159.249,0\Na,1,2.66319,2,96.108,3,100.399,0\\\@
+
+ Total job time:  4.37s(wall), 1.05s(cpu) 
+ Sun Jan 24 11:12:21 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+

--- a/QChem/QChem4.2/CH4---Na+_noprint.out
+++ b/QChem/QChem4.2/CH4---Na+_noprint.out
@@ -1,0 +1,426 @@
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe .CH4---Na+_noprint.in.2299.qcin.1 /tmp/qchem/qchem2299/
+
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2014)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Sun Jan 24 11:13:22 2016  
+
+Host: osmium
+0
+
+     Scratch files written to /tmp/qchem/qchem2299//
+ Jun1415 |home|eric|data|opt|apps|qchem|trunk_RNUM -1
+
+Checking the input file for inconsistencies...	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$molecule
+ 1 1
+ --
+ 0 1
+ C      -1.347085     0.000371    -0.000120
+ H      -1.046164     0.327057    -0.998780
+ H      -1.013267    -1.018202     0.215361
+ H      -2.433843    -0.018112     0.011987
+ H      -1.033273     0.707068     0.772423
+ --
+ 1 1
+ Na      1.237187    -0.000003    -0.000025
+$end
+
+$rem
+jobtype              eda
+exchange             b3lyp
+basis                6-31g*
+scf_guess            fragmo
+frgm_method          stoll
+frgm_lpcorr          rs_exact_scf
+diis_separate_errvec 1
+scf_print_frgm       false
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      C      -1.3470850000     0.0003709638    -0.0001196878
+    2      H      -1.0461639938     0.3272965458    -0.9987012810
+    3      H      -1.0132670896    -1.0182537408     0.2151169004
+    4      H      -2.4338430014    -0.0181148394     0.0119829034
+    5      H      -1.0332729154     0.7068825494     0.7725928479
+    6      Na      1.2371870000    -0.0000032998    -0.0000248403
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    35.5095917853 hartrees
+ There are       10 alpha and       10 beta electrons
+ Requested basis set is 6-31G(d)
+ There are 17 shells and 42 basis functions
+
+Total QAlloc Memory Limit   2000 MB
+Mega-Array Size        61 MB
+MEM_STATIC part        62 MB
+
+                       Distance Matrix (Angstroms)
+             C (  1)   H (  2)   H (  3)   H (  4)   H (  5)
+   H (  2)  1.092977
+   H (  3)  1.093324  1.812441
+   H (  4)  1.086983  1.751127  1.749165
+   H (  5)  1.093033  1.811556  1.813084  1.750927
+   Na(  6)  2.584272  2.513597  2.479448  3.671094  2.500323
+ 
+ A cutoff of  1.0D-08 yielded    151 shell pairs
+ There are       961 function pairs
+ 
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is             15166112
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                         17
+ number of basis is                          42
+ number of cartesian basis is                42
+ number of contracted shell pairs           151
+ number of primitive shell pairs            815
+ maxK2 (contraction) of shell pair           36
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair             16
+ max number of PS2 of shell pair             84
+ mem total for path MDJ                   10660
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 8.86E-03
+
+  Scale SEOQF with 1.000000e-01/1.000000e-01/1.000000e-01
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000013 hartrees
+ Guess MOs from converged MOs on fragments
+
+-----------------------------------------------------------------
+ SCF on fragment 1 out of 2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh  /tmp/qchem/qchem2299/Frg1.input  /dev/null  Frg1
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh /tmp/qchem/qchem2299/Frg1.input /dev/null Frg1
+QCSCRATCH is /tmp/qchem/qchem2299/Frg1
+QCFILEPREF is /tmp/qchem/qchem2299/Frg1/
+-- Serial fragment SCF job
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe /tmp/qchem/qchem2299/Frg1.input /tmp/qchem/qchem2299/Frg1/
+ SCF on fragment 2 out of 2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh  /tmp/qchem/qchem2299/Frg2.input  /dev/null  Frg2
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/bin/xr.csh /tmp/qchem/qchem2299/Frg2.input /dev/null Frg2
+QCSCRATCH is /tmp/qchem/qchem2299/Frg2
+QCFILEPREF is /tmp/qchem/qchem2299/Frg2/
+-- Serial fragment SCF job
+/home/eric/data/opt/apps/qchem/trunk_intel_release_r18414_20150613/exe/qcprog.exe /tmp/qchem/qchem2299/Frg2.input /tmp/qchem/qchem2299/Frg2/
+-----------------------------------------------------------------
+ Done with SCF on isolated fragments
+-----------------------------------------------------------------
+
+ User-specified occupied guess orbitals will be used
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Stoll
+ with single Roothaan step correction
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.14 s  wall 0.14 s
+
+ Total DFTman time = 0.14 CPUs 0.14 Wall
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -202.6000690016      7.63E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.11 s
+
+ Total DFTman time = 0.11 CPUs 0.11 Wall
+    2    -202.6063731533      3.63E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+
+ Total DFTman time = 0.10 CPUs 0.10 Wall
+    3    -202.6070666465      8.27E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+
+ Total DFTman time = 0.10 CPUs 0.10 Wall
+    4    -202.6070979596      4.49E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+
+ Total DFTman time = 0.10 CPUs 0.10 Wall
+    5    -202.6071100242      3.95E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+
+ Total DFTman time = 0.08 CPUs 0.08 Wall
+    6    -202.6071098566      1.99E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+
+ Total DFTman time = 0.08 CPUs 0.08 Wall
+Last iteration: RS correction
+SCF MI energy: -202.6071098307
+SCF MI(RS) energy: -202.6117499093
+    7    -202.6117499093      9.73E-06 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 0.96 s  wall 0.98 s
+-----------------------------------------------------
+ full SCF correction to the locally projected method
+-----------------------------------------------------
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.11 s
+
+ Total DFTman time = 0.11 CPUs 0.11 Wall
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -202.6118698289      4.94E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+
+ Total DFTman time = 0.10 CPUs 0.10 Wall
+    2    -202.6118986361      4.41E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+
+ Total DFTman time = 0.10 CPUs 0.10 Wall
+    3    -202.6119422832      7.41E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+
+ Total DFTman time = 0.10 CPUs 0.10 Wall
+    4    -202.6119439163      1.15E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+
+ Total DFTman time = 0.10 CPUs 0.10 Wall
+    5    -202.6119443654      6.09E-07 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 0.71 s  wall 0.71 s
+ SCF   energy in the final basis set = -202.6119443654
+ Total energy in the final basis set = -202.6119443654
+ Analysis of SCF Wavefunction
+ 
+ --------------------------------------------------------------
+ 
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+ 
+ Alpha MOs
+ -- Occupied --
+-38.761 -10.364  -2.494  -1.425  -1.425  -1.425  -0.895  -0.596
+ -0.596  -0.582
+ -- Virtual --
+ -0.237  -0.149  -0.149  -0.136  -0.071  -0.031  -0.030  -0.026
+ -0.005  -0.005   0.010   0.050   0.141   0.142   0.184   0.187
+  0.239   0.367   0.379   0.380   0.672   0.736   0.737   0.756
+  0.885   1.033   1.473   1.473   2.049   2.051   2.107   4.016
+ --------------------------------------------------------------
+ 
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 C                    -0.742358
+      2 H                     0.210143
+      3 H                     0.208360
+      4 H                     0.264341
+      5 H                     0.209499
+      6 Na                    0.850016
+  ----------------------------------------
+  Sum of atomic charges =     1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                 4.8032
+    Dipole Moment (Debye)
+         X       4.5733      Y       0.0016      Z      -0.0015
+       Tot       4.5733
+    Quadrupole Moments (Debye-Ang)
+        XX      -0.7819     XY       0.0100     YY     -11.0812
+        XZ      -0.0050     YZ       0.0002     ZZ     -11.0777
+    Octopole Moments (Debye-Ang^2)
+       XXX      22.6292    XXY      -0.0556    XYY       7.0242
+       YYY      -0.5221    XXZ       0.0323    XYZ       0.0002
+       YYZ       0.3991    XZZ       7.0043    YZZ       0.5654
+       ZZZ      -0.4288
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX     -96.1131   XXXY       0.2205   XXYY     -24.7585
+      XYYY       0.4972   YYYY     -16.2085   XXXZ      -0.1374
+      XXYZ      -0.0014   XYYZ      -0.3840   YYYZ       0.0150
+      XXZZ     -24.7187   XYZZ      -0.5496   YYZZ      -5.3865
+      XZZZ       0.4215   YZZZ      -0.0133   ZZZZ     -16.1497
+ -----------------------------------------------------------------
+
+ ---------------------------------------------------------------------
+ *                   Energy decomposition analysis                   *
+ *  R.Z.Khaliullin, E.A.Cobar, R.C.Lochan, A.T.Bell, M.Head-Gordon   *
+ *              J. Phys. Chem. A, 2007, 111, 8753-8765.              *
+ ---------------------------------------------------------------------
+   Fragment           E(TOTAL)      E(RS CP-CORR)     E(SCF CP-CORR)
+ ---------------------------------------------------------------------
+          1     -40.5175279989                N/A                N/A
+          2    -162.0812279314                N/A                N/A
+ ---------------------------------------------------------------------
+   initial     -202.6000690016
+    SCF MI     -202.6071098307
+        RS     -202.6117499093
+       SCF     -202.6119443654
+ ---------------------------------------------------------------------
+                                       Energy term         DE, kJ/mol
+ ---------------------------------------------------------------------
+                            Frozen Density ( FRZ )           -3.44751
+                              Polarization ( POL )          -18.48592
+                       RS Delocalization ( P-DEL )          -12.18267
+                      SCF Delocalization ( V-DEL )          -12.69322
+ ---------------------------------------------------------------------
+            RS Total ( P-TOT = FRZ + POL + P-DEL )          -34.11610
+           SCF Total ( V-TOT = FRZ + POL + V-DEL )          -34.62665
+    Higher order relaxation ( HO = V-TOT - P-TOT )           -0.51055
+
+ *-------------------------------------------------------------------* 
+ *      Energy decomposition of the delocalization term, kJ/mol      * 
+ *-------------------------------------------------------------------* 
+                DEL from fragment(row) to fragment(col)                
+  -------------------------------------------------------------------    
+             1           2
+    1     0.00013   -11.98848
+    2    -0.19382    -0.00041
+ ---------------------------------------------------------------------
+
+
+ --------------------------------------------------------------------- 
+ *                     Charge transfer analysis                      * 
+ *             R.Z.Khaliullin, A.T. Bell, M.Head-Gordon              * 
+ *                J. Chem. Phys., 2008, 128, 184112                  * 
+ *-------------------------------------------------------------------* 
+                       Fragment population, a.u.                       
+ --------------------------------------------------------------------- 
+    Method   Fragment         Occ         Vir     Occ+Vir    Isolated
+ --------------------------------------------------------------------- 
+    SCF MI          1   10.000000    0.000000   10.000000   10.000000
+                    2   10.000000    0.000000   10.000000   10.000000
+ --------------------------------------------------------------------- 
+        RS          1    9.992061   -0.001473    9.990588   10.000000
+                    2    9.999967    0.009445   10.009412   10.000000
+ --------------------------------------------------------------------- 
+       SCF          1    9.991584   -0.001332    9.990252   10.000000
+                    2    9.999963    0.009785   10.009748   10.000000
+ --------------------------------------------------------------------- 
+                           Total electron transfer            DQ, me-
+ --------------------------------------------------------------------- 
+                                 RS Delocalization           7.971944
+                                SCF Delocalization           8.453532
+              Higher order relaxation ( SCF - RS )           0.481589
+
+
+ *-------------------------------------------------------------------* 
+ *      Decomposition of the total RS charge-transfer term, me-      * 
+ *-------------------------------------------------------------------* 
+           Delocalization from fragment(row) to fragment(col)          
+  -------------------------------------------------------------------    
+             1           2
+    1    -1.50423     9.44321
+    2     0.03111     0.00185
+  -------------------------------------------------------------------  
+
+Archival summary:
+1\1\osmium\SP\ProcedureUnspecified\6-31G*\a114(1+,1)\eric\SunJan2411:13:252016SunJan2411:13:252016\0\\#,ProcedureUnspecified,6-31G*,\\1,1\C\H,1,1.08698\H,1,1.09298,2,106.889\H,1,1.09303,2,106.868,3,-119.996,0\H,1,1.09332,2,106.692,3,119.975,0\Na,5,2.47945,1,82.9593,2,179.558,0\\\@
+
+ Total job time:  2.83s(wall), 1.75s(cpu) 
+ Sun Jan 24 11:13:25 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+

--- a/QChem/QChem4.2/print_frgm_false_opt.out
+++ b/QChem/QChem4.2/print_frgm_false_opt.out
@@ -1,0 +1,2258 @@
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe .opt_print_frgm_false.in.11273.qcin.1 /tmp/qchem/qchem11273/
+
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Mon Jan 25 20:59:14 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem11273//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$rem
+ jobtype = opt
+ method = b3lyp
+ basis = cc-pvdz
+ frgm_method = gia
+ frgm_lpcorr = 0
+ scf_print_frgm = false
+$end
+
+$molecule
+-1 1
+--
+0 1
+O      2.0046718567   -0.0940911795   -0.0000456417
+H      2.0989955585    0.8620675220   -0.0000086873
+H      1.0186881803   -0.1989910837   -0.0000610506
+--
+-1 1
+Cl    -1.1264842195    0.0053780533   -0.0000197660
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0045014740    -0.0939781001     0.0000017004
+    2      H       2.0987398960     0.8621890110    -0.0000023237
+    3      H       1.0185271576    -0.1989659440    -0.0000163614
+    4      Cl     -1.1266634615     0.0052118667     0.0000002989
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    38.8683285907 hartrees
+ There are       14 alpha and       14 beta electrons
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+
+ Total QAlloc Memory Limit   2000 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+ A cutoff of  1.0D-11 yielded    200 shell pairs
+ There are       918 function pairs (      1013 Cartesian)
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is             19390748
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                         20
+ number of basis is                          44
+ number of cartesian basis is                44
+ number of contracted shell pairs           200
+ number of primitive shell pairs           1958
+ maxK2 (contraction) of shell pair           81
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair             18
+ max number of PS2 of shell pair            486
+ mem total for path MDJ                   13530
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 3.06E-02
+
+ Scale SEOQF with 1.000000e-01/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000027 hartrees
+ Guess MOs from converged MOs on fragments
+
+-----------------------------------------------------------------
+ SCF on fragment 1 out of 2
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh  /tmp/qchem/qchem11273/Frg1.input  /dev/null  Frg1
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh /tmp/qchem/qchem11273/Frg1.input /dev/null Frg1
+QCSCRATCH is /tmp/qchem/qchem11273/Frg1
+QCFILEPREF is /tmp/qchem/qchem11273/Frg1/
+-- Serial fragment SCF job
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe /tmp/qchem/qchem11273/Frg1.input /tmp/qchem/qchem11273/Frg1/
+ SCF on fragment 2 out of 2
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh  /tmp/qchem/qchem11273/Frg2.input  /dev/null  Frg2
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh /tmp/qchem/qchem11273/Frg2.input /dev/null Frg2
+QCSCRATCH is /tmp/qchem/qchem11273/Frg2
+QCFILEPREF is /tmp/qchem/qchem11273/Frg2/
+-- Serial fragment SCF job
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe /tmp/qchem/qchem11273/Frg2.input /tmp/qchem/qchem11273/Frg2/
+-----------------------------------------------------------------
+ Done with SCF on isolated fragments
+-----------------------------------------------------------------
+
+ User-specified occupied guess orbitals will be used
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.6992110706      7.03E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    2    -536.7039377532      2.71E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    3    -536.7042517876      1.12E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7043044908      5.36E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    5    -536.7043182580      2.64E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7043183201      9.70E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7043183390      2.25E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7043183407      3.09E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    9    -536.7043183405      4.89E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+   10    -536.7043183405      8.79E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.99 s  wall 1.87 s
+ SCF   energy in the final basis set = -536.7043183405
+ Total energy in the final basis set = -536.7043183405
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.937  -0.803  -0.316  -0.187  -0.107-101.191  -9.104  -6.861
+ -6.861  -6.861  -0.453  -0.006   0.000   0.001
+ -- Virtual --
+  0.234   0.385   0.727   0.801   1.083   1.094   1.199   1.367
+  1.428   1.598   1.813   1.860   2.261   2.315   3.098   3.127
+  3.302   3.621   3.925   0.837   0.838   0.840   0.909   1.063
+  1.065   1.065   1.070   1.070
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.350975
+      2 H                     0.102935
+      3 H                     0.248040
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.2305      Y       1.2185      Z      -0.0000
+       Tot       3.4527
+    Quadrupole Moments (Debye-Ang)
+        XX     -33.8070     XY       3.2387     YY     -20.5618
+        XZ      -0.0000     YZ       0.0000     ZZ     -22.3238
+    Octopole Moments (Debye-Ang^2)
+       XXX       5.6332    XXY       7.4508    XYY       6.8658
+       YYY       1.2184    XXZ      -0.0000    XYZ      -0.0000
+       YYZ      -0.0000    XZZ       3.3376    YZZ       0.1299
+       ZZZ      -0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -327.8247   XXXY      17.4892   XXYY     -47.6651
+      XYYY       3.0504   YYYY     -23.8475   XXXZ       0.0000
+      XXYZ      -0.0000   XYYZ      -0.0000   YYYZ      -0.0000
+      XXZZ     -54.4133   XYZZ       0.4071   YYZZ      -7.9929
+      XZZZ      -0.0000   YZZZ       0.0000   ZZZZ     -22.7825
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.16 s  wall 0.20 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1   0.0082092   0.0025052  -0.0169743   0.0062600
+    2   0.0098472  -0.0066251  -0.0021109  -0.0011112
+    3   0.0000006  -0.0000000  -0.0000008   0.0000001
+ Max gradient component =       1.697E-02
+ RMS gradient           =       6.755E-03
+ Gradient time:  CPU 0.67 s  wall 5.32 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   1
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0045014740   -0.0939781001    0.0000017004
+      2  H         2.0987398960    0.8621890110   -0.0000023237
+      3  H         1.0185271576   -0.1989659440   -0.0000163614
+      4  Cl       -1.1266634615    0.0052118667    0.0000002989
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.704318340
+
+
+ Attempting to Generate Delocalized Internal Coordinates
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.043648    0.160000    0.200000    0.200000    0.492057    0.553017
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00142891
+ Step Taken.  Stepsize is  0.147333
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.010087      0.000300      NO
+         Displacement       0.092561      0.001200      NO
+         Energy change     *********      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.113633
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0260905938    -0.0993578939     0.0000000211
+    2      H       2.0824429475     0.8658746290    -0.0000019715
+    3      H       1.0523119123    -0.2073867542    -0.0000146682
+    4      Cl     -1.1657403876     0.0153268527    -0.0000000671
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    38.3028669020 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000028 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    200 shell pairs
+ There are       918 function pairs (      1013 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.06E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7230214456      4.02E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7050343783      2.27E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    3    -536.7051813539      1.49E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    4    -536.7052895669      2.01E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7052918567      1.84E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7052919090      5.93E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    7    -536.7052919175      7.96E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7052919176      2.24E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7052919177      1.14E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+   10    -536.7052919176      2.34E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.88 s  wall 1.75 s
+ SCF   energy in the final basis set = -536.7052919176
+ Total energy in the final basis set = -536.7052919176
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.943  -0.811  -0.318  -0.196  -0.112-101.190  -9.103  -6.860
+ -6.860  -6.860  -0.451  -0.004   0.002   0.002
+ -- Virtual --
+  0.231   0.377   0.719   0.810   1.082   1.090   1.196   1.344
+  1.431   1.584   1.800   1.871   2.265   2.316   3.109   3.115
+  3.300   3.612   3.933   0.838   0.839   0.840   0.910   1.065
+  1.067   1.068   1.072   1.072
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.339207
+      2 H                     0.106150
+      3 H                     0.233057
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.4317      Y       1.1720      Z      -0.0000
+       Tot       3.6263
+    Quadrupole Moments (Debye-Ang)
+        XX     -34.3819     XY       3.2650     YY     -20.5365
+        XZ      -0.0000     YZ       0.0000     ZZ     -22.3196
+    Octopole Moments (Debye-Ang^2)
+       XXX       7.0706    XXY       7.1448    XYY       7.3839
+       YYY       0.8471    XXZ       0.0000    XYZ       0.0000
+       YYZ       0.0000    XZZ       3.8202    YZZ       0.0042
+       ZZZ       0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -342.3719   XXXY      18.0182   XXYY     -49.5020
+      XYYY       3.8023   YYYY     -23.9047   XXXZ       0.0001
+      XXYZ      -0.0000   XYYZ       0.0000   YYYZ      -0.0000
+      XXZZ     -56.2721   XYZZ       0.6650   YYZZ      -8.0080
+      XZZZ       0.0000   YZZZ      -0.0000   ZZZZ     -22.7797
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1   0.0012969  -0.0000569  -0.0045117   0.0032717
+    2   0.0001562  -0.0014427   0.0023426  -0.0010561
+    3   0.0000004  -0.0000001  -0.0000005   0.0000001
+ Max gradient component =       4.512E-03
+ RMS gradient           =       1.859E-03
+ Gradient time:  CPU 0.49 s  wall 0.48 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   2
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0260905938   -0.0993578939    0.0000000211
+      2  H         2.0824429475    0.8658746290   -0.0000019715
+      3  H         1.0523119123   -0.2073867542   -0.0000146682
+      4  Cl       -1.1657403876    0.0153268527   -0.0000000671
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.705291918
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.024935    0.167539    0.200000    0.201169    0.518711    0.553245
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00055402
+ Step Taken.  Stepsize is  0.142680
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.003117      0.000300      NO
+         Displacement       0.094385      0.001200      NO
+         Energy change     -0.000974      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.112551
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0469566552    -0.0978978838    -0.0000022201
+    2      H       2.0807250632     0.8715802633    -0.0000014371
+    3      H       1.0788689153    -0.2222475959    -0.0000123983
+    4      Cl     -1.2114455677     0.0230220500    -0.0000006303
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.6814631097 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000029 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    199 shell pairs
+ There are       903 function pairs (       995 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.10E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7143613349      2.09E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    2    -536.7053428174      2.52E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    3    -536.7056675240      2.31E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7056698580      1.09E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    5    -536.7056711372      2.15E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7056712706      4.97E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7056712765      4.86E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7056712765      1.34E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7056712764      1.12E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.06 s  wall 0.06 s
+   10    -536.7056712764      3.02E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.78 s  wall 1.67 s
+ SCF   energy in the final basis set = -536.7056712764
+ Total energy in the final basis set = -536.7056712764
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.947  -0.816  -0.322  -0.202  -0.116-101.189  -9.102  -6.859
+ -6.859  -6.859  -0.450  -0.003   0.003   0.003
+ -- Virtual --
+  0.227   0.367   0.714   0.809   1.079   1.086   1.191   1.337
+  1.429   1.579   1.792   1.870   2.260   2.316   3.106   3.110
+  3.295   3.607   3.931   0.839   0.840   0.840   0.911   1.067
+  1.069   1.069   1.073   1.073
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.334223
+      2 H                     0.109544
+      3 H                     0.224679
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.6657      Y       1.1172      Z      -0.0000
+       Tot       3.8322
+    Quadrupole Moments (Debye-Ang)
+        XX     -34.9968     XY       3.2865     YY     -20.4965
+        XZ      -0.0000     YZ       0.0000     ZZ     -22.3201
+    Octopole Moments (Debye-Ang^2)
+       XXX       9.2104    XXY       6.9456    XYY       8.0497
+       YYY       0.5039    XXZ       0.0001    XYZ       0.0000
+       YYZ       0.0000    XZZ       4.3969    YZZ      -0.1193
+       ZZZ       0.0001
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -358.4146   XXXY      18.5834   XXYY     -51.4972
+      XYYY       4.2945   YYYY     -23.9225   XXXZ       0.0002
+      XXYZ      -0.0000   XYYZ       0.0000   YYYZ      -0.0000
+      XXZZ     -58.4430   XYZZ       0.8137   YYZZ      -8.0178
+      XZZZ       0.0001   YZZZ      -0.0000   ZZZZ     -22.7816
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1  -0.0007308  -0.0003865   0.0000009   0.0011164
+    2  -0.0035506   0.0014447   0.0029715  -0.0008656
+    3   0.0000003  -0.0000001  -0.0000003   0.0000001
+ Max gradient component =       3.551E-03
+ RMS gradient           =       1.478E-03
+ Gradient time:  CPU 0.45 s  wall 0.43 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   3
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0469566552   -0.0978978838   -0.0000022201
+      2  H         2.0807250632    0.8715802633   -0.0000014371
+      3  H         1.0788689153   -0.2222475959   -0.0000123983
+      4  Cl       -1.2114455677    0.0230220500   -0.0000006303
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.705671276
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.015396    0.166436    0.191742    0.200000    0.523749    0.586021
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00021569
+ Step Taken.  Stepsize is  0.105885
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.002654      0.000300      NO
+         Displacement       0.069475      0.001200      NO
+         Energy change     -0.000379      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.086126
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0632802685    -0.0934036310    -0.0000043740
+    2      H       2.0758151865     0.8761323272    -0.0000008862
+    3      H       1.0985675195    -0.2399757888    -0.0000102365
+    4      Cl     -1.2425579085     0.0317039261    -0.0000011890
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.2599205418 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000030 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    197 shell pairs
+ There are       891 function pairs (       983 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.14E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.969514918421
+   Relative error      =    -0.1088752914 %
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7097264298      1.71E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7054110903      2.74E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    3    -536.7057991255      4.76E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.08 s
+    4    -536.7058128336      1.54E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    5    -536.7058145651      2.63E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7058147273      6.30E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7058147369      7.64E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7058147370      1.67E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7058147369      1.06E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+   10    -536.7058147369      1.25E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.68 s  wall 1.57 s
+ SCF   energy in the final basis set = -536.7058147369
+ Total energy in the final basis set = -536.7058147369
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.950  -0.819  -0.326  -0.204  -0.119-101.188  -9.101  -6.858
+ -6.858  -6.858  -0.449  -0.001   0.004   0.004
+ -- Virtual --
+  0.226   0.359   0.712   0.808   1.077   1.083   1.187   1.335
+  1.426   1.576   1.786   1.867   2.259   2.314   3.104   3.107
+  3.293   3.605   3.928   0.840   0.840   0.841   0.911   1.069
+  1.070   1.071   1.074   1.074
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.331862
+      2 H                     0.111622
+      3 H                     0.220240
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.8146      Y       1.0462      Z       0.0000
+       Tot       3.9555
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.4778     XY       3.2955     YY     -20.4529
+        XZ       0.0000     YZ       0.0000     ZZ     -22.3197
+    Octopole Moments (Debye-Ang^2)
+       XXX      10.5053    XXY       6.6698    XYY       8.5216
+       YYY       0.0761    XXZ       0.0001    XYZ       0.0000
+       YYZ       0.0000    XZZ       4.7802    YZZ      -0.2705
+       ZZZ       0.0002
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -370.4401   XXXY      19.0543   XXYY     -52.8949
+      XYYY       4.7639   YYYY     -23.9308   XXXZ       0.0002
+      XXYZ       0.0000   XYYZ       0.0000   YYYZ      -0.0000
+      XXZZ     -60.0003   XYZZ       0.9559   YYZZ      -8.0240
+      XZZZ       0.0001   YZZZ      -0.0000   ZZZZ     -22.7817
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1  -0.0003468  -0.0002157   0.0007826  -0.0002201
+    2  -0.0027901   0.0010337   0.0024102  -0.0006538
+    3   0.0000001  -0.0000000  -0.0000001   0.0000000
+ Max gradient component =       2.790E-03
+ RMS gradient           =       1.152E-03
+ Gradient time:  CPU 0.42 s  wall 0.41 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   4
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0632802685   -0.0934036310   -0.0000043740
+      2  H         2.0758151865    0.8761323272   -0.0000008862
+      3  H         1.0985675195   -0.2399757888   -0.0000102365
+      4  Cl       -1.2425579085    0.0317039261   -0.0000011890
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.705814737
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.012508    0.156929    0.172473    0.200000    0.521407    0.569542
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00008871
+ Step Taken.  Stepsize is  0.059266
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.002269      0.000300      NO
+         Displacement       0.037890      0.001200      NO
+         Energy change     -0.000143      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.058162
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0725209304    -0.0888765849    -0.0000060390
+    2      H       2.0635582984     0.8797913151    -0.0000004288
+    3      H       1.1113476164    -0.2579540940    -0.0000085971
+    4      Cl     -1.2523217792     0.0414961974    -0.0000016207
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.0996358015 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000030 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    197 shell pairs
+ There are       891 function pairs (       983 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.15E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.963644302385
+   Relative error      =    -0.1298417772 %
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7074104525      1.80E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    2    -536.7054227268      2.90E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    3    -536.7058638322      5.21E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    4    -536.7058808794      1.88E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7058830845      2.82E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.11 s
+    6    -536.7058832579      6.96E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7058832700      1.04E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    8    -536.7058832702      1.93E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7058832701      1.42E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+   10    -536.7058832701      1.55E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.78 s  wall 1.71 s
+ SCF   energy in the final basis set = -536.7058832701
+ Total energy in the final basis set = -536.7058832701
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.951  -0.820  -0.327  -0.205  -0.120-101.188  -9.101  -6.858
+ -6.858  -6.857  -0.449  -0.001   0.004   0.005
+ -- Virtual --
+  0.226   0.355   0.712   0.807   1.076   1.082   1.185   1.334
+  1.425   1.576   1.784   1.866   2.259   2.313   3.104   3.106
+  3.293   3.604   3.927   0.840   0.840   0.841   0.912   1.069
+  1.071   1.071   1.074   1.074
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.331067
+      2 H                     0.113057
+      3 H                     0.218010
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.8476      Y       0.9668      Z       0.0000
+       Tot       3.9672
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.7256     XY       3.2934     YY     -20.4129
+        XZ       0.0000     YZ       0.0000     ZZ     -22.3191
+    Octopole Moments (Debye-Ang^2)
+       XXX      10.5120    XXY       6.3123    XYY       8.6919
+       YYY      -0.4079    XXZ       0.0002    XYZ       0.0000
+       YYZ       0.0001    XZZ       4.8813    YZZ      -0.4383
+       ZZZ       0.0002
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -375.8214   XXXY      19.3844   XXYY     -53.3888
+      XYYY       5.2602   YYYY     -23.9686   XXXZ       0.0003
+      XXYZ       0.0000   XYYZ       0.0000   YYYZ      -0.0000
+      XXZZ     -60.5776   XYZZ       1.1133   YYZZ      -8.0339
+      XZZZ       0.0002   YZZZ      -0.0000   ZZZZ     -22.7811
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1  -0.0000420   0.0000370   0.0007688  -0.0007639
+    2  -0.0014853   0.0002206   0.0017562  -0.0004914
+    3   0.0000001  -0.0000000  -0.0000001   0.0000000
+ Max gradient component =       1.756E-03
+ RMS gradient           =       7.505E-04
+ Gradient time:  CPU 0.45 s  wall 0.44 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   5
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0725209304   -0.0888765849   -0.0000060390
+      2  H         2.0635582984    0.8797913151   -0.0000004288
+      3  H         1.1113476164   -0.2579540940   -0.0000085971
+      4  Cl       -1.2523217792    0.0414961974   -0.0000016207
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.705883270
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.010331    0.081520    0.175766    0.200000    0.521344    0.578057
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00013767
+ Step Taken.  Stepsize is  0.084519
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.001813      0.000300      NO
+         Displacement       0.056174      0.001200      NO
+         Energy change     -0.000069      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.114017
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0841099719    -0.0802508343    -0.0000087510
+    2      H       2.0288117203     0.8857693438     0.0000003492
+    3      H       1.1317747302    -0.2940412721    -0.0000059728
+    4      Cl     -1.2495913565     0.0629795961    -0.0000023112
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.0351119800 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000031 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    197 shell pairs
+ There are       891 function pairs (       983 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.17E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.960690695026
+   Relative error      =    -0.1403903749 %
+ CPU 0.11 s  wall 0.12 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7056468774      2.86E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7054893641      3.02E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    3    -536.7059744070      5.19E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.11 s
+    4    -536.7059857358      1.83E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7059888860      3.66E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    6    -536.7059891658      8.41E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7059891835      1.08E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    8    -536.7059891837      2.37E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7059891835      1.98E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.06 s
+   10    -536.7059891837      4.83E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.83 s  wall 1.73 s
+ SCF   energy in the final basis set = -536.7059891837
+ Total energy in the final basis set = -536.7059891837
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.952  -0.821  -0.328  -0.206  -0.120-101.188  -9.101  -6.858
+ -6.857  -6.857  -0.448  -0.000   0.004   0.005
+ -- Virtual --
+  0.228   0.349   0.712   0.808   1.076   1.082   1.182   1.333
+  1.425   1.575   1.782   1.867   2.261   2.313   3.104   3.106
+  3.293   3.604   3.927   0.840   0.841   0.841   0.912   1.070
+  1.071   1.071   1.074   1.074
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.330766
+      2 H                     0.115804
+      3 H                     0.214961
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.7934      Y       0.7951      Z       0.0000
+       Tot       3.8759
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.9777     XY       3.2701     YY     -20.3397
+        XZ       0.0000     YZ       0.0000     ZZ     -22.3183
+    Octopole Moments (Debye-Ang^2)
+       XXX       9.1247    XXY       5.4676    XYY       8.7131
+       YYY      -1.4670    XXZ       0.0002    XYZ       0.0000
+       YYZ       0.0001    XZZ       4.7856    YZZ      -0.8005
+       ZZZ       0.0003
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -379.6072   XXXY      19.8392   XXYY     -53.4564
+      XYYY       6.3080   YYYY     -24.1378   XXXZ       0.0004
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ      -0.0000
+      XXZZ     -60.7016   XYZZ       1.4567   YYZZ      -8.0684
+      XZZZ       0.0002   YZZZ      -0.0000   ZZZZ     -22.7802
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1   0.0001356   0.0004157   0.0005826  -0.0011339
+    2   0.0002556  -0.0007985   0.0007808  -0.0002379
+    3  -0.0000001   0.0000000   0.0000001  -0.0000000
+ Max gradient component =       1.134E-03
+ RMS gradient           =       5.152E-04
+ Gradient time:  CPU 0.45 s  wall 0.43 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   6
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0841099719   -0.0802508343   -0.0000087510
+      2  H         2.0288117203    0.8857693438    0.0000003492
+      3  H         1.1317747302   -0.2940412721   -0.0000059728
+      4  Cl       -1.2495913565    0.0629795961   -0.0000023112
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.705989184
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.008002    0.044357    0.179560    0.200000    0.521969    0.602144
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00018086
+ Step Taken.  Stepsize is  0.116165
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.002012      0.000300      NO
+         Displacement       0.077093      0.001200      NO
+         Energy change     -0.000106      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.199499
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0945028418    -0.0662784233    -0.0000121033
+    2      H       1.9605453424     0.8915082124     0.0000013178
+    3      H       1.1608258363    -0.3501552242    -0.0000027607
+    4      Cl     -1.2207689545     0.0993822687    -0.0000031395
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.2105029290 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000031 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    197 shell pairs
+ There are       891 function pairs (       983 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.19E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.956006357213
+   Relative error      =    -0.1571201528 %
+ CPU 0.12 s  wall 0.12 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7034698730      4.37E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    2    -536.7055125709      3.37E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    3    -536.7060228215      1.38E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7061119175      2.48E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7061165794      4.48E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7061169897      1.08E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    7    -536.7061170191      1.18E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7061170193      3.15E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7061170192      3.66E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.06 s  wall 0.07 s
+   10    -536.7061170193      5.80E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.79 s  wall 1.71 s
+ SCF   energy in the final basis set = -536.7061170193
+ Total energy in the final basis set = -536.7061170193
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.951  -0.820  -0.326  -0.206  -0.119-101.188  -9.101  -6.858
+ -6.857  -6.857  -0.449  -0.000   0.004   0.005
+ -- Virtual --
+  0.233   0.344   0.712   0.812   1.079   1.083   1.180   1.330
+  1.428   1.573   1.781   1.872   2.263   2.316   3.105   3.108
+  3.294   3.604   3.929   0.840   0.841   0.841   0.912   1.070
+  1.071   1.071   1.074   1.074
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.331541
+      2 H                     0.120658
+      3 H                     0.210883
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.5806      Y       0.5048      Z       0.0001
+       Tot       3.6160
+    Quadrupole Moments (Debye-Ang)
+        XX     -36.0949     XY       3.1862     YY     -20.2409
+        XZ       0.0001     YZ       0.0000     ZZ     -22.3180
+    Octopole Moments (Debye-Ang^2)
+       XXX       5.4808    XXY       3.9452    XYY       8.3924
+       YYY      -3.2816    XXZ       0.0003    XYZ       0.0000
+       YYZ       0.0001    XZZ       4.3086    YZZ      -1.4121
+       ZZZ       0.0004
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -377.7185   XXXY      20.1025   XXYY     -52.6116
+      XYYY       7.9219   YYYY     -24.6504   XXXZ       0.0006
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ       0.0000
+      XXZZ     -59.7671   XYZZ       2.0024   YYZZ      -8.1609
+      XZZZ       0.0003   YZZZ      -0.0000   ZZZZ     -22.7798
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.15 s  wall 0.15 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1   0.0001054   0.0006712   0.0002077  -0.0009843
+    2   0.0015481  -0.0013455  -0.0002264   0.0000238
+    3  -0.0000003   0.0000001   0.0000003  -0.0000001
+ Max gradient component =       1.548E-03
+ RMS gradient           =       6.912E-04
+ Gradient time:  CPU 0.48 s  wall 0.47 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   7
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0945028418   -0.0662784233   -0.0000121033
+      2  H         1.9605453424    0.8915082124    0.0000013178
+      3  H         1.1608258363   -0.3501552242   -0.0000027607
+      4  Cl       -1.2207689545    0.0993822687   -0.0000031395
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.706117019
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.007330    0.029406    0.178107    0.200000    0.522040    0.600608
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00008644
+ Step Taken.  Stepsize is  0.076222
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.001528      0.000300      NO
+         Displacement       0.059472      0.001200      NO
+         Energy change     -0.000128      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.151089
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0960393831    -0.0568410760    -0.0000130852
+    2      H       1.9069132304     0.8924658113     0.0000015422
+    3      H       1.1777989342    -0.3857502108    -0.0000017968
+    4      Cl     -1.1856464817     0.1245823092    -0.0000033459
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.5140049766 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000032 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    199 shell pairs
+ There are       897 function pairs (       989 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.19E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.956707878319
+   Relative error      =    -0.1546147203 %
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7051406902      3.19E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7056067622      3.18E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    3    -536.7061434475      6.65E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.10 s
+    4    -536.7061619349      2.08E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7061658978      3.97E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7061662247      9.03E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7061662449      1.17E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7061662453      2.67E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    9    -536.7061662451      2.69E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+   10    -536.7061662450      5.28E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.73 s  wall 1.62 s
+ SCF   energy in the final basis set = -536.7061662450
+ Total energy in the final basis set = -536.7061662450
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.949  -0.818  -0.323  -0.205  -0.118-101.188  -9.101  -6.858
+ -6.858  -6.858  -0.449  -0.001   0.004   0.004
+ -- Virtual --
+  0.237   0.341   0.712   0.815   1.083   1.084   1.180   1.327
+  1.432   1.572   1.781   1.877   2.264   2.318   3.105   3.111
+  3.294   3.604   3.932   0.839   0.841   0.841   0.911   1.069
+  1.071   1.071   1.074   1.074
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.333002
+      2 H                     0.124553
+      3 H                     0.208450
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.3576      Y       0.3041      Z       0.0001
+       Tot       3.3714
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.9890     XY       3.0932     YY     -20.1918
+        XZ       0.0001     YZ       0.0000     ZZ     -22.3186
+    Octopole Moments (Debye-Ang^2)
+       XXX       2.2085    XXY       2.8525    XYY       7.9420
+       YYY      -4.5547    XXZ       0.0003    XYZ       0.0000
+       YYZ       0.0001    XZZ       3.7803    YZZ      -1.8352
+       ZZZ       0.0004
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -371.3965   XXXY      19.8947   XXYY     -51.4666
+      XYYY       8.8688   YYYY     -25.1685   XXXZ       0.0006
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ       0.0000
+      XXZZ     -58.4387   XYZZ       2.3343   YYZZ      -8.2498
+      XZZZ       0.0003   YZZZ       0.0000   ZZZZ     -22.7807
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1  -0.0000283   0.0003928   0.0000196  -0.0003841
+    2   0.0010684  -0.0007116  -0.0004454   0.0000886
+    3  -0.0000003   0.0000001   0.0000003  -0.0000001
+ Max gradient component =       1.068E-03
+ RMS gradient           =       4.240E-04
+ Gradient time:  CPU 0.48 s  wall 0.47 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   8
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0960393831   -0.0568410760   -0.0000130852
+      2  H         1.9069132304    0.8924658113    0.0000015422
+      3  H         1.1777989342   -0.3857502108   -0.0000017968
+      4  Cl       -1.1856464817    0.1245823092   -0.0000033459
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.706166245
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.009032    0.022058    0.173885    0.200000    0.521629    0.575278
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00000963
+ Step Taken.  Stepsize is  0.019370
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.000776      0.000300      NO
+         Displacement       0.012862      0.001200      NO
+         Energy change     -0.000049      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.017065
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0938617037    -0.0574772485    -0.0000117495
+    2      H       1.9038057893     0.8923048560     0.0000010566
+    3      H       1.1753358522    -0.3849668598    -0.0000030152
+    4      Cl     -1.1778982792     0.1245960859    -0.0000029777
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.6033490688 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000032 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    200 shell pairs
+ There are       906 function pairs (       998 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.19E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.959229693740
+   Relative error      =    -0.1456082366 %
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7070886552      1.38E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7056711911      2.99E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    3    -536.7061237969      8.69E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7061526762      5.90E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7061712580      1.38E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    6    -536.7061727102      1.31E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7061727190      1.09E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7061727192      4.08E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7061727192      5.28E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+   10    -536.7061727191      2.87E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.72 s  wall 1.61 s
+ SCF   energy in the final basis set = -536.7061727191
+ Total energy in the final basis set = -536.7061727191
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.949  -0.818  -0.322  -0.204  -0.117-101.188  -9.101  -6.858
+ -6.858  -6.858  -0.449  -0.001   0.004   0.004
+ -- Virtual --
+  0.238   0.342   0.712   0.816   1.084   1.085   1.181   1.326
+  1.433   1.572   1.782   1.878   2.264   2.319   3.105   3.112
+  3.294   3.604   3.933   0.839   0.840   0.841   0.911   1.069
+  1.070   1.071   1.073   1.074
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.333556
+      2 H                     0.124647
+      3 H                     0.208909
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.3152      Y       0.3054      Z       0.0000
+       Tot       3.3293
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.9091     XY       3.0866     YY     -20.1957
+        XZ       0.0001     YZ       0.0000     ZZ     -22.3191
+    Octopole Moments (Debye-Ang^2)
+       XXX       1.7435    XXY       2.8501    XYY       7.8238
+       YYY      -4.5492    XXZ       0.0003    XYZ       0.0000
+       YYZ       0.0001    XZZ       3.6749    YZZ      -1.8327
+       ZZZ       0.0004
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -369.0794   XXXY      19.7952   XXYY     -51.1630
+      XYYY       8.8352   YYYY     -25.1763   XXXZ       0.0006
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ       0.0000
+      XXZZ     -58.1010   XYZZ       2.3261   YYZZ      -8.2510
+      XZZZ       0.0003   YZZZ       0.0000   ZZZZ     -22.7812
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.15 s  wall 0.15 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1  -0.0000564   0.0001200   0.0000672  -0.0001309
+    2   0.0002991  -0.0001711  -0.0001844   0.0000564
+    3  -0.0000003   0.0000001   0.0000003  -0.0000001
+ Max gradient component =       2.991E-04
+ RMS gradient           =       1.275E-04
+ Gradient time:  CPU 0.50 s  wall 0.50 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   9
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0938617037   -0.0574772485   -0.0000117495
+      2  H         1.9038057893    0.8923048560    0.0000010566
+      3  H         1.1753358522   -0.3849668598   -0.0000030152
+      4  Cl       -1.1778982792    0.1245960859   -0.0000029777
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.706172719
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.006937    0.019973    0.167990    0.200000    0.521411    0.564937
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00000298
+ Step Taken.  Stepsize is  0.019359
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.000221      0.000300     YES
+         Displacement       0.012527      0.001200      NO
+         Energy change     -0.000006      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.019813
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0918023118    -0.0593766186    -0.0000099973
+    2      H       1.9091887432     0.8921339378     0.0000004309
+    3      H       1.1705403767    -0.3791483550    -0.0000046149
+    4      Cl     -1.1764263657     0.1208478693    -0.0000025044
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.6349577740 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000031 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    200 shell pairs
+ There are       906 function pairs (       998 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.18E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.960097904038
+   Relative error      =    -0.1425074856 %
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7076166388      1.41E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7056759290      3.00E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    3    -536.7061264705      8.71E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    4    -536.7061601971      5.11E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.11 s
+    5    -536.7061741201      2.74E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    6    -536.7061742937      9.95E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7061743069      1.89E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7061743072      3.32E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7061743072      2.58E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.06 s  wall 0.07 s
+   10    -536.7061743073      2.77E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.82 s  wall 1.72 s
+ SCF   energy in the final basis set = -536.7061743073
+ Total energy in the final basis set = -536.7061743073
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.948  -0.818  -0.322  -0.204  -0.117-101.188  -9.101  -6.858
+ -6.858  -6.858  -0.449  -0.001   0.003   0.004
+ -- Virtual --
+  0.238   0.343   0.712   0.816   1.084   1.085   1.182   1.326
+  1.434   1.572   1.783   1.878   2.264   2.319   3.105   3.112
+  3.294   3.604   3.933   0.839   0.840   0.841   0.911   1.069
+  1.070   1.071   1.073   1.073
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.333823
+      2 H                     0.124053
+      3 H                     0.209770
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.3113      Y       0.3362      Z       0.0000
+       Tot       3.3283
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.8567     XY       3.0958     YY     -20.2054
+        XZ       0.0000     YZ       0.0000     ZZ     -22.3193
+    Octopole Moments (Debye-Ang^2)
+       XXX       1.8166    XXY       3.0099    XYY       7.7893
+       YYY      -4.3544    XXZ       0.0002    XYZ       0.0000
+       YYZ       0.0001    XZZ       3.6622    YZZ      -1.7675
+       ZZZ       0.0003
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -368.0206   XXXY      19.7493   XXYY     -51.0648
+      XYYY       8.6716   YYYY     -25.0973   XXXZ       0.0005
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ       0.0000
+      XXZZ     -58.0044   XYZZ       2.2714   YYZZ      -8.2373
+      XZZZ       0.0003   YZZZ       0.0000   ZZZZ     -22.7814
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1  -0.0000069  -0.0000215   0.0000284   0.0000001
+    2  -0.0000868   0.0000524   0.0000127   0.0000217
+    3  -0.0000002   0.0000001   0.0000002  -0.0000001
+ Max gradient component =       8.680E-05
+ RMS gradient           =       3.192E-05
+ Gradient time:  CPU 0.44 s  wall 0.43 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:  10
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0918023118   -0.0593766186   -0.0000099973
+      2  H         1.9091887432    0.8921339378    0.0000004309
+      3  H         1.1705403767   -0.3791483550   -0.0000046149
+      4  Cl       -1.1764263657    0.1208478693   -0.0000025044
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.706174307
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.005997    0.020874    0.170988    0.200000    0.521760    0.579151
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =   0.00000000
+ Step Taken.  Stepsize is  0.002599
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.000061      0.000300     YES
+         Displacement       0.001662      0.001200      NO
+         Energy change     -0.000002      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.004321
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0915742182    -0.0596724512    -0.0000093743
+    2      H       1.9107181762     0.8921208890     0.0000002069
+    3      H       1.1697794708    -0.3780370043    -0.0000051847
+    4      Cl     -1.1769667993     0.1200454001    -0.0000023337
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.6320526137 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000031 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    200 shell pairs
+ There are       906 function pairs (       998 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.18E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.961193580499
+   Relative error      =    -0.1385943554 %
+ CPU 0.11 s  wall 0.12 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7079870216      1.33E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7056920956      2.95E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.11 s
+    3    -536.7061255127      8.77E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7061515284      6.28E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.11 s
+    5    -536.7061680314      3.19E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7061742655      3.80E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7061743402      2.47E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7061743406      1.92E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7061743405      1.67E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+   10    -536.7061743406      1.48E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.06 s  wall 0.06 s
+   11    -536.7061743406      1.81E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 2.01 s  wall 1.91 s
+ SCF   energy in the final basis set = -536.7061743406
+ Total energy in the final basis set = -536.7061743406
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.948  -0.818  -0.322  -0.204  -0.117-101.188  -9.101  -6.858
+ -6.858  -6.858  -0.449  -0.001   0.003   0.004
+ -- Virtual --
+  0.237   0.344   0.712   0.816   1.084   1.085   1.182   1.326
+  1.433   1.572   1.783   1.878   2.264   2.319   3.105   3.112
+  3.294   3.604   3.933   0.839   0.840   0.841   0.911   1.069
+  1.070   1.071   1.073   1.073
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.333820
+      2 H                     0.123908
+      3 H                     0.209912
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.3153      Y       0.3426      Z       0.0000
+       Tot       3.3329
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.8538     XY       3.0983     YY     -20.2069
+        XZ       0.0000     YZ       0.0000     ZZ     -22.3193
+    Octopole Moments (Debye-Ang^2)
+       XXX       1.8852    XXY       3.0443    XYY       7.7956
+       YYY      -4.3138    XXZ       0.0002    XYZ       0.0000
+       YYZ       0.0001    XZZ       3.6713    YZZ      -1.7541
+       ZZZ       0.0003
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -368.0416   XXXY      19.7498   XXYY     -51.0758
+      XYYY       8.6393   YYYY     -25.0795   XXXZ       0.0005
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ       0.0000
+      XXZZ     -58.0201   XYZZ       2.2601   YYZZ      -8.2343
+      XZZZ       0.0002   YZZZ       0.0000   ZZZZ     -22.7814
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1   0.0000022  -0.0000030   0.0000005   0.0000003
+    2  -0.0000369   0.0000132   0.0000053   0.0000183
+    3  -0.0000001   0.0000000   0.0000001  -0.0000000
+ Max gradient component =       3.687E-05
+ RMS gradient           =       1.263E-05
+ Gradient time:  CPU 0.45 s  wall 0.44 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:  11
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0915742182   -0.0596724512   -0.0000093743
+      2  H         1.9107181762    0.8921208890    0.0000002069
+      3  H         1.1697794708   -0.3780370043   -0.0000051847
+      4  Cl       -1.1769667993    0.1200454001   -0.0000023337
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.706174341
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.006011    0.020409    0.165271    0.199999    0.522575    0.535685
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =   0.00000000
+ Step Taken.  Stepsize is  0.000230
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.000022      0.000300     YES
+         Displacement       0.000186      0.001200     YES
+         Energy change     -0.000000      0.000001     YES
+
+
+                       Distance Matrix (Angstroms)
+             O (  1)   H (  2)   H (  3)
+   H (  2)  0.968824
+   H (  3)  0.975224  1.470473
+   Cl(  4)  3.273478  3.182750  2.399021
+
+ Final energy is   -536.70617434061785     
+
+
+ ******************************
+ **  OPTIMIZATION CONVERGED  **
+ ******************************
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0915742182   -0.0596724512   -0.0000093743
+      2  H         1.9107181762    0.8921208890    0.0000002069
+      3  H         1.1697794708   -0.3780370043   -0.0000051847
+      4  Cl       -1.1769667993    0.1200454001   -0.0000023337
+
+Z-matrix Print:
+$molecule
+-1 1
+O 
+H  1 0.968824
+H  1 0.975224 2 98.294759
+Cl 3 2.399021 1 148.963529 2 -0.000885 0
+$end
+
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.948  -0.818  -0.322  -0.204  -0.117-101.188  -9.101  -6.858
+ -6.858  -6.858  -0.449  -0.001   0.003   0.004
+ -- Virtual --
+  0.237   0.344   0.712   0.816   1.084   1.085   1.182   1.326
+  1.433   1.572   1.783   1.878   2.264   2.319   3.105   3.112
+  3.294   3.604   3.933   0.839   0.840   0.841   0.911   1.069
+  1.070   1.071   1.073   1.073
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.333820
+      2 H                     0.123908
+      3 H                     0.209912
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.3153      Y       0.3426      Z       0.0000
+       Tot       3.3329
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.8538     XY       3.0983     YY     -20.2069
+        XZ       0.0000     YZ       0.0000     ZZ     -22.3193
+    Octopole Moments (Debye-Ang^2)
+       XXX       1.8852    XXY       3.0443    XYY       7.7956
+       YYY      -4.3138    XXZ       0.0002    XYZ       0.0000
+       YYZ       0.0001    XZZ       3.6713    YZZ      -1.7541
+       ZZZ       0.0003
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -368.0416   XXXY      19.7498   XXYY     -51.0758
+      XYYY       8.6393   YYYY     -25.0795   XXXZ       0.0005
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ       0.0000
+      XXZZ     -58.0201   XYZZ       2.2601   YYZZ      -8.2343
+      XZZZ       0.0002   YZZZ       0.0000   ZZZZ     -22.7814
+ -----------------------------------------------------------------
+Archival summary:
+1\1\copper\OPT\ProcedureUnspecified\BasisUnspecified\l112(1-,1)\eric\MonJan2520:59:472016MonJan2520:59:472016\0\\#,OPT,ProcedureUnspecified,BasisUnspecified,\\-1,1\O\H,1,0.968824\H,1,0.975224,2,98.2948\Cl,3,2.39902,1,148.964,2,-0.000885496,0\\\@
+
+ Total job time:  32.49s(wall), 25.68s(cpu) 
+ Mon Jan 25 20:59:47 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 

--- a/QChem/QChem4.2/print_frgm_false_sp.out
+++ b/QChem/QChem4.2/print_frgm_false_sp.out
@@ -1,0 +1,288 @@
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe .print_frgm_false_sp.in.19038.qcin.1 /tmp/qchem/qchem19038/
+
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Mon Jan 25 21:04:08 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem19038//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$rem
+ jobtype = sp
+ method = b3lyp
+ basis = cc-pvdz
+ frgm_method = gia
+ frgm_lpcorr = 0
+ scf_print_frgm = false
+$end
+
+$molecule
+-1 1
+--
+0 1
+O      2.0046718567   -0.0940911795   -0.0000456417
+H      2.0989955585    0.8620675220   -0.0000086873
+H      1.0186881803   -0.1989910837   -0.0000610506
+--
+-1 1
+Cl    -1.1264842195    0.0053780533   -0.0000197660
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0045014740    -0.0939781001     0.0000017004
+    2      H       2.0987398960     0.8621890110    -0.0000023237
+    3      H       1.0185271576    -0.1989659440    -0.0000163614
+    4      Cl     -1.1266634615     0.0052118667     0.0000002989
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    38.8683285907 hartrees
+ There are       14 alpha and       14 beta electrons
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+
+ Total QAlloc Memory Limit   2000 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+
+                       Distance Matrix (Angstroms)
+             O (  1)   H (  2)   H (  3)
+   H (  2)  0.960800
+   H (  3)  0.991548  1.514236
+   Cl(  4)  3.132736  3.337310  2.154885
+
+ A cutoff of  1.0D-08 yielded    194 shell pairs
+ There are       874 function pairs (       965 Cartesian)
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is             19390748
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                         20
+ number of basis is                          44
+ number of cartesian basis is                44
+ number of contracted shell pairs           194
+ number of primitive shell pairs           1886
+ maxK2 (contraction) of shell pair           81
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair             18
+ max number of PS2 of shell pair            486
+ mem total for path MDJ                   13530
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 3.06E-02
+
+ Scale SEOQF with 1.000000e-01/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000027 hartrees
+ Guess MOs from converged MOs on fragments
+
+-----------------------------------------------------------------
+ SCF on fragment 1 out of 2
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh  /tmp/qchem/qchem19038/Frg1.input  /dev/null  Frg1
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh /tmp/qchem/qchem19038/Frg1.input /dev/null Frg1
+QCSCRATCH is /tmp/qchem/qchem19038/Frg1
+QCFILEPREF is /tmp/qchem/qchem19038/Frg1/
+-- Serial fragment SCF job
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe /tmp/qchem/qchem19038/Frg1.input /tmp/qchem/qchem19038/Frg1/
+ SCF on fragment 2 out of 2
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh  /tmp/qchem/qchem19038/Frg2.input  /dev/null  Frg2
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh /tmp/qchem/qchem19038/Frg2.input /dev/null Frg2
+QCSCRATCH is /tmp/qchem/qchem19038/Frg2
+QCFILEPREF is /tmp/qchem/qchem19038/Frg2/
+-- Serial fragment SCF job
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe /tmp/qchem/qchem19038/Frg2.input /tmp/qchem/qchem19038/Frg2/
+-----------------------------------------------------------------
+ Done with SCF on isolated fragments
+-----------------------------------------------------------------
+
+ User-specified occupied guess orbitals will be used
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.11 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.6992110205      7.03E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    2    -536.7039377242      2.71E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    3    -536.7042516078      1.12E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7043043344      5.36E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7043182461      2.64E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.06 s  wall 0.07 s
+    6    -536.7043180991      9.89E-06 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.07 s  wall 1.02 s
+ SCF   energy in the final basis set = -536.7043180991
+ Total energy in the final basis set = -536.7043180991
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.937  -0.803  -0.316  -0.187  -0.107-101.191  -9.105  -6.862
+ -6.861  -6.861  -0.453  -0.006   0.000   0.001
+ -- Virtual --
+  0.234   0.385   0.727   0.801   1.083   1.094   1.199   1.367
+  1.428   1.598   1.813   1.860   2.261   2.315   3.098   3.127
+  3.302   3.621   3.925   0.837   0.838   0.840   0.909   1.063
+  1.065   1.065   1.070   1.070
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.350980
+      2 H                     0.102936
+      3 H                     0.248044
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.2305      Y       1.2185      Z      -0.0000
+       Tot       3.4527
+    Quadrupole Moments (Debye-Ang)
+        XX     -33.8072     XY       3.2387     YY     -20.5620
+        XZ      -0.0000     YZ       0.0000     ZZ     -22.3240
+    Octopole Moments (Debye-Ang^2)
+       XXX       5.6342    XXY       7.4508    XYY       6.8662
+       YYY       1.2184    XXZ      -0.0000    XYZ       0.0000
+       YYZ      -0.0000    XZZ       3.3379    YZZ       0.1299
+       ZZZ      -0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -327.8266   XXXY      17.4894   XXYY     -47.6655
+      XYYY       3.0504   YYYY     -23.8480   XXXZ       0.0000
+      XXYZ      -0.0000   XYYZ      -0.0000   YYYZ      -0.0000
+      XXZZ     -54.4137   XYZZ       0.4071   YYZZ      -7.9930
+      XZZZ      -0.0000   YZZZ       0.0000   ZZZZ     -22.7830
+ -----------------------------------------------------------------
+Archival summary:
+1\1\copper\SP\ProcedureUnspecified\BasisUnspecified\l112(1-,1)\eric\MonJan2521:04:102016MonJan2521:04:102016\0\\#,ProcedureUnspecified,BasisUnspecified,\\-1,1\O\H,1,0.9608\H,1,0.991548,2,101.707\Cl,3,2.15489,1,168.485,2,0.00780336,0\\\@
+
+ Total job time:  2.01s(wall), 1.12s(cpu) 
+ Mon Jan 25 21:04:10 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 

--- a/QChem/QChem4.2/print_frgm_true_opt.out
+++ b/QChem/QChem4.2/print_frgm_true_opt.out
@@ -1,0 +1,2791 @@
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe .opt_print_frgm_true.in.12126.qcin.1 /tmp/qchem/qchem12126/
+
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Mon Jan 25 20:59:56 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem12126//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$rem
+ jobtype = opt
+ method = b3lyp
+ basis = cc-pvdz
+ frgm_method = gia
+ frgm_lpcorr = 0
+ scf_print_frgm = true
+$end
+
+$molecule
+-1 1
+--
+0 1
+O      2.0046718567   -0.0940911795   -0.0000456417
+H      2.0989955585    0.8620675220   -0.0000086873
+H      1.0186881803   -0.1989910837   -0.0000610506
+--
+-1 1
+Cl    -1.1264842195    0.0053780533   -0.0000197660
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0045014740    -0.0939781001     0.0000017004
+    2      H       2.0987398960     0.8621890110    -0.0000023237
+    3      H       1.0185271576    -0.1989659440    -0.0000163614
+    4      Cl     -1.1266634615     0.0052118667     0.0000002989
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    38.8683285907 hartrees
+ There are       14 alpha and       14 beta electrons
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+
+ Total QAlloc Memory Limit   2000 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+ A cutoff of  1.0D-11 yielded    200 shell pairs
+ There are       918 function pairs (      1013 Cartesian)
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is             19390748
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                         20
+ number of basis is                          44
+ number of cartesian basis is                44
+ number of contracted shell pairs           200
+ number of primitive shell pairs           1958
+ maxK2 (contraction) of shell pair           81
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair             18
+ max number of PS2 of shell pair            486
+ mem total for path MDJ                   13530
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 3.06E-02
+
+ Scale SEOQF with 1.000000e-01/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000027 hartrees
+ Guess MOs from converged MOs on fragments
+
+QCSCRATCH   is /tmp/qchem
+QCFILEPREF  is /tmp/qchem/qchem12126/
+
+-----------------------------------------------------------------
+ SCF on fragment 1 out of 2
+-----------------------------------------------------------------
+
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh  /tmp/qchem/qchem12126/Frg1.input  stdout  Frg1
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh /tmp/qchem/qchem12126/Frg1.input stdout Frg1
+QCSCRATCH is /tmp/qchem/qchem12126/Frg1
+QCFILEPREF is /tmp/qchem/qchem12126/Frg1/
+-- Serial fragment SCF job
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe /tmp/qchem/qchem12126/Frg1.input /tmp/qchem/qchem12126/Frg1/
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Mon Jan 25 20:59:56 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem12126/Frg1//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$molecule
+0 1
+ 8	2.0045014740	-0.0939781001	0.0000017004
+ 1	2.0987398960	0.8621890110	-0.0000023237
+ 1	1.0185271576	-0.1989659440	-0.0000163614
+$end
+$rem
+METHOD		B3LYP
+BASIS		CC-PVDZ
+SCF_PRINT_FRGM		TRUE
+!required keywords
+JOBTYPE		SP
+SYM_IGNORE		TRUE
+SUBSYSTEM		TRUE
+SAVE_SUBSYSTEM		TRUE
+PURECART		11
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0045014740    -0.0939781001     0.0000017004
+    2      H       2.0987398960     0.8621890110    -0.0000023237
+    3      H       1.0185271576    -0.1989659440    -0.0000163614
+ ----------------------------------------------------------------
+ Nuclear Repulsion Energy =     9.0251097803 hartrees
+ There are        5 alpha and        5 beta electrons
+ Requested basis set is cc-pVDZ
+ There are 12 shells and 24 basis functions
+
+ Total QAlloc Memory Limit   2000 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+
+                       Distance Matrix (Angstroms)
+             O (  1)   H (  2)
+   H (  2)  0.960800
+   H (  3)  0.991548  1.514236
+
+ A cutoff of  1.0D-08 yielded     78 shell pairs
+ There are       322 function pairs (       352 Cartesian)
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is              3179904
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                         12
+ number of basis is                          25
+ number of cartesian basis is                25
+ number of contracted shell pairs            78
+ number of primitive shell pairs            491
+ maxK2 (contraction) of shell pair           49
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair              9
+ max number of PS2 of shell pair            147
+ mem total for path MDJ                    9444
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 3.55E-02
+
+ Scale SEOQF with 1.000000e-01/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000020 hartrees
+ Guess from superposition of atomic densities
+ Warning:  Energy on first SCF cycle will be non-variational
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1     -76.3878598350      1.28E-01
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+    2     -76.3543312512      3.49E-02
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+    3     -76.3195251097      4.38E-02
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+    4     -76.4200545742      9.15E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+    5     -76.4200959677      1.72E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+    6     -76.4200973476      2.26E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+    7     -76.4200973746      8.02E-07 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 0.49 s  wall 0.46 s
+ SCF   energy in the final basis set = -76.4200973746
+ Total energy in the final basis set = -76.4200973746
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-19.126  -0.990  -0.502  -0.369  -0.288
+ -- Virtual --
+  0.047   0.123   0.541   0.611   0.905   0.917   0.997   1.183
+  1.238   1.410   1.590   1.668   2.056   2.135   2.911   2.948
+  3.116   3.433   3.733
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.267718
+      2 H                     0.128465
+      3 H                     0.139253
+  ----------------------------------------
+  Sum of atomic charges =    -0.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -0.0000
+    Dipole Moment (Debye)
+         X      -1.3953      Y       1.3682      Z      -0.0000
+       Tot       1.9542
+    Quadrupole Moments (Debye-Ang)
+        XX     -10.4242     XY       3.3771     YY      -5.1647
+        XZ      -0.0000     YZ       0.0000     ZZ      -7.0156
+    Octopole Moments (Debye-Ang^2)
+       XXX     -46.1160    XXY       7.9189    XYY      -9.8667
+       YYY       1.6754    XXZ      -0.0000    XYZ      -0.0000
+       YYZ      -0.0000    XZZ     -13.5953    YZZ       0.2441
+       ZZZ      -0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -168.7477   XXXY      17.9481   XXYY     -21.0950
+      XYYY       3.1580   YYYY      -5.6247   XXXZ       0.0000
+      XXYZ      -0.0000   XYYZ      -0.0000   YYYZ      -0.0000
+      XXZZ     -28.3651   XYZZ       0.3592   YYZZ      -1.9825
+      XZZZ      -0.0000   YZZZ       0.0000   ZZZZ      -4.8572
+ -----------------------------------------------------------------
+Archival summary:
+1\1\copper\SP\ProcedureUnspecified\BasisUnspecified\12\eric\MonJan2520:59:562016MonJan2520:59:562016\0\\#,ProcedureUnspecified,BasisUnspecified,\\0,1\O\H,1,0.9608\H,1,0.991548,2,101.707\\\@
+
+ Total job time:  0.49s(wall), 0.52s(cpu) 
+ Mon Jan 25 20:59:56 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 
+Copy Fragment Subsystem from /tmp/qchem/qchem12126/Frg1/
+
+-----------------------------------------------------------------
+ SCF on fragment 2 out of 2
+-----------------------------------------------------------------
+
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh  /tmp/qchem/qchem12126/Frg2.input  stdout  Frg2
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh /tmp/qchem/qchem12126/Frg2.input stdout Frg2
+QCSCRATCH is /tmp/qchem/qchem12126/Frg2
+QCFILEPREF is /tmp/qchem/qchem12126/Frg2/
+-- Serial fragment SCF job
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe /tmp/qchem/qchem12126/Frg2.input /tmp/qchem/qchem12126/Frg2/
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Mon Jan 25 20:59:56 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem12126/Frg2//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$molecule
+-1 1
+ 17	-1.1266634615	0.0052118667	0.0000002989
+$end
+$rem
+METHOD		B3LYP
+BASIS		CC-PVDZ
+SCF_PRINT_FRGM		TRUE
+!required keywords
+JOBTYPE		SP
+SYM_IGNORE		TRUE
+SUBSYSTEM		TRUE
+SAVE_SUBSYSTEM		TRUE
+PURECART		11
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      Cl     -1.1266634615     0.0052118667     0.0000002989
+ ----------------------------------------------------------------
+ Nuclear Repulsion Energy =     0.0000000000 hartrees
+ There are        9 alpha and        9 beta electrons
+ Requested basis set is cc-pVDZ
+ There are 8 shells and 18 basis functions
+
+ Total QAlloc Memory Limit   2000 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+ A cutoff of  1.0D-08 yielded     36 shell pairs
+ There are       190 function pairs (       214 Cartesian)
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is             19390748
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                          8
+ number of basis is                          19
+ number of cartesian basis is                19
+ number of contracted shell pairs            36
+ number of primitive shell pairs           1041
+ maxK2 (contraction) of shell pair           81
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair              6
+ max number of PS2 of shell pair            486
+ mem total for path MDJ                   13530
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 1.42E-01
+
+ Scale SEOQF with 1.000000e+00/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000077 hartrees
+ Guess from superposition of atomic densities
+ Warning:  Energy on first SCF cycle will be non-variational
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-05
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    18
+   Numerical integral  =    16.999999837106
+   Relative error      =    -5.5555564605 %
+ CPU 0.01 s  wall 0.01 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -460.1092841212      1.43E-02
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.01 s  wall 0.01 s
+    2    -460.2193895888      3.09E-02
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.01 s  wall 0.01 s
+    3    -460.2451458243      2.08E-02
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.02 s  wall 0.01 s
+    4    -460.2655097812      4.70E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.01 s  wall 0.01 s
+    5    -460.2665676058      1.42E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.01 s  wall 0.01 s
+    6    -460.2665685942      6.65E-06 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 0.20 s  wall 0.20 s
+ SCF   energy in the final basis set = -460.2665685942
+ Total energy in the final basis set = -460.2665685942
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+*******  -9.076  -6.833  -6.833  -6.833  -0.422   0.028   0.028
+  0.028
+ -- Virtual --
+  0.863   0.863   0.863   0.935   1.098   1.098   1.098   1.098
+  1.098
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       5.4116      Y      -0.0250      Z       0.0000
+       Tot       5.4116
+    Quadrupole Moments (Debye-Ang)
+        XX     -21.4107     XY       0.0282     YY     -15.3138
+        XZ      -0.0000     YZ       0.0000     ZZ     -15.3137
+    Octopole Moments (Debye-Ang^2)
+       XXX      58.6293    XXY      -0.1116    XYY      17.2535
+       YYY      -0.2394    XXZ      -0.0000    XYZ      -0.0000
+       YYZ      -0.0000    XZZ      17.2533    YZZ      -0.0798
+       ZZZ      -0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -142.3451   XXXY       0.3056   XXYY     -25.4304
+      XYYY       0.2698   YYYY     -17.9760   XXXZ       0.0000
+      XXYZ       0.0000   XYYZ       0.0000   YYYZ       0.0000
+      XXZZ     -25.4299   XYZZ       0.0899   YYZZ      -5.9916
+      XZZZ       0.0000   YZZZ       0.0000   ZZZZ     -17.9735
+ -----------------------------------------------------------------
+
+ STANDARD THERMODYNAMIC QUANTITIES AT   298.15 K  AND     1.00 ATM
+
+   Translational Enthalpy:        0.889 kcal/mol
+   Rotational Enthalpy:           0.000 kcal/mol
+   Vibrational Enthalpy:          0.000 kcal/mol
+   gas constant (RT):             0.592 kcal/mol
+   Translational Entropy:        36.586  cal/mol.K
+   Rotational Entropy:            0.000  cal/mol.K
+   Vibrational Entropy:           0.000  cal/mol.K
+
+   Total Enthalpy:                1.481 kcal/mol
+   Total Entropy:                36.586  cal/mol.K
+
+ -----------------------------------------------------------------
+
+Archival summary:
+1\1\copper\SP\ProcedureUnspecified\BasisUnspecified\l1(1-,1)\eric\MonJan2520:59:572016MonJan2520:59:572016\0\\#,ProcedureUnspecified,BasisUnspecified,\\-1,1\Cl\\\@
+
+ Total job time:  0.23s(wall), 0.23s(cpu) 
+ Mon Jan 25 20:59:57 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 
+Copy Fragment Subsystem from /tmp/qchem/qchem12126/Frg2/
+
+-----------------------------------------------------------------
+ Done with SCF on isolated fragments
+-----------------------------------------------------------------
+
+ User-specified occupied guess orbitals will be used
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.6992110706      7.03E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    2    -536.7039377532      2.71E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    3    -536.7042517876      1.12E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7043044908      5.36E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.11 s
+    5    -536.7043182580      2.64E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7043183201      9.70E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7043183390      2.25E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7043183407      3.09E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    9    -536.7043183405      4.89E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+   10    -536.7043183405      8.79E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.95 s  wall 1.85 s
+ SCF   energy in the final basis set = -536.7043183405
+ Total energy in the final basis set = -536.7043183405
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.937  -0.803  -0.316  -0.187  -0.107-101.191  -9.104  -6.861
+ -6.861  -6.861  -0.453  -0.006   0.000   0.001
+ -- Virtual --
+  0.234   0.385   0.727   0.801   1.083   1.094   1.199   1.367
+  1.428   1.598   1.813   1.860   2.261   2.315   3.098   3.127
+  3.302   3.621   3.925   0.837   0.838   0.840   0.909   1.063
+  1.065   1.065   1.070   1.070
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.350975
+      2 H                     0.102935
+      3 H                     0.248040
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.2305      Y       1.2185      Z      -0.0000
+       Tot       3.4527
+    Quadrupole Moments (Debye-Ang)
+        XX     -33.8070     XY       3.2387     YY     -20.5618
+        XZ      -0.0000     YZ       0.0000     ZZ     -22.3238
+    Octopole Moments (Debye-Ang^2)
+       XXX       5.6332    XXY       7.4508    XYY       6.8658
+       YYY       1.2184    XXZ      -0.0000    XYZ      -0.0000
+       YYZ      -0.0000    XZZ       3.3376    YZZ       0.1299
+       ZZZ      -0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -327.8247   XXXY      17.4892   XXYY     -47.6651
+      XYYY       3.0504   YYYY     -23.8475   XXXZ       0.0000
+      XXYZ      -0.0000   XYYZ      -0.0000   YYYZ      -0.0000
+      XXZZ     -54.4133   XYZZ       0.4071   YYZZ      -7.9929
+      XZZZ      -0.0000   YZZZ       0.0000   ZZZZ     -22.7825
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1   0.0082092   0.0025052  -0.0169743   0.0062600
+    2   0.0098472  -0.0066251  -0.0021109  -0.0011112
+    3   0.0000006  -0.0000000  -0.0000008   0.0000001
+ Max gradient component =       1.697E-02
+ RMS gradient           =       6.755E-03
+ Gradient time:  CPU 0.47 s  wall 0.46 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   1
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0045014740   -0.0939781001    0.0000017004
+      2  H         2.0987398960    0.8621890110   -0.0000023237
+      3  H         1.0185271576   -0.1989659440   -0.0000163614
+      4  Cl       -1.1266634615    0.0052118667    0.0000002989
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.704318340
+
+
+ Attempting to Generate Delocalized Internal Coordinates
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.043648    0.160000    0.200000    0.200000    0.492057    0.553017
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00142891
+ Step Taken.  Stepsize is  0.147333
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.010087      0.000300      NO
+         Displacement       0.092561      0.001200      NO
+         Energy change     *********      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.113633
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0260905938    -0.0993578939     0.0000000211
+    2      H       2.0824429475     0.8658746290    -0.0000019715
+    3      H       1.0523119123    -0.2073867542    -0.0000146682
+    4      Cl     -1.1657403876     0.0153268527    -0.0000000671
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    38.3028669020 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000028 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    200 shell pairs
+ There are       918 function pairs (      1013 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.06E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7230214456      4.02E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7050343783      2.27E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    3    -536.7051813539      1.49E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7052895669      2.01E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7052918567      1.84E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    6    -536.7052919090      5.93E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.08 s
+    7    -536.7052919175      7.96E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    8    -536.7052919176      2.24E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7052919177      1.14E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+   10    -536.7052919176      2.34E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.89 s  wall 1.78 s
+ SCF   energy in the final basis set = -536.7052919176
+ Total energy in the final basis set = -536.7052919176
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.943  -0.811  -0.318  -0.196  -0.112-101.190  -9.103  -6.860
+ -6.860  -6.860  -0.451  -0.004   0.002   0.002
+ -- Virtual --
+  0.231   0.377   0.719   0.810   1.082   1.090   1.196   1.344
+  1.431   1.584   1.800   1.871   2.265   2.316   3.109   3.115
+  3.300   3.612   3.933   0.838   0.839   0.840   0.910   1.065
+  1.067   1.068   1.072   1.072
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.339207
+      2 H                     0.106150
+      3 H                     0.233057
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.4317      Y       1.1720      Z      -0.0000
+       Tot       3.6263
+    Quadrupole Moments (Debye-Ang)
+        XX     -34.3819     XY       3.2650     YY     -20.5365
+        XZ      -0.0000     YZ       0.0000     ZZ     -22.3196
+    Octopole Moments (Debye-Ang^2)
+       XXX       7.0706    XXY       7.1448    XYY       7.3839
+       YYY       0.8471    XXZ       0.0000    XYZ       0.0000
+       YYZ       0.0000    XZZ       3.8202    YZZ       0.0042
+       ZZZ       0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -342.3719   XXXY      18.0182   XXYY     -49.5020
+      XYYY       3.8023   YYYY     -23.9047   XXXZ       0.0001
+      XXYZ      -0.0000   XYYZ       0.0000   YYYZ      -0.0000
+      XXZZ     -56.2721   XYZZ       0.6650   YYZZ      -8.0080
+      XZZZ       0.0000   YZZZ      -0.0000   ZZZZ     -22.7797
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1   0.0012969  -0.0000569  -0.0045117   0.0032717
+    2   0.0001562  -0.0014427   0.0023426  -0.0010561
+    3   0.0000004  -0.0000001  -0.0000005   0.0000001
+ Max gradient component =       4.512E-03
+ RMS gradient           =       1.859E-03
+ Gradient time:  CPU 0.46 s  wall 0.46 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   2
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0260905938   -0.0993578939    0.0000000211
+      2  H         2.0824429475    0.8658746290   -0.0000019715
+      3  H         1.0523119123   -0.2073867542   -0.0000146682
+      4  Cl       -1.1657403876    0.0153268527   -0.0000000671
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.705291918
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.024935    0.167539    0.200000    0.201169    0.518711    0.553245
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00055402
+ Step Taken.  Stepsize is  0.142680
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.003117      0.000300      NO
+         Displacement       0.094385      0.001200      NO
+         Energy change     -0.000974      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.112551
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0469566552    -0.0978978838    -0.0000022201
+    2      H       2.0807250632     0.8715802633    -0.0000014371
+    3      H       1.0788689153    -0.2222475959    -0.0000123983
+    4      Cl     -1.2114455677     0.0230220500    -0.0000006303
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.6814631097 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000029 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    199 shell pairs
+ There are       903 function pairs (       995 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.10E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7143613349      2.09E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7053428174      2.52E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    3    -536.7056675240      2.31E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    4    -536.7056698580      1.09E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7056711372      2.15E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7056712706      4.97E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7056712765      4.86E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7056712765      1.34E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    9    -536.7056712764      1.12E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+   10    -536.7056712764      3.02E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.80 s  wall 1.69 s
+ SCF   energy in the final basis set = -536.7056712764
+ Total energy in the final basis set = -536.7056712764
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.947  -0.816  -0.322  -0.202  -0.116-101.189  -9.102  -6.859
+ -6.859  -6.859  -0.450  -0.003   0.003   0.003
+ -- Virtual --
+  0.227   0.367   0.714   0.809   1.079   1.086   1.191   1.337
+  1.429   1.579   1.792   1.870   2.260   2.316   3.106   3.110
+  3.295   3.607   3.931   0.839   0.840   0.840   0.911   1.067
+  1.069   1.069   1.073   1.073
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.334223
+      2 H                     0.109544
+      3 H                     0.224679
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.6657      Y       1.1172      Z      -0.0000
+       Tot       3.8322
+    Quadrupole Moments (Debye-Ang)
+        XX     -34.9968     XY       3.2865     YY     -20.4965
+        XZ      -0.0000     YZ       0.0000     ZZ     -22.3201
+    Octopole Moments (Debye-Ang^2)
+       XXX       9.2104    XXY       6.9456    XYY       8.0497
+       YYY       0.5039    XXZ       0.0001    XYZ       0.0000
+       YYZ       0.0000    XZZ       4.3969    YZZ      -0.1193
+       ZZZ       0.0001
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -358.4146   XXXY      18.5834   XXYY     -51.4972
+      XYYY       4.2945   YYYY     -23.9225   XXXZ       0.0002
+      XXYZ      -0.0000   XYYZ       0.0000   YYYZ      -0.0000
+      XXZZ     -58.4430   XYZZ       0.8137   YYZZ      -8.0178
+      XZZZ       0.0001   YZZZ      -0.0000   ZZZZ     -22.7816
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1  -0.0007308  -0.0003865   0.0000009   0.0011164
+    2  -0.0035506   0.0014447   0.0029715  -0.0008656
+    3   0.0000003  -0.0000001  -0.0000003   0.0000001
+ Max gradient component =       3.551E-03
+ RMS gradient           =       1.478E-03
+ Gradient time:  CPU 0.45 s  wall 0.44 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   3
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0469566552   -0.0978978838   -0.0000022201
+      2  H         2.0807250632    0.8715802633   -0.0000014371
+      3  H         1.0788689153   -0.2222475959   -0.0000123983
+      4  Cl       -1.2114455677    0.0230220500   -0.0000006303
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.705671276
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.015396    0.166436    0.191742    0.200000    0.523749    0.586021
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00021569
+ Step Taken.  Stepsize is  0.105885
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.002654      0.000300      NO
+         Displacement       0.069475      0.001200      NO
+         Energy change     -0.000379      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.086126
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0632802685    -0.0934036310    -0.0000043740
+    2      H       2.0758151865     0.8761323272    -0.0000008862
+    3      H       1.0985675195    -0.2399757888    -0.0000102365
+    4      Cl     -1.2425579085     0.0317039261    -0.0000011890
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.2599205418 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000030 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    197 shell pairs
+ There are       891 function pairs (       983 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.14E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.969514918421
+   Relative error      =    -0.1088752914 %
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7097264298      1.71E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7054110903      2.74E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    3    -536.7057991255      4.76E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.09 s
+    4    -536.7058128336      1.54E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7058145651      2.63E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    6    -536.7058147273      6.30E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    7    -536.7058147369      7.64E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7058147370      1.67E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    9    -536.7058147369      1.06E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.08 s
+   10    -536.7058147369      1.25E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.76 s  wall 1.68 s
+ SCF   energy in the final basis set = -536.7058147369
+ Total energy in the final basis set = -536.7058147369
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.950  -0.819  -0.326  -0.204  -0.119-101.188  -9.101  -6.858
+ -6.858  -6.858  -0.449  -0.001   0.004   0.004
+ -- Virtual --
+  0.226   0.359   0.712   0.808   1.077   1.083   1.187   1.335
+  1.426   1.576   1.786   1.867   2.259   2.314   3.104   3.107
+  3.293   3.605   3.928   0.840   0.840   0.841   0.911   1.069
+  1.070   1.071   1.074   1.074
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.331862
+      2 H                     0.111622
+      3 H                     0.220240
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.8146      Y       1.0462      Z       0.0000
+       Tot       3.9555
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.4778     XY       3.2955     YY     -20.4529
+        XZ       0.0000     YZ       0.0000     ZZ     -22.3197
+    Octopole Moments (Debye-Ang^2)
+       XXX      10.5053    XXY       6.6698    XYY       8.5216
+       YYY       0.0761    XXZ       0.0001    XYZ       0.0000
+       YYZ       0.0000    XZZ       4.7802    YZZ      -0.2705
+       ZZZ       0.0002
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -370.4401   XXXY      19.0543   XXYY     -52.8949
+      XYYY       4.7639   YYYY     -23.9308   XXXZ       0.0002
+      XXYZ       0.0000   XYYZ       0.0000   YYYZ      -0.0000
+      XXZZ     -60.0003   XYZZ       0.9559   YYZZ      -8.0240
+      XZZZ       0.0001   YZZZ      -0.0000   ZZZZ     -22.7817
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1  -0.0003468  -0.0002157   0.0007826  -0.0002201
+    2  -0.0027901   0.0010337   0.0024102  -0.0006538
+    3   0.0000001  -0.0000000  -0.0000001   0.0000000
+ Max gradient component =       2.790E-03
+ RMS gradient           =       1.152E-03
+ Gradient time:  CPU 0.43 s  wall 0.42 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   4
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0632802685   -0.0934036310   -0.0000043740
+      2  H         2.0758151865    0.8761323272   -0.0000008862
+      3  H         1.0985675195   -0.2399757888   -0.0000102365
+      4  Cl       -1.2425579085    0.0317039261   -0.0000011890
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.705814737
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.012508    0.156929    0.172473    0.200000    0.521407    0.569542
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00008871
+ Step Taken.  Stepsize is  0.059266
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.002269      0.000300      NO
+         Displacement       0.037890      0.001200      NO
+         Energy change     -0.000143      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.058162
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0725209304    -0.0888765849    -0.0000060390
+    2      H       2.0635582984     0.8797913151    -0.0000004288
+    3      H       1.1113476164    -0.2579540940    -0.0000085971
+    4      Cl     -1.2523217792     0.0414961974    -0.0000016207
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.0996358015 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000030 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    197 shell pairs
+ There are       891 function pairs (       983 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.15E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.963644302385
+   Relative error      =    -0.1298417772 %
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7074104525      1.80E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.10 s
+    2    -536.7054227268      2.90E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    3    -536.7058638322      5.21E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7058808794      1.88E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    5    -536.7058830845      2.82E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    6    -536.7058832579      6.96E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7058832700      1.04E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.08 s
+    8    -536.7058832702      1.93E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7058832701      1.42E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.06 s  wall 0.06 s
+   10    -536.7058832701      1.55E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.83 s  wall 1.72 s
+ SCF   energy in the final basis set = -536.7058832701
+ Total energy in the final basis set = -536.7058832701
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.951  -0.820  -0.327  -0.205  -0.120-101.188  -9.101  -6.858
+ -6.858  -6.857  -0.449  -0.001   0.004   0.005
+ -- Virtual --
+  0.226   0.355   0.712   0.807   1.076   1.082   1.185   1.334
+  1.425   1.576   1.784   1.866   2.259   2.313   3.104   3.106
+  3.293   3.604   3.927   0.840   0.840   0.841   0.912   1.069
+  1.071   1.071   1.074   1.074
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.331067
+      2 H                     0.113057
+      3 H                     0.218010
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.8476      Y       0.9668      Z       0.0000
+       Tot       3.9672
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.7256     XY       3.2934     YY     -20.4129
+        XZ       0.0000     YZ       0.0000     ZZ     -22.3191
+    Octopole Moments (Debye-Ang^2)
+       XXX      10.5120    XXY       6.3123    XYY       8.6919
+       YYY      -0.4079    XXZ       0.0002    XYZ       0.0000
+       YYZ       0.0001    XZZ       4.8813    YZZ      -0.4383
+       ZZZ       0.0002
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -375.8214   XXXY      19.3844   XXYY     -53.3888
+      XYYY       5.2602   YYYY     -23.9686   XXXZ       0.0003
+      XXYZ       0.0000   XYYZ       0.0000   YYYZ      -0.0000
+      XXZZ     -60.5776   XYZZ       1.1133   YYZZ      -8.0339
+      XZZZ       0.0002   YZZZ      -0.0000   ZZZZ     -22.7811
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1  -0.0000420   0.0000370   0.0007688  -0.0007639
+    2  -0.0014853   0.0002206   0.0017562  -0.0004914
+    3   0.0000001  -0.0000000  -0.0000001   0.0000000
+ Max gradient component =       1.756E-03
+ RMS gradient           =       7.505E-04
+ Gradient time:  CPU 0.45 s  wall 0.44 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   5
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0725209304   -0.0888765849   -0.0000060390
+      2  H         2.0635582984    0.8797913151   -0.0000004288
+      3  H         1.1113476164   -0.2579540940   -0.0000085971
+      4  Cl       -1.2523217792    0.0414961974   -0.0000016207
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.705883270
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.010331    0.081520    0.175766    0.200000    0.521344    0.578057
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00013767
+ Step Taken.  Stepsize is  0.084519
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.001813      0.000300      NO
+         Displacement       0.056174      0.001200      NO
+         Energy change     -0.000069      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.114017
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0841099719    -0.0802508343    -0.0000087510
+    2      H       2.0288117203     0.8857693438     0.0000003492
+    3      H       1.1317747302    -0.2940412721    -0.0000059728
+    4      Cl     -1.2495913565     0.0629795961    -0.0000023112
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.0351119800 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000031 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    197 shell pairs
+ There are       891 function pairs (       983 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.17E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.960690695026
+   Relative error      =    -0.1403903749 %
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7056468774      2.86E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    2    -536.7054893641      3.02E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    3    -536.7059744070      5.19E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7059857358      1.83E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7059888860      3.66E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7059891658      8.41E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    7    -536.7059891835      1.08E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7059891837      2.37E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7059891835      1.98E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.06 s  wall 0.06 s
+   10    -536.7059891837      4.83E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.70 s  wall 1.61 s
+ SCF   energy in the final basis set = -536.7059891837
+ Total energy in the final basis set = -536.7059891837
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.952  -0.821  -0.328  -0.206  -0.120-101.188  -9.101  -6.858
+ -6.857  -6.857  -0.448  -0.000   0.004   0.005
+ -- Virtual --
+  0.228   0.349   0.712   0.808   1.076   1.082   1.182   1.333
+  1.425   1.575   1.782   1.867   2.261   2.313   3.104   3.106
+  3.293   3.604   3.927   0.840   0.841   0.841   0.912   1.070
+  1.071   1.071   1.074   1.074
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.330766
+      2 H                     0.115804
+      3 H                     0.214961
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.7934      Y       0.7951      Z       0.0000
+       Tot       3.8759
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.9777     XY       3.2701     YY     -20.3397
+        XZ       0.0000     YZ       0.0000     ZZ     -22.3183
+    Octopole Moments (Debye-Ang^2)
+       XXX       9.1247    XXY       5.4676    XYY       8.7131
+       YYY      -1.4670    XXZ       0.0002    XYZ       0.0000
+       YYZ       0.0001    XZZ       4.7856    YZZ      -0.8005
+       ZZZ       0.0003
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -379.6072   XXXY      19.8392   XXYY     -53.4564
+      XYYY       6.3080   YYYY     -24.1378   XXXZ       0.0004
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ      -0.0000
+      XXZZ     -60.7016   XYZZ       1.4567   YYZZ      -8.0684
+      XZZZ       0.0002   YZZZ      -0.0000   ZZZZ     -22.7802
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1   0.0001356   0.0004157   0.0005826  -0.0011339
+    2   0.0002556  -0.0007985   0.0007808  -0.0002379
+    3  -0.0000001   0.0000000   0.0000001  -0.0000000
+ Max gradient component =       1.134E-03
+ RMS gradient           =       5.152E-04
+ Gradient time:  CPU 0.44 s  wall 0.43 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   6
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0841099719   -0.0802508343   -0.0000087510
+      2  H         2.0288117203    0.8857693438    0.0000003492
+      3  H         1.1317747302   -0.2940412721   -0.0000059728
+      4  Cl       -1.2495913565    0.0629795961   -0.0000023112
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.705989184
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.008002    0.044357    0.179560    0.200000    0.521969    0.602144
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00018086
+ Step Taken.  Stepsize is  0.116165
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.002012      0.000300      NO
+         Displacement       0.077093      0.001200      NO
+         Energy change     -0.000106      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.199499
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0945028418    -0.0662784233    -0.0000121033
+    2      H       1.9605453424     0.8915082124     0.0000013178
+    3      H       1.1608258363    -0.3501552242    -0.0000027607
+    4      Cl     -1.2207689545     0.0993822687    -0.0000031395
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.2105029290 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000031 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    197 shell pairs
+ There are       891 function pairs (       983 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.19E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.956006357213
+   Relative error      =    -0.1571201528 %
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7034698730      4.37E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7055125709      3.37E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    3    -536.7060228215      1.38E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7061119175      2.48E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    5    -536.7061165794      4.48E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7061169897      1.08E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    7    -536.7061170191      1.18E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.08 s
+    8    -536.7061170193      3.15E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7061170192      3.66E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.10 s
+   10    -536.7061170193      5.80E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.80 s  wall 1.71 s
+ SCF   energy in the final basis set = -536.7061170193
+ Total energy in the final basis set = -536.7061170193
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.951  -0.820  -0.326  -0.206  -0.119-101.188  -9.101  -6.858
+ -6.857  -6.857  -0.449  -0.000   0.004   0.005
+ -- Virtual --
+  0.233   0.344   0.712   0.812   1.079   1.083   1.180   1.330
+  1.428   1.573   1.781   1.872   2.263   2.316   3.105   3.108
+  3.294   3.604   3.929   0.840   0.841   0.841   0.912   1.070
+  1.071   1.071   1.074   1.074
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.331541
+      2 H                     0.120658
+      3 H                     0.210883
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.5806      Y       0.5048      Z       0.0001
+       Tot       3.6160
+    Quadrupole Moments (Debye-Ang)
+        XX     -36.0949     XY       3.1862     YY     -20.2409
+        XZ       0.0001     YZ       0.0000     ZZ     -22.3180
+    Octopole Moments (Debye-Ang^2)
+       XXX       5.4808    XXY       3.9452    XYY       8.3924
+       YYY      -3.2816    XXZ       0.0003    XYZ       0.0000
+       YYZ       0.0001    XZZ       4.3086    YZZ      -1.4121
+       ZZZ       0.0004
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -377.7185   XXXY      20.1025   XXYY     -52.6116
+      XYYY       7.9219   YYYY     -24.6504   XXXZ       0.0006
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ       0.0000
+      XXZZ     -59.7671   XYZZ       2.0024   YYZZ      -8.1609
+      XZZZ       0.0003   YZZZ      -0.0000   ZZZZ     -22.7798
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1   0.0001054   0.0006712   0.0002077  -0.0009843
+    2   0.0015481  -0.0013455  -0.0002264   0.0000238
+    3  -0.0000003   0.0000001   0.0000003  -0.0000001
+ Max gradient component =       1.548E-03
+ RMS gradient           =       6.912E-04
+ Gradient time:  CPU 0.51 s  wall 0.51 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   7
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0945028418   -0.0662784233   -0.0000121033
+      2  H         1.9605453424    0.8915082124    0.0000013178
+      3  H         1.1608258363   -0.3501552242   -0.0000027607
+      4  Cl       -1.2207689545    0.0993822687   -0.0000031395
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.706117019
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.007330    0.029406    0.178107    0.200000    0.522040    0.600608
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00008644
+ Step Taken.  Stepsize is  0.076222
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.001528      0.000300      NO
+         Displacement       0.059472      0.001200      NO
+         Energy change     -0.000128      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.151089
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0960393831    -0.0568410760    -0.0000130852
+    2      H       1.9069132304     0.8924658113     0.0000015422
+    3      H       1.1777989342    -0.3857502108    -0.0000017968
+    4      Cl     -1.1856464817     0.1245823092    -0.0000033459
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.5140049766 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000032 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    199 shell pairs
+ There are       897 function pairs (       989 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.19E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.956707878319
+   Relative error      =    -0.1546147203 %
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7051406902      3.19E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7056067622      3.18E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    3    -536.7061434475      6.65E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7061619349      2.08E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7061658978      3.97E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7061662247      9.03E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7061662449      1.17E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7061662453      2.67E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7061662451      2.69E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+   10    -536.7061662450      5.28E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.71 s  wall 1.60 s
+ SCF   energy in the final basis set = -536.7061662450
+ Total energy in the final basis set = -536.7061662450
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.949  -0.818  -0.323  -0.205  -0.118-101.188  -9.101  -6.858
+ -6.858  -6.858  -0.449  -0.001   0.004   0.004
+ -- Virtual --
+  0.237   0.341   0.712   0.815   1.083   1.084   1.180   1.327
+  1.432   1.572   1.781   1.877   2.264   2.318   3.105   3.111
+  3.294   3.604   3.932   0.839   0.841   0.841   0.911   1.069
+  1.071   1.071   1.074   1.074
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.333002
+      2 H                     0.124553
+      3 H                     0.208450
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.3576      Y       0.3041      Z       0.0001
+       Tot       3.3714
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.9890     XY       3.0932     YY     -20.1918
+        XZ       0.0001     YZ       0.0000     ZZ     -22.3186
+    Octopole Moments (Debye-Ang^2)
+       XXX       2.2085    XXY       2.8525    XYY       7.9420
+       YYY      -4.5547    XXZ       0.0003    XYZ       0.0000
+       YYZ       0.0001    XZZ       3.7803    YZZ      -1.8352
+       ZZZ       0.0004
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -371.3965   XXXY      19.8947   XXYY     -51.4666
+      XYYY       8.8688   YYYY     -25.1685   XXXZ       0.0006
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ       0.0000
+      XXZZ     -58.4387   XYZZ       2.3343   YYZZ      -8.2498
+      XZZZ       0.0003   YZZZ       0.0000   ZZZZ     -22.7807
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1  -0.0000283   0.0003928   0.0000196  -0.0003841
+    2   0.0010684  -0.0007116  -0.0004454   0.0000886
+    3  -0.0000003   0.0000001   0.0000003  -0.0000001
+ Max gradient component =       1.068E-03
+ RMS gradient           =       4.240E-04
+ Gradient time:  CPU 0.46 s  wall 0.45 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   8
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0960393831   -0.0568410760   -0.0000130852
+      2  H         1.9069132304    0.8924658113    0.0000015422
+      3  H         1.1777989342   -0.3857502108   -0.0000017968
+      4  Cl       -1.1856464817    0.1245823092   -0.0000033459
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.706166245
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.009032    0.022058    0.173885    0.200000    0.521629    0.575278
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00000963
+ Step Taken.  Stepsize is  0.019370
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.000776      0.000300      NO
+         Displacement       0.012862      0.001200      NO
+         Energy change     -0.000049      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.017065
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0938617037    -0.0574772485    -0.0000117495
+    2      H       1.9038057893     0.8923048560     0.0000010566
+    3      H       1.1753358522    -0.3849668598    -0.0000030152
+    4      Cl     -1.1778982792     0.1245960859    -0.0000029777
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.6033490688 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000032 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    200 shell pairs
+ There are       906 function pairs (       998 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.19E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.959229693740
+   Relative error      =    -0.1456082366 %
+ CPU 0.10 s  wall 0.10 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7070886552      1.38E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7056711911      2.99E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    3    -536.7061237969      8.69E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    4    -536.7061526762      5.90E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7061712580      1.38E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7061727102      1.31E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7061727190      1.09E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7061727192      4.08E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7061727192      5.28E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.06 s  wall 0.07 s
+   10    -536.7061727191      2.87E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.72 s  wall 1.60 s
+ SCF   energy in the final basis set = -536.7061727191
+ Total energy in the final basis set = -536.7061727191
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.949  -0.818  -0.322  -0.204  -0.117-101.188  -9.101  -6.858
+ -6.858  -6.858  -0.449  -0.001   0.004   0.004
+ -- Virtual --
+  0.238   0.342   0.712   0.816   1.084   1.085   1.181   1.326
+  1.433   1.572   1.782   1.878   2.264   2.319   3.105   3.112
+  3.294   3.604   3.933   0.839   0.840   0.841   0.911   1.069
+  1.070   1.071   1.073   1.074
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.333556
+      2 H                     0.124647
+      3 H                     0.208909
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.3152      Y       0.3054      Z       0.0000
+       Tot       3.3293
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.9091     XY       3.0866     YY     -20.1957
+        XZ       0.0001     YZ       0.0000     ZZ     -22.3191
+    Octopole Moments (Debye-Ang^2)
+       XXX       1.7435    XXY       2.8501    XYY       7.8238
+       YYY      -4.5492    XXZ       0.0003    XYZ       0.0000
+       YYZ       0.0001    XZZ       3.6749    YZZ      -1.8327
+       ZZZ       0.0004
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -369.0794   XXXY      19.7952   XXYY     -51.1630
+      XYYY       8.8352   YYYY     -25.1763   XXXZ       0.0006
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ       0.0000
+      XXZZ     -58.1010   XYZZ       2.3261   YYZZ      -8.2510
+      XZZZ       0.0003   YZZZ       0.0000   ZZZZ     -22.7812
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.15 s  wall 0.16 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1  -0.0000564   0.0001200   0.0000672  -0.0001309
+    2   0.0002991  -0.0001711  -0.0001844   0.0000564
+    3  -0.0000003   0.0000001   0.0000003  -0.0000001
+ Max gradient component =       2.991E-04
+ RMS gradient           =       1.275E-04
+ Gradient time:  CPU 0.49 s  wall 0.49 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:   9
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0938617037   -0.0574772485   -0.0000117495
+      2  H         1.9038057893    0.8923048560    0.0000010566
+      3  H         1.1753358522   -0.3849668598   -0.0000030152
+      4  Cl       -1.1778982792    0.1245960859   -0.0000029777
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.706172719
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.006937    0.019973    0.167990    0.200000    0.521411    0.564937
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =  -0.00000298
+ Step Taken.  Stepsize is  0.019359
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.000221      0.000300     YES
+         Displacement       0.012527      0.001200      NO
+         Energy change     -0.000006      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.019813
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0918023118    -0.0593766186    -0.0000099973
+    2      H       1.9091887432     0.8921339378     0.0000004309
+    3      H       1.1705403767    -0.3791483550    -0.0000046149
+    4      Cl     -1.1764263657     0.1208478693    -0.0000025044
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.6349577740 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000031 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    200 shell pairs
+ There are       906 function pairs (       998 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.18E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.960097904038
+   Relative error      =    -0.1425074856 %
+ CPU 0.11 s  wall 0.11 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7076166388      1.41E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    2    -536.7056759290      3.00E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    3    -536.7061264705      8.71E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    4    -536.7061601971      5.11E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7061741201      2.74E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    6    -536.7061742937      9.95E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    7    -536.7061743069      1.89E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    8    -536.7061743072      3.32E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    9    -536.7061743072      2.58E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+   10    -536.7061743073      2.77E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.90 s  wall 1.80 s
+ SCF   energy in the final basis set = -536.7061743073
+ Total energy in the final basis set = -536.7061743073
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.948  -0.818  -0.322  -0.204  -0.117-101.188  -9.101  -6.858
+ -6.858  -6.858  -0.449  -0.001   0.003   0.004
+ -- Virtual --
+  0.238   0.343   0.712   0.816   1.084   1.085   1.182   1.326
+  1.434   1.572   1.783   1.878   2.264   2.319   3.105   3.112
+  3.294   3.604   3.933   0.839   0.840   0.841   0.911   1.069
+  1.070   1.071   1.073   1.073
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.333823
+      2 H                     0.124053
+      3 H                     0.209770
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.3113      Y       0.3362      Z       0.0000
+       Tot       3.3283
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.8567     XY       3.0958     YY     -20.2054
+        XZ       0.0000     YZ       0.0000     ZZ     -22.3193
+    Octopole Moments (Debye-Ang^2)
+       XXX       1.8166    XXY       3.0099    XYY       7.7893
+       YYY      -4.3544    XXZ       0.0002    XYZ       0.0000
+       YYZ       0.0001    XZZ       3.6622    YZZ      -1.7675
+       ZZZ       0.0003
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -368.0206   XXXY      19.7493   XXYY     -51.0648
+      XYYY       8.6716   YYYY     -25.0973   XXXZ       0.0005
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ       0.0000
+      XXZZ     -58.0044   XYZZ       2.2714   YYZZ      -8.2373
+      XZZZ       0.0003   YZZZ       0.0000   ZZZZ     -22.7814
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.15 s  wall 0.15 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1  -0.0000069  -0.0000215   0.0000284   0.0000001
+    2  -0.0000868   0.0000524   0.0000127   0.0000217
+    3  -0.0000002   0.0000001   0.0000002  -0.0000001
+ Max gradient component =       8.680E-05
+ RMS gradient           =       3.192E-05
+ Gradient time:  CPU 0.49 s  wall 0.48 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:  10
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0918023118   -0.0593766186   -0.0000099973
+      2  H         1.9091887432    0.8921339378    0.0000004309
+      3  H         1.1705403767   -0.3791483550   -0.0000046149
+      4  Cl       -1.1764263657    0.1208478693   -0.0000025044
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.706174307
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.005997    0.020874    0.170988    0.200000    0.521760    0.579151
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =   0.00000000
+ Step Taken.  Stepsize is  0.002599
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.000061      0.000300     YES
+         Displacement       0.001662      0.001200      NO
+         Energy change     -0.000002      0.000001      NO
+
+
+ New Cartesian Coordinates Obtained by Inverse Iteration
+
+ Displacement from previous Coordinates is:  0.004321
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0915742182    -0.0596724512    -0.0000093743
+    2      H       1.9107181762     0.8921208890     0.0000002069
+    3      H       1.1697794708    -0.3780370043    -0.0000051847
+    4      Cl     -1.1769667993     0.1200454001    -0.0000023337
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    37.6320526137 hartrees
+ There are       14 alpha and       14 beta electrons
+ Applying Cartesian multipole field
+    Component          Value
+    ---------          -----
+     (2,0,0)        1.00000E-11
+     (0,2,0)        2.00000E-10
+     (0,0,2)       -3.00000E-10
+ Nucleus-field energy     =     0.0000000031 hartrees
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ A cutoff of  1.0D-11 yielded    200 shell pairs
+ There are       906 function pairs (       998 Cartesian)
+ Smallest overlap matrix eigenvalue = 3.18E-02
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-08
+Geometry optimization detected.  Setting ReadMinima to 0
+Setting SaveMinima to 0
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    28
+   Numerical integral  =    27.961193580499
+   Relative error      =    -0.1385943554 %
+ CPU 0.08 s  wall 0.08 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.7079870216      1.33E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7056920956      2.95E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    3    -536.7061255127      8.77E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    4    -536.7061515284      6.28E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    5    -536.7061680314      3.19E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    6    -536.7061742655      3.80E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.11 s
+    7    -536.7061743402      2.47E-06
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.11 s
+    8    -536.7061743406      1.92E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    9    -536.7061743405      1.67E-07
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+   10    -536.7061743406      1.48E-08
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+   11    -536.7061743406      1.81E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 2.08 s  wall 2.03 s
+ SCF   energy in the final basis set = -536.7061743406
+ Total energy in the final basis set = -536.7061743406
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.948  -0.818  -0.322  -0.204  -0.117-101.188  -9.101  -6.858
+ -6.858  -6.858  -0.449  -0.001   0.003   0.004
+ -- Virtual --
+  0.237   0.344   0.712   0.816   1.084   1.085   1.182   1.326
+  1.433   1.572   1.783   1.878   2.264   2.319   3.105   3.112
+  3.294   3.604   3.933   0.839   0.840   0.841   0.911   1.069
+  1.070   1.071   1.073   1.073
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.333820
+      2 H                     0.123908
+      3 H                     0.209912
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.3153      Y       0.3426      Z       0.0000
+       Tot       3.3329
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.8538     XY       3.0983     YY     -20.2069
+        XZ       0.0000     YZ       0.0000     ZZ     -22.3193
+    Octopole Moments (Debye-Ang^2)
+       XXX       1.8852    XXY       3.0443    XYY       7.7956
+       YYY      -4.3138    XXZ       0.0002    XYZ       0.0000
+       YYZ       0.0001    XZZ       3.6713    YZZ      -1.7541
+       ZZZ       0.0003
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -368.0416   XXXY      19.7498   XXYY     -51.0758
+      XYYY       8.6393   YYYY     -25.0795   XXXZ       0.0005
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ       0.0000
+      XXZZ     -58.0201   XYZZ       2.2601   YYZZ      -8.2343
+      XZZZ       0.0002   YZZZ       0.0000   ZZZZ     -22.7814
+ -----------------------------------------------------------------
+ Calculating analytic gradient of the SCF energy
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+ Gradient of SCF Energy
+            1           2           3           4
+    1   0.0000022  -0.0000030   0.0000005   0.0000003
+    2  -0.0000369   0.0000132   0.0000053   0.0000183
+    3  -0.0000001   0.0000000   0.0000001  -0.0000000
+ Max gradient component =       3.687E-05
+ RMS gradient           =       1.263E-05
+ Gradient time:  CPU 0.45 s  wall 0.44 s
+ Geometry Optimization Parameters
+   NAtoms,    NIC,     NZ,  NCons,   NDum,   NFix, NCnnct, MaxDiis
+        4      14       0       0       0       0       0       0
+
+ Cartesian Hessian Update
+ Hessian Updated using BFGS Update
+
+
+** GEOMETRY OPTIMIZATION IN DELOCALIZED INTERNAL COORDINATES **
+   Searching for a Minimum
+
+   Optimization Cycle:  11
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0915742182   -0.0596724512   -0.0000093743
+      2  H         1.9107181762    0.8921208890    0.0000002069
+      3  H         1.1697794708   -0.3780370043   -0.0000051847
+      4  Cl       -1.1769667993    0.1200454001   -0.0000023337
+   Point Group: c1    Number of degrees of freedom:     6
+
+
+   Energy is   -536.706174341
+
+ Hessian Updated using BFGS Update
+
+  6 Hessian modes will be used to form the next step
+  Hessian Eigenvalues:
+     0.006011    0.020409    0.165271    0.199999    0.522575    0.535685
+
+ Minimum Search - Taking Simple RFO Step
+ Searching for Lamda that Minimizes Along All modes
+ Value Taken    Lamda =   0.00000000
+ Step Taken.  Stepsize is  0.000230
+
+                             Maximum     Tolerance    Cnvgd?
+         Gradient           0.000022      0.000300     YES
+         Displacement       0.000186      0.001200     YES
+         Energy change     -0.000000      0.000001     YES
+
+
+                       Distance Matrix (Angstroms)
+             O (  1)   H (  2)   H (  3)
+   H (  2)  0.968824
+   H (  3)  0.975224  1.470473
+   Cl(  4)  3.273478  3.182750  2.399021
+
+ Final energy is   -536.70617434061785     
+
+
+ ******************************
+ **  OPTIMIZATION CONVERGED  **
+ ******************************
+
+                       Coordinates (Angstroms)
+     ATOM                X               Y               Z
+      1  O         2.0915742182   -0.0596724512   -0.0000093743
+      2  H         1.9107181762    0.8921208890    0.0000002069
+      3  H         1.1697794708   -0.3780370043   -0.0000051847
+      4  Cl       -1.1769667993    0.1200454001   -0.0000023337
+
+Z-matrix Print:
+$molecule
+-1 1
+O 
+H  1 0.968824
+H  1 0.975224 2 98.294759
+Cl 3 2.399021 1 148.963529 2 -0.000885 0
+$end
+
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.948  -0.818  -0.322  -0.204  -0.117-101.188  -9.101  -6.858
+ -6.858  -6.858  -0.449  -0.001   0.003   0.004
+ -- Virtual --
+  0.237   0.344   0.712   0.816   1.084   1.085   1.182   1.326
+  1.433   1.572   1.783   1.878   2.264   2.319   3.105   3.112
+  3.294   3.604   3.933   0.839   0.840   0.841   0.911   1.069
+  1.070   1.071   1.073   1.073
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.333820
+      2 H                     0.123908
+      3 H                     0.209912
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.3153      Y       0.3426      Z       0.0000
+       Tot       3.3329
+    Quadrupole Moments (Debye-Ang)
+        XX     -35.8538     XY       3.0983     YY     -20.2069
+        XZ       0.0000     YZ       0.0000     ZZ     -22.3193
+    Octopole Moments (Debye-Ang^2)
+       XXX       1.8852    XXY       3.0443    XYY       7.7956
+       YYY      -4.3138    XXZ       0.0002    XYZ       0.0000
+       YYZ       0.0001    XZZ       3.6713    YZZ      -1.7541
+       ZZZ       0.0003
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -368.0416   XXXY      19.7498   XXYY     -51.0758
+      XYYY       8.6393   YYYY     -25.0795   XXXZ       0.0005
+      XXYZ       0.0000   XYYZ       0.0001   YYYZ       0.0000
+      XXZZ     -58.0201   XYZZ       2.2601   YYZZ      -8.2343
+      XZZZ       0.0002   YZZZ       0.0000   ZZZZ     -22.7814
+ -----------------------------------------------------------------
+Archival summary:
+1\1\copper\OPT\ProcedureUnspecified\BasisUnspecified\l112(1-,1)\eric\MonJan2521:00:212016MonJan2521:00:212016\0\\#,OPT,ProcedureUnspecified,BasisUnspecified,\\-1,1\O\H,1,0.968824\H,1,0.975224,2,98.2948\Cl,3,2.39902,1,148.964,2,-0.000885496,0\\\@
+
+ Total job time:  25.34s(wall), 25.60s(cpu) 
+ Mon Jan 25 21:00:21 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 

--- a/QChem/QChem4.2/print_frgm_true_sp.out
+++ b/QChem/QChem4.2/print_frgm_true_sp.out
@@ -1,0 +1,821 @@
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe .print_frgm_true_sp.in.19271.qcin.1 /tmp/qchem/qchem19271/
+
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Mon Jan 25 21:04:16 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem19271//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$rem
+ jobtype = sp
+ method = b3lyp
+ basis = cc-pvdz
+ frgm_method = gia
+ frgm_lpcorr = 0
+ scf_print_frgm = true
+$end
+
+$molecule
+-1 1
+--
+0 1
+O      2.0046718567   -0.0940911795   -0.0000456417
+H      2.0989955585    0.8620675220   -0.0000086873
+H      1.0186881803   -0.1989910837   -0.0000610506
+--
+-1 1
+Cl    -1.1264842195    0.0053780533   -0.0000197660
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0045014740    -0.0939781001     0.0000017004
+    2      H       2.0987398960     0.8621890110    -0.0000023237
+    3      H       1.0185271576    -0.1989659440    -0.0000163614
+    4      Cl     -1.1266634615     0.0052118667     0.0000002989
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    38.8683285907 hartrees
+ There are       14 alpha and       14 beta electrons
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+
+ Total QAlloc Memory Limit   2000 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+
+                       Distance Matrix (Angstroms)
+             O (  1)   H (  2)   H (  3)
+   H (  2)  0.960800
+   H (  3)  0.991548  1.514236
+   Cl(  4)  3.132736  3.337310  2.154885
+
+ A cutoff of  1.0D-08 yielded    194 shell pairs
+ There are       874 function pairs (       965 Cartesian)
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is             19390748
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                         20
+ number of basis is                          44
+ number of cartesian basis is                44
+ number of contracted shell pairs           194
+ number of primitive shell pairs           1886
+ maxK2 (contraction) of shell pair           81
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair             18
+ max number of PS2 of shell pair            486
+ mem total for path MDJ                   13530
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 3.06E-02
+
+ Scale SEOQF with 1.000000e-01/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000027 hartrees
+ Guess MOs from converged MOs on fragments
+
+QCSCRATCH   is /tmp/qchem
+QCFILEPREF  is /tmp/qchem/qchem19271/
+
+-----------------------------------------------------------------
+ SCF on fragment 1 out of 2
+-----------------------------------------------------------------
+
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh  /tmp/qchem/qchem19271/Frg1.input  stdout  Frg1
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh /tmp/qchem/qchem19271/Frg1.input stdout Frg1
+QCSCRATCH is /tmp/qchem/qchem19271/Frg1
+QCFILEPREF is /tmp/qchem/qchem19271/Frg1/
+-- Serial fragment SCF job
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe /tmp/qchem/qchem19271/Frg1.input /tmp/qchem/qchem19271/Frg1/
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Mon Jan 25 21:04:16 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem19271/Frg1//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$molecule
+0 1
+ 8	2.0045014740	-0.0939781001	0.0000017004
+ 1	2.0987398960	0.8621890110	-0.0000023237
+ 1	1.0185271576	-0.1989659440	-0.0000163614
+$end
+$rem
+METHOD		B3LYP
+BASIS		CC-PVDZ
+SCF_PRINT_FRGM		TRUE
+!required keywords
+JOBTYPE		SP
+SYM_IGNORE		TRUE
+SUBSYSTEM		TRUE
+SAVE_SUBSYSTEM		TRUE
+PURECART		11
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0045014740    -0.0939781001     0.0000017004
+    2      H       2.0987398960     0.8621890110    -0.0000023237
+    3      H       1.0185271576    -0.1989659440    -0.0000163614
+ ----------------------------------------------------------------
+ Nuclear Repulsion Energy =     9.0251097803 hartrees
+ There are        5 alpha and        5 beta electrons
+ Requested basis set is cc-pVDZ
+ There are 12 shells and 24 basis functions
+
+ Total QAlloc Memory Limit   2000 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+
+                       Distance Matrix (Angstroms)
+             O (  1)   H (  2)
+   H (  2)  0.960800
+   H (  3)  0.991548  1.514236
+
+ A cutoff of  1.0D-08 yielded     78 shell pairs
+ There are       322 function pairs (       352 Cartesian)
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is              3179904
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                         12
+ number of basis is                          25
+ number of cartesian basis is                25
+ number of contracted shell pairs            78
+ number of primitive shell pairs            491
+ maxK2 (contraction) of shell pair           49
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair              9
+ max number of PS2 of shell pair            147
+ mem total for path MDJ                    9444
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 3.55E-02
+
+ Scale SEOQF with 1.000000e-01/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000020 hartrees
+ Guess from superposition of atomic densities
+ Warning:  Energy on first SCF cycle will be non-variational
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.05 s  wall 0.05 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1     -76.3878598350      1.28E-01
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+    2     -76.3543312512      3.49E-02
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+    3     -76.3195251097      4.38E-02
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+    4     -76.4200545742      9.15E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+    5     -76.4200959677      1.72E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+    6     -76.4200973476      2.26E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.04 s  wall 0.04 s
+    7     -76.4200973746      8.02E-07 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 0.53 s  wall 0.50 s
+ SCF   energy in the final basis set = -76.4200973746
+ Total energy in the final basis set = -76.4200973746
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-19.126  -0.990  -0.502  -0.369  -0.288
+ -- Virtual --
+  0.047   0.123   0.541   0.611   0.905   0.917   0.997   1.183
+  1.238   1.410   1.590   1.668   2.056   2.135   2.911   2.948
+  3.116   3.433   3.733
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.267718
+      2 H                     0.128465
+      3 H                     0.139253
+  ----------------------------------------
+  Sum of atomic charges =    -0.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -0.0000
+    Dipole Moment (Debye)
+         X      -1.3953      Y       1.3682      Z      -0.0000
+       Tot       1.9542
+    Quadrupole Moments (Debye-Ang)
+        XX     -10.4242     XY       3.3771     YY      -5.1647
+        XZ      -0.0000     YZ       0.0000     ZZ      -7.0156
+    Octopole Moments (Debye-Ang^2)
+       XXX     -46.1160    XXY       7.9189    XYY      -9.8667
+       YYY       1.6754    XXZ      -0.0000    XYZ      -0.0000
+       YYZ      -0.0000    XZZ     -13.5953    YZZ       0.2441
+       ZZZ      -0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -168.7477   XXXY      17.9481   XXYY     -21.0950
+      XYYY       3.1580   YYYY      -5.6247   XXXZ       0.0000
+      XXYZ      -0.0000   XYYZ      -0.0000   YYYZ      -0.0000
+      XXZZ     -28.3651   XYZZ       0.3592   YYZZ      -1.9825
+      XZZZ      -0.0000   YZZZ       0.0000   ZZZZ      -4.8572
+ -----------------------------------------------------------------
+Archival summary:
+1\1\copper\SP\ProcedureUnspecified\BasisUnspecified\12\eric\MonJan2521:04:162016MonJan2521:04:162016\0\\#,ProcedureUnspecified,BasisUnspecified,\\0,1\O\H,1,0.9608\H,1,0.991548,2,101.707\\\@
+
+ Total job time:  0.55s(wall), 0.57s(cpu) 
+ Mon Jan 25 21:04:16 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 
+Copy Fragment Subsystem from /tmp/qchem/qchem19271/Frg1/
+
+-----------------------------------------------------------------
+ SCF on fragment 2 out of 2
+-----------------------------------------------------------------
+
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh  /tmp/qchem/qchem19271/Frg2.input  stdout  Frg2
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/bin/xr.csh /tmp/qchem/qchem19271/Frg2.input stdout Frg2
+QCSCRATCH is /tmp/qchem/qchem19271/Frg2
+QCFILEPREF is /tmp/qchem/qchem19271/Frg2/
+-- Serial fragment SCF job
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe /tmp/qchem/qchem19271/Frg2.input /tmp/qchem/qchem19271/Frg2/
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Mon Jan 25 21:04:16 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem19271/Frg2//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$molecule
+-1 1
+ 17	-1.1266634615	0.0052118667	0.0000002989
+$end
+$rem
+METHOD		B3LYP
+BASIS		CC-PVDZ
+SCF_PRINT_FRGM		TRUE
+!required keywords
+JOBTYPE		SP
+SYM_IGNORE		TRUE
+SUBSYSTEM		TRUE
+SAVE_SUBSYSTEM		TRUE
+PURECART		11
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      Cl     -1.1266634615     0.0052118667     0.0000002989
+ ----------------------------------------------------------------
+ Nuclear Repulsion Energy =     0.0000000000 hartrees
+ There are        9 alpha and        9 beta electrons
+ Requested basis set is cc-pVDZ
+ There are 8 shells and 18 basis functions
+
+ Total QAlloc Memory Limit   2000 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+ A cutoff of  1.0D-08 yielded     36 shell pairs
+ There are       190 function pairs (       214 Cartesian)
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is             19390748
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                          8
+ number of basis is                          19
+ number of cartesian basis is                19
+ number of contracted shell pairs            36
+ number of primitive shell pairs           1041
+ maxK2 (contraction) of shell pair           81
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair              6
+ max number of PS2 of shell pair            486
+ mem total for path MDJ                   13530
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 1.42E-01
+
+ Scale SEOQF with 1.000000e+00/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000077 hartrees
+ Guess from superposition of atomic densities
+ Warning:  Energy on first SCF cycle will be non-variational
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-05
+ CPU 0.00 s  wall 0.00 s
+ Inaccurate integrated density:
+   Number of electrons =    18
+   Numerical integral  =    16.999999837106
+   Relative error      =    -5.5555564605 %
+ CPU 0.01 s  wall 0.01 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -460.1092841212      1.43E-02
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.01 s  wall 0.01 s
+    2    -460.2193895888      3.09E-02
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.01 s  wall 0.01 s
+    3    -460.2451458243      2.08E-02
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.01 s  wall 0.01 s
+    4    -460.2655097812      4.70E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.01 s  wall 0.01 s
+    5    -460.2665676058      1.42E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.01 s  wall 0.01 s
+    6    -460.2665685942      6.65E-06 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 0.20 s  wall 0.19 s
+ SCF   energy in the final basis set = -460.2665685942
+ Total energy in the final basis set = -460.2665685942
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+*******  -9.076  -6.833  -6.833  -6.833  -0.422   0.028   0.028
+  0.028
+ -- Virtual --
+  0.863   0.863   0.863   0.935   1.098   1.098   1.098   1.098
+  1.098
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       5.4116      Y      -0.0250      Z       0.0000
+       Tot       5.4116
+    Quadrupole Moments (Debye-Ang)
+        XX     -21.4107     XY       0.0282     YY     -15.3138
+        XZ      -0.0000     YZ       0.0000     ZZ     -15.3137
+    Octopole Moments (Debye-Ang^2)
+       XXX      58.6293    XXY      -0.1116    XYY      17.2535
+       YYY      -0.2394    XXZ      -0.0000    XYZ      -0.0000
+       YYZ      -0.0000    XZZ      17.2533    YZZ      -0.0798
+       ZZZ      -0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -142.3451   XXXY       0.3056   XXYY     -25.4304
+      XYYY       0.2698   YYYY     -17.9760   XXXZ       0.0000
+      XXYZ       0.0000   XYYZ       0.0000   YYYZ       0.0000
+      XXZZ     -25.4299   XYZZ       0.0899   YYZZ      -5.9916
+      XZZZ       0.0000   YZZZ       0.0000   ZZZZ     -17.9735
+ -----------------------------------------------------------------
+
+ STANDARD THERMODYNAMIC QUANTITIES AT   298.15 K  AND     1.00 ATM
+
+   Translational Enthalpy:        0.889 kcal/mol
+   Rotational Enthalpy:           0.000 kcal/mol
+   Vibrational Enthalpy:          0.000 kcal/mol
+   gas constant (RT):             0.592 kcal/mol
+   Translational Entropy:        36.586  cal/mol.K
+   Rotational Entropy:            0.000  cal/mol.K
+   Vibrational Entropy:           0.000  cal/mol.K
+
+   Total Enthalpy:                1.481 kcal/mol
+   Total Entropy:                36.586  cal/mol.K
+
+ -----------------------------------------------------------------
+
+Archival summary:
+1\1\copper\SP\ProcedureUnspecified\BasisUnspecified\l1(1-,1)\eric\MonJan2521:04:172016MonJan2521:04:172016\0\\#,ProcedureUnspecified,BasisUnspecified,\\-1,1\Cl\\\@
+
+ Total job time:  0.23s(wall), 0.23s(cpu) 
+ Mon Jan 25 21:04:17 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 
+Copy Fragment Subsystem from /tmp/qchem/qchem19271/Frg2/
+
+-----------------------------------------------------------------
+ Done with SCF on isolated fragments
+-----------------------------------------------------------------
+
+ User-specified occupied guess orbitals will be used
+ A restricted hybrid HF-DFT SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ Exchange:     0.2000 Hartree-Fock + 0.0800 Slater + 0.7200 B88
+ Correlation:  0.1900 VWN1RPA + 0.8100 LYP
+ Using SG-1 standard quadrature grid
+ SCF converges when DIIS error is below 1.0E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.11 s  wall 0.11 s
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -536.6992110205      7.03E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    2    -536.7039377242      2.71E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.09 s  wall 0.09 s
+    3    -536.7042516078      1.12E-03
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.08 s  wall 0.08 s
+    4    -536.7043043344      5.36E-04
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.07 s  wall 0.07 s
+    5    -536.7043182461      2.64E-05
+ CPU 0.00 s  wall 0.00 s
+ CPU 0.10 s  wall 0.10 s
+    6    -536.7043180991      9.89E-06 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.09 s  wall 1.04 s
+ SCF   energy in the final basis set = -536.7043180991
+ Total energy in the final basis set = -536.7043180991
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-18.937  -0.803  -0.316  -0.187  -0.107-101.191  -9.105  -6.862
+ -6.861  -6.861  -0.453  -0.006   0.000   0.001
+ -- Virtual --
+  0.234   0.385   0.727   0.801   1.083   1.094   1.199   1.367
+  1.428   1.598   1.813   1.860   2.261   2.315   3.098   3.127
+  3.302   3.621   3.925   0.837   0.838   0.840   0.909   1.063
+  1.065   1.065   1.070   1.070
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.350980
+      2 H                     0.102936
+      3 H                     0.248044
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.2305      Y       1.2185      Z      -0.0000
+       Tot       3.4527
+    Quadrupole Moments (Debye-Ang)
+        XX     -33.8072     XY       3.2387     YY     -20.5620
+        XZ      -0.0000     YZ       0.0000     ZZ     -22.3240
+    Octopole Moments (Debye-Ang^2)
+       XXX       5.6342    XXY       7.4508    XYY       6.8662
+       YYY       1.2184    XXZ      -0.0000    XYZ       0.0000
+       YYZ      -0.0000    XZZ       3.3379    YZZ       0.1299
+       ZZZ      -0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -327.8266   XXXY      17.4894   XXYY     -47.6655
+      XYYY       3.0504   YYYY     -23.8480   XXXZ       0.0000
+      XXYZ      -0.0000   XYYZ      -0.0000   YYYZ      -0.0000
+      XXZZ     -54.4137   XYZZ       0.4071   YYZZ      -7.9930
+      XZZZ      -0.0000   YZZZ       0.0000   ZZZZ     -22.7830
+ -----------------------------------------------------------------
+Archival summary:
+1\1\copper\SP\ProcedureUnspecified\BasisUnspecified\l112(1-,1)\eric\MonJan2521:04:182016MonJan2521:04:182016\0\\#,ProcedureUnspecified,BasisUnspecified,\\-1,1\O\H,1,0.9608\H,1,0.991548,2,101.707\Cl,3,2.15489,1,168.485,2,0.00780336,0\\\@
+
+ Total job time:  2.05s(wall), 1.13s(cpu) 
+ Mon Jan 25 21:04:18 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 

--- a/QChem/QChem4.2/print_frgm_true_sp_ccsdt.out
+++ b/QChem/QChem4.2/print_frgm_true_sp_ccsdt.out
@@ -1,0 +1,1246 @@
+/home/eric/opt/apps/qchem/trunk_gcc_release/exe/qcprog.exe .print_frgm_true_sp_ccsdt.in.10965.qcin.1 /tmp/qchem/qchem10965/
+
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Tue Jan 26 10:06:41 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem10965//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$rem
+ jobtype = sp
+ method = ccsd(t)
+ basis = cc-pvdz
+ frgm_method = gia
+ frgm_lpcorr = 0
+ scf_print_frgm = true
+$end
+
+$molecule
+-1 1
+--
+0 1
+O      2.0046718567   -0.0940911795   -0.0000456417
+H      2.0989955585    0.8620675220   -0.0000086873
+H      1.0186881803   -0.1989910837   -0.0000610506
+--
+-1 1
+Cl    -1.1264842195    0.0053780533   -0.0000197660
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0045014740    -0.0939781001     0.0000017004
+    2      H       2.0987398960     0.8621890110    -0.0000023237
+    3      H       1.0185271576    -0.1989659440    -0.0000163614
+    4      Cl     -1.1266634615     0.0052118667     0.0000002989
+ ----------------------------------------------------------------
+ Molecular Point Group                 C1    NOp =  1
+ Largest Abelian Subgroup              C1    NOp =  1
+ Nuclear Repulsion Energy =    38.8683285907 hartrees
+ There are       14 alpha and       14 beta electrons
+ Requested basis set is cc-pVDZ
+ There are 20 shells and 42 basis functions
+ Total memory of 1562MB is distributed as follows: 
+   QALLOC including MEM_STATIC uses 1062MB
+   MEM_STATIC is set to 62MB
+   CCMAN JOB total memory use is  1500MB
+ Warning: actual memory use might exceed 1562MB
+
+ Total QAlloc Memory Limit   1062 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+
+                       Distance Matrix (Angstroms)
+             O (  1)   H (  2)   H (  3)
+   H (  2)  0.960800
+   H (  3)  0.991548  1.514236
+   Cl(  4)  3.132736  3.337310  2.154885
+
+ tim1(1): 
+   0.0000000000000000     
+ tim1(2): 
+   0.0000000000000000     
+ A cutoff of  1.0D-14 yielded    204 shell pairs
+ There are       930 function pairs (      1026 Cartesian)
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is             19390748
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                         20
+ number of basis is                          44
+ number of cartesian basis is                44
+ number of contracted shell pairs           204
+ number of primitive shell pairs           2023
+ maxK2 (contraction) of shell pair           81
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair             17
+ max number of PS2 of shell pair            486
+ mem total for path MDJ                   13530
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 3.06E-02
+
+ Scale SEOQF with 1.000000e-01/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000027 hartrees
+ Guess MOs from converged MOs on fragments
+
+QCSCRATCH   is /tmp/qchem
+QCFILEPREF  is /tmp/qchem/qchem10965/
+
+-----------------------------------------------------------------
+ SCF on fragment 1 out of 2
+-----------------------------------------------------------------
+
+/home/eric/opt/apps/qchem/trunk_gcc_release/bin/xr.csh  /tmp/qchem/qchem10965/Frg1.input  stdout  Frg1
+/home/eric/opt/apps/qchem/trunk_gcc_release/bin/xr.csh /tmp/qchem/qchem10965/Frg1.input stdout Frg1
+QCSCRATCH is /tmp/qchem/qchem10965/Frg1
+QCFILEPREF is /tmp/qchem/qchem10965/Frg1/
+-- Serial fragment SCF job
+/home/eric/opt/apps/qchem/trunk_gcc_release/exe/qcprog.exe /tmp/qchem/qchem10965/Frg1.input /tmp/qchem/qchem10965/Frg1/
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Tue Jan 26 10:06:41 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem10965/Frg1//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$molecule
+0 1
+ 8	2.0045014740	-0.0939781001	0.0000017004
+ 1	2.0987398960	0.8621890110	-0.0000023237
+ 1	1.0185271576	-0.1989659440	-0.0000163614
+$end
+$rem
+METHOD		CCSD(T)
+BASIS		CC-PVDZ
+SCF_PRINT_FRGM		TRUE
+!required keywords
+JOBTYPE		SP
+SYM_IGNORE		TRUE
+SUBSYSTEM		TRUE
+SAVE_SUBSYSTEM		TRUE
+PURECART		11
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       2.0045014740    -0.0939781001     0.0000017004
+    2      H       2.0987398960     0.8621890110    -0.0000023237
+    3      H       1.0185271576    -0.1989659440    -0.0000163614
+ ----------------------------------------------------------------
+ Nuclear Repulsion Energy =     9.0251097803 hartrees
+ There are        5 alpha and        5 beta electrons
+ Requested basis set is cc-pVDZ
+ There are 12 shells and 24 basis functions
+ Total memory of 1562MB is distributed as follows: 
+   QALLOC including MEM_STATIC uses 1062MB
+   MEM_STATIC is set to 62MB
+   CCMAN JOB total memory use is  1500MB
+ Warning: actual memory use might exceed 1562MB
+
+ Total QAlloc Memory Limit   1062 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+
+                       Distance Matrix (Angstroms)
+             O (  1)   H (  2)
+   H (  2)  0.960800
+   H (  3)  0.991548  1.514236
+
+ tim1(1): 
+   0.0000000000000000     
+ tim1(2): 
+   0.0000000000000000     
+ A cutoff of  1.0D-14 yielded     78 shell pairs
+ There are       322 function pairs (       352 Cartesian)
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is              3179904
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                         12
+ number of basis is                          25
+ number of cartesian basis is                25
+ number of contracted shell pairs            78
+ number of primitive shell pairs            497
+ maxK2 (contraction) of shell pair           49
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair              9
+ max number of PS2 of shell pair            147
+ mem total for path MDJ                    9444
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 3.55E-02
+
+ Scale SEOQF with 1.000000e-01/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000020 hartrees
+ Guess from superposition of atomic densities
+ Warning:  Energy on first SCF cycle will be non-variational
+ A restricted Hartree-Fock SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ SCF converges when DIIS error is below 1.0E-08
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1     -75.8794352980      1.36E-01
+    2     -75.9899300432      2.41E-02
+    3     -76.0169578479      1.24E-02
+    4     -76.0245082891      1.41E-03
+    5     -76.0246951291      3.87E-04
+    6     -76.0247131048      6.58E-05
+    7     -76.0247137645      1.02E-05
+    8     -76.0247137815      1.29E-06
+    9     -76.0247137818      3.38E-07
+   10     -76.0247137818      4.22E-08
+   11     -76.0247137818      5.79E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 0.29 s  wall 0.25 s
+ SCF   energy in the final basis set = -76.0247137818
+ Total energy in the final basis set = -76.0247137818
+
+
+ ------------------------------------------------------------------------------
+
+   CCMAN2: suite of methods based on coupled cluster
+           and equation of motion theories.
+
+   Components:
+   * libvmm-1.2-release
+     by Evgeny Epifanovsky, Ilya Kaliman.
+   * libtensor-2.4-trunk
+     by Evgeny Epifanovsky, Michael Wormit, Dmitry Zuev, Sam Manzer.
+   * libcc-2.4-trunk
+     by Evgeny Epifanovsky, Arik Landau, Tomasz Kus, Kirill Khistyaev, 
+        Dmitry Zuev, Prashant Manohar, Xintian Feng, Anna Krylov, 
+        Matthew Goldey, Alec White, Thomas Jagau, Kaushik Nanda, 
+        Anastasia Gunina.
+
+   CCMAN original authors:
+   Anna I. Krylov, C. David Sherrill, Steven R. Gwaltney,
+   Edward F. C. Byrd (2000)
+   Sergey V. Levchenko, Lyudmila V. Slipchenko, Tao Wang,
+   Ana-Maria C. Cristian (2003)
+   Piotr A. Pieniazek, C. Melania Oana, Evgeny Epifanovsky (2007)
+   Prashant Manohar (2009)
+
+ ------------------------------------------------------------------------------
+
+
+ Calculation will run on 1 core with 1500MB of RAM.
+
+
+ Alpha MOs, Restricted
+ -- Occupied --                  
+-20.555  -1.330  -0.684  -0.569  -0.493
+  1 A     2 A     3 A     4 A     5 A                                          
+ -- Virtual --                   
+  0.182   0.254   0.765   0.851   1.167   1.199   1.258   1.421
+  6 A     7 A     8 A     9 A    10 A    11 A    12 A    13 A                  
+  1.481   1.656   1.866   1.930   2.383   2.469   3.276   3.317
+ 14 A    15 A    16 A    17 A    18 A    19 A    20 A    21 A                  
+  3.494   3.827   4.142
+ 22 A    23 A    24 A                                                          
+
+ Beta MOs, Restricted
+ -- Occupied --                  
+-20.555  -1.330  -0.684  -0.569  -0.493
+  1 A     2 A     3 A     4 A     5 A                                          
+ -- Virtual --                   
+  0.182   0.254   0.765   0.851   1.167   1.199   1.258   1.421
+  6 A     7 A     8 A     9 A    10 A    11 A    12 A    13 A                  
+  1.481   1.656   1.866   1.930   2.383   2.469   3.276   3.317
+ 14 A    15 A    16 A    17 A    18 A    19 A    20 A    21 A                  
+  3.494   3.827   4.142
+ 22 A    23 A    24 A                                                          
+
+ Occupation and symmetry of molecular orbitals
+
+ Point group: C1 (1 irreducible representation).
+
+                           A     All 
+ -------------------------------------
+ All molecular orbitals:
+  - Alpha                  24    24  
+  - Beta                   24    24  
+ -------------------------------------
+ Alpha orbitals:
+  - Frozen occupied        0     0   
+  - Active occupied        5     5   
+  - Active virtual         19    19  
+  - Frozen virtual         0     0   
+ -------------------------------------
+ Beta orbitals:
+  - Frozen occupied        0     0   
+  - Active occupied        5     5   
+  - Active virtual         19    19  
+  - Frozen virtual         0     0   
+ -------------------------------------
+
+ Import integrals:   CPU 0.00 s  wall 0.00 s
+
+
+ Import integrals:   CPU 0.04 s  wall 0.05 s
+
+ MP2 amplitudes:   CPU 0.00 s  wall 0.00 s
+
+           CCSD T amplitudes will be solved using DIIS.
+
+           Start     Size      MaxIter   EConv     TConv     
+           3         7         100       0x1.0c6f7a0b5ed8dp-20 0x1.a36e2eb1c432dp-14 
+ ------------------------------------------------------------------------------
+           Energy (a.u.)   Ediff      Tdiff       Comment
+ ------------------------------------------------------------------------------
+           -76.23029400                           
+     1     -76.23499050   4.70e-03   3.94e-01     
+     2     -76.23836139   3.37e-03   3.95e-02     
+     3     -76.23910466   7.43e-04   1.23e-02     
+     4     -76.23956793   4.63e-04   6.45e-03     Switched to DIIS steps.
+     5     -76.23959995   3.20e-05   9.59e-04     
+     6     -76.23959921   7.45e-07   2.90e-04     
+     7     -76.23959921   2.44e-10   7.22e-05     
+ ------------------------------------------------------------------------------
+           -76.23959921                           CCSD T converged.
+
+ SCF energy                 = -76.02471378
+ MP2 energy                 = -76.23029400
+ CCSD correlation energy     =  -0.21488543
+ CCSD total energy           = -76.23959921
+ CCSD(T) correlation energy =  -0.00317715
+ CCSD(T) total energy       = -76.24277636
+
+ CCSD  T1^2 = 0.0006  T2^2 = 0.0579  Leading amplitudes:
+
+ Amplitude    Orbitals with energies
+ -0.0081       4 (A) A                   ->    6 (A) A                    
+              -0.5687                          0.1816                     
+ -0.0081       4 (A) B                   ->    6 (A) B                    
+              -0.5687                          0.1816                     
+  0.0067       3 (A) A                   ->    18 (A) A                   
+              -0.6842                          2.3832                     
+  0.0067       3 (A) B                   ->    18 (A) B                   
+              -0.6842                          2.3832                     
+
+ Amplitude    Orbitals with energies
+ -0.0514       5 (A) A       5 (A) B     ->    11 (A) A      11 (A) B     
+              -0.4929       -0.4929            1.1989        1.1989       
+  0.0514       5 (A) A       5 (A) B     ->    11 (A) B      11 (A) A     
+              -0.4929       -0.4929            1.1989        1.1989       
+  0.0514       5 (A) B       5 (A) A     ->    11 (A) A      11 (A) B     
+              -0.4929       -0.4929            1.1989        1.1989       
+ -0.0514       5 (A) B       5 (A) A     ->    11 (A) B      11 (A) A     
+              -0.4929       -0.4929            1.1989        1.1989       
+
+ CCSD calculation:   CPU 0.86 s  wall 0.85 s
+
+ Total ccman2 time:   CPU 2.27 s  wall 2.26 s
+
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-20.555  -1.330  -0.684  -0.569  -0.493
+ -- Virtual --
+  0.182   0.254   0.765   0.851   1.167   1.199   1.258   1.421
+  1.481   1.656   1.866   1.930   2.383   2.469   3.276   3.317
+  3.494   3.827   4.142
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.321155
+      2 H                     0.153879
+      3 H                     0.167276
+  ----------------------------------------
+  Sum of atomic charges =    -0.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -0.0000
+    Dipole Moment (Debye)
+         X      -1.5159      Y       1.4770      Z      -0.0000
+       Tot       2.1165
+    Quadrupole Moments (Debye-Ang)
+        XX     -10.7828     XY       3.6465     YY      -5.0730
+        XZ      -0.0000     YZ       0.0000     ZZ      -7.0738
+    Octopole Moments (Debye-Ang^2)
+       XXX     -47.1668    XXY       8.5547    XYY      -9.7044
+       YYY       1.9598    XXZ      -0.0000    XYZ      -0.0000
+       YYZ      -0.0000    XZZ     -13.7456    YZZ       0.2806
+       ZZZ      -0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -171.8711   XXXY      19.5042   XXYY     -20.7319
+      XYYY       3.7968   YYYY      -5.2519   XXXZ      -0.0000
+      XXYZ      -0.0000   XYYZ      -0.0000   YYYZ      -0.0000
+      XXZZ     -28.6994   XYZZ       0.4489   YYZZ      -1.9580
+      XZZZ      -0.0000   YZZZ       0.0000   ZZZZ      -4.8991
+ -----------------------------------------------------------------
+Archival summary:
+1\1\copper\SP\ProcedureUnspecified\BasisUnspecified\12\eric\TueJan2610:06:442016TueJan2610:06:442016\0\\#,ProcedureUnspecified,BasisUnspecified,\\0,1\O\H,1,0.9608\H,1,0.991548,2,101.707\\HF=-76.0247138\\@
+
+ Total job time:  2.81s(wall), 2.86s(cpu) 
+ Tue Jan 26 10:06:44 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 
+Copy Fragment Subsystem from /tmp/qchem/qchem10965/Frg1/
+
+-----------------------------------------------------------------
+ SCF on fragment 2 out of 2
+-----------------------------------------------------------------
+
+/home/eric/opt/apps/qchem/trunk_gcc_release/bin/xr.csh  /tmp/qchem/qchem10965/Frg2.input  stdout  Frg2
+/home/eric/opt/apps/qchem/trunk_gcc_release/bin/xr.csh /tmp/qchem/qchem10965/Frg2.input stdout Frg2
+QCSCRATCH is /tmp/qchem/qchem10965/Frg2
+QCFILEPREF is /tmp/qchem/qchem10965/Frg2/
+-- Serial fragment SCF job
+/home/eric/opt/apps/qchem/trunk_gcc_release/exe/qcprog.exe /tmp/qchem/qchem10965/Frg2.input /tmp/qchem/qchem10965/Frg2/
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Tue Jan 26 10:06:44 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem10965/Frg2//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$molecule
+-1 1
+ 17	-1.1266634615	0.0052118667	0.0000002989
+$end
+$rem
+METHOD		CCSD(T)
+BASIS		CC-PVDZ
+SCF_PRINT_FRGM		TRUE
+!required keywords
+JOBTYPE		SP
+SYM_IGNORE		TRUE
+SUBSYSTEM		TRUE
+SAVE_SUBSYSTEM		TRUE
+PURECART		11
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      Cl     -1.1266634615     0.0052118667     0.0000002989
+ ----------------------------------------------------------------
+ Nuclear Repulsion Energy =     0.0000000000 hartrees
+ There are        9 alpha and        9 beta electrons
+ Requested basis set is cc-pVDZ
+ There are 8 shells and 18 basis functions
+ Total memory of 1562MB is distributed as follows: 
+   QALLOC including MEM_STATIC uses 1062MB
+   MEM_STATIC is set to 62MB
+   CCMAN JOB total memory use is  1500MB
+ Warning: actual memory use might exceed 1562MB
+
+ Total QAlloc Memory Limit   1062 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+ tim1(1): 
+   0.0000000000000000     
+ tim1(2): 
+   0.0000000000000000     
+ A cutoff of  1.0D-14 yielded     36 shell pairs
+ There are       190 function pairs (       214 Cartesian)
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                593474
+ size of scratch memory is             19390748
+ max col of scratch BK array               1296
+ max len of scratch array in speh3          155
+ max len of scratch index in speh4           18
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  2
+ order of int derivative is                   0
+ number of shells is                          8
+ number of basis is                          19
+ number of cartesian basis is                19
+ number of contracted shell pairs            36
+ number of primitive shell pairs           1041
+ maxK2 (contraction) of shell pair           81
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair              6
+ max number of PS2 of shell pair            486
+ mem total for path MDJ                   13530
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 1.42E-01
+
+ Scale SEOQF with 1.000000e+00/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000077 hartrees
+ Guess from superposition of atomic densities
+ Warning:  Energy on first SCF cycle will be non-variational
+ A restricted Hartree-Fock SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ SCF converges when DIIS error is below 1.0E-08
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -459.3108146720      5.01E-03
+    2    -459.5111944424      2.50E-02
+    3    -459.5067264925      2.67E-02
+    4    -459.5367907278      1.05E-02
+    5    -459.5409036199      5.15E-03
+    6    -459.5422187540      1.76E-04
+    7    -459.5422202734      2.91E-05
+    8    -459.5422203032      1.59E-05
+    9    -459.5422203156      7.68E-07
+   10    -459.5422203156      2.58E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 0.18 s  wall 0.16 s
+ SCF   energy in the final basis set = -459.5422203156
+ Total energy in the final basis set = -459.5422203156
+
+
+ ------------------------------------------------------------------------------
+
+   CCMAN2: suite of methods based on coupled cluster
+           and equation of motion theories.
+
+   Components:
+   * libvmm-1.2-release
+     by Evgeny Epifanovsky, Ilya Kaliman.
+   * libtensor-2.4-trunk
+     by Evgeny Epifanovsky, Michael Wormit, Dmitry Zuev, Sam Manzer.
+   * libcc-2.4-trunk
+     by Evgeny Epifanovsky, Arik Landau, Tomasz Kus, Kirill Khistyaev, 
+        Dmitry Zuev, Prashant Manohar, Xintian Feng, Anna Krylov, 
+        Matthew Goldey, Alec White, Thomas Jagau, Kaushik Nanda, 
+        Anastasia Gunina.
+
+   CCMAN original authors:
+   Anna I. Krylov, C. David Sherrill, Steven R. Gwaltney,
+   Edward F. C. Byrd (2000)
+   Sergey V. Levchenko, Lyudmila V. Slipchenko, Tao Wang,
+   Ana-Maria C. Cristian (2003)
+   Piotr A. Pieniazek, C. Melania Oana, Evgeny Epifanovsky (2007)
+   Prashant Manohar (2009)
+
+ ------------------------------------------------------------------------------
+
+
+ Calculation will run on 1 core with 1500MB of RAM.
+
+
+ Alpha MOs, Restricted
+ -- Occupied --                  
+-104.46  -10.18   -7.65   -7.65   -7.65   -0.69   -0.11   -0.11
+  1 A     2 A     3 A     4 A     5 A     6 A     7 A     8 A                  
+ -0.113
+  9 A                                                                          
+ -- Virtual --                   
+  1.078   1.078   1.078   1.149   1.344   1.344   1.344   1.344
+ 10 A    11 A    12 A    13 A    14 A    15 A    16 A    17 A                  
+  1.344
+ 18 A                                                                          
+
+ Beta MOs, Restricted
+ -- Occupied --                  
+-104.46  -10.18   -7.65   -7.65   -7.65   -0.69   -0.11   -0.11
+  1 A     2 A     3 A     4 A     5 A     6 A     7 A     8 A                  
+ -0.113
+  9 A                                                                          
+ -- Virtual --                   
+  1.078   1.078   1.078   1.149   1.344   1.344   1.344   1.344
+ 10 A    11 A    12 A    13 A    14 A    15 A    16 A    17 A                  
+  1.344
+ 18 A                                                                          
+
+ Occupation and symmetry of molecular orbitals
+
+ Point group: C1 (1 irreducible representation).
+
+                           A     All 
+ -------------------------------------
+ All molecular orbitals:
+  - Alpha                  18    18  
+  - Beta                   18    18  
+ -------------------------------------
+ Alpha orbitals:
+  - Frozen occupied        0     0   
+  - Active occupied        9     9   
+  - Active virtual         9     9   
+  - Frozen virtual         0     0   
+ -------------------------------------
+ Beta orbitals:
+  - Frozen occupied        0     0   
+  - Active occupied        9     9   
+  - Active virtual         9     9   
+  - Frozen virtual         0     0   
+ -------------------------------------
+
+ Import integrals:   CPU 0.00 s  wall 0.00 s
+
+
+ Import integrals:   CPU 0.04 s  wall 0.05 s
+
+ MP2 amplitudes:   CPU 0.00 s  wall 0.00 s
+
+           CCSD T amplitudes will be solved using DIIS.
+
+           Start     Size      MaxIter   EConv     TConv     
+           3         7         100       0x1.0c6f7a0b5ed8dp-20 0x1.a36e2eb1c432dp-14 
+ ------------------------------------------------------------------------------
+           Energy (a.u.)   Ediff      Tdiff       Comment
+ ------------------------------------------------------------------------------
+          -459.68242858                           
+     1    -459.69151336   9.08e-03   3.91e-01     
+     2    -459.69290861   1.40e-03   3.24e-02     
+     3    -459.69324023   3.32e-04   8.22e-03     
+     4    -459.69338546   1.45e-04   3.73e-03     Switched to DIIS steps.
+     5    -459.69338666   1.20e-06   2.55e-04     
+     6    -459.69338669   3.85e-08   4.74e-05     
+ ------------------------------------------------------------------------------
+          -459.69338669                           CCSD T converged.
+
+ SCF energy                 = -459.54222032
+ MP2 energy                 = -459.68242858
+ CCSD correlation energy     =   -0.15116638
+ CCSD total energy           = -459.69338669
+ CCSD(T) correlation energy =   -0.00131753
+ CCSD(T) total energy       = -459.69470422
+
+ CCSD  T1^2 = 0.0001  T2^2 = 0.0561  Leading amplitudes:
+
+ Amplitude    Orbitals with energies
+  0.0037       6 (A) A                   ->    13 (A) A                   
+              -0.6928                          1.1487                     
+  0.0037       6 (A) B                   ->    13 (A) B                   
+              -0.6928                          1.1487                     
+  0.0036       9 (A) A                   ->    12 (A) A                   
+              -0.1133                          1.0780                     
+  0.0036       9 (A) B                   ->    12 (A) B                   
+              -0.1133                          1.0780                     
+  0.0036       8 (A) A                   ->    11 (A) A                   
+              -0.1133                          1.0780                     
+  0.0036       8 (A) B                   ->    11 (A) B                   
+              -0.1133                          1.0780                     
+  0.0036       7 (A) A                   ->    10 (A) A                   
+              -0.1133                          1.0780                     
+  0.0036       7 (A) B                   ->    10 (A) B                   
+              -0.1133                          1.0780                     
+
+ Amplitude    Orbitals with energies
+ -0.0428       7 (A) A       7 (A) B     ->    14 (A) A      14 (A) B     
+              -0.1133       -0.1133            1.3444        1.3444       
+  0.0428       7 (A) A       7 (A) B     ->    14 (A) B      14 (A) A     
+              -0.1133       -0.1133            1.3444        1.3444       
+  0.0428       7 (A) B       7 (A) A     ->    14 (A) A      14 (A) B     
+              -0.1133       -0.1133            1.3444        1.3444       
+ -0.0428       7 (A) B       7 (A) A     ->    14 (A) B      14 (A) A     
+              -0.1133       -0.1133            1.3444        1.3444       
+
+ CCSD calculation:   CPU 0.43 s  wall 0.43 s
+
+ Total ccman2 time:   CPU 1.83 s  wall 1.82 s
+
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+******* -10.179  -7.646  -7.646  -7.646  -0.693  -0.113  -0.113
+ -0.113
+ -- Virtual --
+  1.078   1.078   1.078   1.149   1.344   1.344   1.344   1.344
+  1.344
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       5.4116      Y      -0.0250      Z      -0.0000
+       Tot       5.4117
+    Quadrupole Moments (Debye-Ang)
+        XX     -21.5512     XY       0.0282     YY     -15.4543
+        XZ       0.0000     YZ      -0.0000     ZZ     -15.4542
+    Octopole Moments (Debye-Ang^2)
+       XXX      59.1042    XXY      -0.1123    XYY      17.4118
+       YYY      -0.2416    XXZ      -0.0000    XYZ       0.0000
+       YYZ      -0.0000    XZZ      17.4116    YZZ      -0.0805
+       ZZZ      -0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -143.7147   XXXY       0.3080   XXYY     -25.7086
+      XYYY       0.2722   YYYY     -18.2755   XXXZ       0.0000
+      XXYZ      -0.0000   XYYZ       0.0000   YYYZ      -0.0000
+      XXZZ     -25.7080   XYZZ       0.0907   YYZZ      -6.0914
+      XZZZ       0.0000   YZZZ      -0.0000   ZZZZ     -18.2730
+ -----------------------------------------------------------------
+
+ STANDARD THERMODYNAMIC QUANTITIES AT   298.15 K  AND     1.00 ATM
+
+   Translational Enthalpy:        0.889 kcal/mol
+   Rotational Enthalpy:           0.000 kcal/mol
+   Vibrational Enthalpy:          0.000 kcal/mol
+   gas constant (RT):             0.592 kcal/mol
+   Translational Entropy:        36.586  cal/mol.K
+   Rotational Entropy:            0.000  cal/mol.K
+   Vibrational Entropy:           0.000  cal/mol.K
+
+   Total Enthalpy:                1.481 kcal/mol
+   Total Entropy:                36.586  cal/mol.K
+
+ -----------------------------------------------------------------
+
+Archival summary:
+1\1\copper\SP\ProcedureUnspecified\BasisUnspecified\l1(1-,1)\eric\TueJan2610:06:462016TueJan2610:06:462016\0\\#,ProcedureUnspecified,BasisUnspecified,\\-1,1\Cl\\HF=-459.54222\\@
+
+ Total job time:  2.25s(wall), 2.27s(cpu) 
+ Tue Jan 26 10:06:46 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 
+Copy Fragment Subsystem from /tmp/qchem/qchem10965/Frg2/
+
+-----------------------------------------------------------------
+ Done with SCF on isolated fragments
+-----------------------------------------------------------------
+
+ User-specified occupied guess orbitals will be used
+ A restricted Hartree-Fock SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ Locally projected approximation of Gianinetti
+ SCF converges when DIIS error is below 1.0E-08
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -535.5793324452      7.21E-03
+    2    -535.5840544133      2.15E-03
+    3    -535.5845135899      7.62E-04
+    4    -535.5845749095      2.55E-04
+    5    -535.5845793133      4.93E-05
+    6    -535.5845796232      7.74E-06
+    7    -535.5845796313      1.58E-06
+    8    -535.5845796316      2.97E-07
+    9    -535.5845796316      5.45E-08
+   10    -535.5845796316      1.32E-08
+   11    -535.5845796316      3.24E-09 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 1.04 s  wall 0.92 s
+ SCF   energy in the final basis set = -535.5845796316
+ Total energy in the final basis set = -535.5845796316
+
+
+ ------------------------------------------------------------------------------
+
+   CCMAN2: suite of methods based on coupled cluster
+           and equation of motion theories.
+
+   Components:
+   * libvmm-1.2-release
+     by Evgeny Epifanovsky, Ilya Kaliman.
+   * libtensor-2.4-trunk
+     by Evgeny Epifanovsky, Michael Wormit, Dmitry Zuev, Sam Manzer.
+   * libcc-2.4-trunk
+     by Evgeny Epifanovsky, Arik Landau, Tomasz Kus, Kirill Khistyaev, 
+        Dmitry Zuev, Prashant Manohar, Xintian Feng, Anna Krylov, 
+        Matthew Goldey, Alec White, Thomas Jagau, Kaushik Nanda, 
+        Anastasia Gunina.
+
+   CCMAN original authors:
+   Anna I. Krylov, C. David Sherrill, Steven R. Gwaltney,
+   Edward F. C. Byrd (2000)
+   Sergey V. Levchenko, Lyudmila V. Slipchenko, Tao Wang,
+   Ana-Maria C. Cristian (2003)
+   Piotr A. Pieniazek, C. Melania Oana, Evgeny Epifanovsky (2007)
+   Prashant Manohar (2009)
+
+ ------------------------------------------------------------------------------
+
+
+ Calculation will run on 1 core with 1500MB of RAM.
+
+
+ Alpha MOs, Restricted
+ -- Occupied --                  
+-20.365  -1.146  -0.501  -0.390  -0.311-104.486 -10.208  -7.675
+  1 A     2 A     3 A     4 A     5 A     6 A     7 A     8 A                  
+ -7.674  -7.674  -0.726  -0.151  -0.143  -0.142
+  9 A    10 A    11 A    12 A    13 A    14 A                                  
+ -- Virtual --                   
+  0.366   0.538   0.952   1.043   1.345   1.377   1.463   1.606
+ 15 A    16 A    17 A    18 A    19 A    20 A    21 A    22 A                  
+  1.671   1.844   2.092   2.122   2.587   2.650   3.461   3.498
+ 23 A    24 A    25 A    26 A    27 A    28 A    29 A    30 A                  
+  3.679   4.016   4.333   1.051   1.052   1.056   1.121   1.308
+ 31 A    32 A    33 A    34 A    35 A    36 A    37 A    38 A                  
+  1.310   1.310   1.315   1.315
+ 39 A    40 A    41 A    42 A                                                  
+
+ Beta MOs, Restricted
+ -- Occupied --                  
+-20.365  -1.146  -0.501  -0.390  -0.311-104.486 -10.208  -7.675
+  1 A     2 A     3 A     4 A     5 A     6 A     7 A     8 A                  
+ -7.674  -7.674  -0.726  -0.151  -0.143  -0.142
+  9 A    10 A    11 A    12 A    13 A    14 A                                  
+ -- Virtual --                   
+  0.366   0.538   0.952   1.043   1.345   1.377   1.463   1.606
+ 15 A    16 A    17 A    18 A    19 A    20 A    21 A    22 A                  
+  1.671   1.844   2.092   2.122   2.587   2.650   3.461   3.498
+ 23 A    24 A    25 A    26 A    27 A    28 A    29 A    30 A                  
+  3.679   4.016   4.333   1.051   1.052   1.056   1.121   1.308
+ 31 A    32 A    33 A    34 A    35 A    36 A    37 A    38 A                  
+  1.310   1.310   1.315   1.315
+ 39 A    40 A    41 A    42 A                                                  
+
+ Occupation and symmetry of molecular orbitals
+
+ Point group: C1 (1 irreducible representation).
+
+                           A     All 
+ -------------------------------------
+ All molecular orbitals:
+  - Alpha                  42    42  
+  - Beta                   42    42  
+ -------------------------------------
+ Alpha orbitals:
+  - Frozen occupied        0     0   
+  - Active occupied        14    14  
+  - Active virtual         28    28  
+  - Frozen virtual         0     0   
+ -------------------------------------
+ Beta orbitals:
+  - Frozen occupied        0     0   
+  - Active occupied        14    14  
+  - Active virtual         28    28  
+  - Frozen virtual         0     0   
+ -------------------------------------
+
+ Import integrals:   CPU 0.00 s  wall 0.00 s
+
+ Molecular orbitals will be canonicalized.
+
+ Import integrals:   CPU 0.34 s  wall 0.34 s
+
+ MP2 amplitudes:   CPU 0.00 s  wall 0.00 s
+
+           CCSD T amplitudes will be solved using DIIS.
+
+           Start     Size      MaxIter   EConv     TConv     
+           3         7         100       0x1.0c6f7a0b5ed8dp-20 0x1.a36e2eb1c432dp-14 
+ ------------------------------------------------------------------------------
+           Energy (a.u.)   Ediff      Tdiff       Comment
+ ------------------------------------------------------------------------------
+          -536.47939103                           
+     1    -536.21442051   2.65e-01   1.69e-01     
+     2    -536.54495111   3.31e-01   2.70e-01     
+     3    -536.11184793   4.33e-01   3.75e-01     
+     4    -536.43855498   3.27e-01   1.69e+00     Switched to DIIS steps.
+     5    -536.43614229   2.41e-03   5.94e-02     
+     6    -536.42919041   6.95e-03   9.23e-02     
+     7    -536.42685361   2.34e-03   5.93e-02     
+     8    -536.42519355   1.66e-03   3.23e-02     
+     9    -536.42469027   5.03e-04   2.61e-03     
+    10    -536.42498303   2.93e-04   3.66e-03     
+    11    -536.42499812   1.51e-05   3.21e-04     
+    12    -536.42500424   6.12e-06   9.19e-05     
+    13    -536.42500213   2.12e-06   2.39e-05     
+    14    -536.42500391   1.78e-06   1.47e-05     
+    15    -536.42500261   1.30e-06   8.00e-06     
+    16    -536.42500332   7.13e-07   2.35e-06     
+ ------------------------------------------------------------------------------
+          -536.42500332                           CCSD T converged.
+
+ SCF energy                 = -535.58457963
+ MP2 energy                 = -536.54272325
+ CCSD correlation energy     =   -0.84042369
+ CCSD total energy           = -536.42500332
+ CCSD(T) correlation energy =   -0.00817592
+ CCSD(T) total energy       = -536.43317924
+
+ CCSD  T1^2 = 0.2417  T2^2 = 0.1459  Leading amplitudes:
+
+ Amplitude    Orbitals with energies
+ -0.2949       8 (A) A                   ->    15 (A) A                   
+              -0.7328                          0.1315                     
+ -0.2949       8 (A) B                   ->    15 (A) B                   
+              -0.7328                          0.1315                     
+ -0.0670       8 (A) A                   ->    22 (A) A                   
+              -0.7328                          1.1993                     
+ -0.0670       8 (A) B                   ->    22 (A) B                   
+              -0.7328                          1.1993                     
+
+ Amplitude    Orbitals with energies
+ -0.0996       14 (A) A      14 (A) B    ->    15 (A) A      15 (A) B     
+              -0.1408       -0.1408            0.1315        0.1315       
+  0.0996       14 (A) A      14 (A) B    ->    15 (A) B      15 (A) A     
+              -0.1408       -0.1408            0.1315        0.1315       
+  0.0996       14 (A) B      14 (A) A    ->    15 (A) A      15 (A) B     
+              -0.1408       -0.1408            0.1315        0.1315       
+ -0.0996       14 (A) B      14 (A) A    ->    15 (A) B      15 (A) A     
+              -0.1408       -0.1408            0.1315        0.1315       
+
+ CCSD calculation:   CPU 11.79 s  wall 11.76 s
+
+ Total ccman2 time:   CPU 13.51 s  wall 13.48 s
+
+
+ --------------------------------------------------------------
+
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+
+ Alpha MOs
+ -- Occupied --
+-20.365  -1.146  -0.501  -0.390  -0.311-104.486 -10.208  -7.675
+ -7.674  -7.674  -0.726  -0.151  -0.143  -0.142
+ -- Virtual --
+  0.366   0.538   0.952   1.043   1.345   1.377   1.463   1.606
+  1.671   1.844   2.092   2.122   2.587   2.650   3.461   3.498
+  3.679   4.016   4.333   1.051   1.052   1.056   1.121   1.308
+  1.310   1.310   1.315   1.315
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 O                    -0.410012
+      2 H                     0.129798
+      3 H                     0.280215
+      4 Cl                   -1.000000
+  ----------------------------------------
+  Sum of atomic charges =    -1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -4.8032
+    Dipole Moment (Debye)
+         X       3.1232      Y       1.3277      Z      -0.0000
+       Tot       3.3937
+    Quadrupole Moments (Debye-Ang)
+        XX     -34.2192     XY       3.5078     YY     -20.5977
+        XZ      -0.0000     YZ       0.0000     ZZ     -22.5206
+    Octopole Moments (Debye-Ang^2)
+       XXX       5.1479    XXY       8.0992    XYY       7.2130
+       YYY       1.5150    XXZ      -0.0000    XYZ      -0.0000
+       YYZ      -0.0000    XZZ       3.3464    YZZ       0.1673
+       ZZZ      -0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -331.5919   XXXY      19.0882   XXYY     -47.4745
+      XYYY       3.7239   YYYY     -23.7251   XXXZ      -0.0000
+      XXYZ      -0.0000   XYYZ      -0.0000   YYYZ      -0.0000
+      XXZZ     -54.9856   XYZZ       0.5008   YYZZ      -8.0618
+      XZZZ      -0.0000   YZZZ       0.0000   ZZZZ     -23.1237
+ -----------------------------------------------------------------
+Archival summary:
+1\1\copper\SP\ProcedureUnspecified\BasisUnspecified\l112(1-,1)\eric\TueJan2610:07:012016TueJan2610:07:012016\0\\#,ProcedureUnspecified,BasisUnspecified,\\-1,1\O\H,1,0.9608\H,1,0.991548,2,101.707\Cl,3,2.15489,1,168.485,2,0.00780336,0\\HF=-535.58458\\@
+
+ Total job time:  19.89s(wall), 14.85s(cpu) 
+ Tue Jan 26 10:07:01 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 

--- a/QChem/QChem4.2/read_molecule.out
+++ b/QChem/QChem4.2/read_molecule.out
@@ -1,0 +1,551 @@
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe .read_molecule.in.10694.qcin.1 /tmp/qchem/qchem10694/
+
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Sat Jan 23 13:19:38 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem10694//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$rem
+ method = hf
+ basis = 3-21g
+ scf_convergence = 10
+ thresh = 14
+$end
+
+$molecule
+read molecule_neutral
+$end
+
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      H      -0.5596989552     0.0357358296    -0.0000000000
+    2      O      -1.5120945103    -0.1206953267     0.0000000000
+    3      O       1.3931364000     0.1177545793    -0.0000000000
+    4      H      -1.8875213197     0.7615510735    -0.0000000000
+    5      H       1.6994425787    -0.3868804620     0.7580000000
+    6      H       1.6994425787    -0.3868804620    -0.7580000000
+ ----------------------------------------------------------------
+ Molecular Point Group                 Cs    NOp =  2
+ Largest Abelian Subgroup              Cs    NOp =  2
+ Nuclear Repulsion Energy =    36.6338958500 hartrees
+ There are       10 alpha and       10 beta electrons
+ Requested basis set is 3-21G
+ There are 14 shells and 26 basis functions
+
+ Total QAlloc Memory Limit   2000 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+
+                       Distance Matrix (Angstroms)
+             H (  1)   O (  2)   O (  3)   H (  4)   H (  5)
+   O (  2)  0.965157
+   O (  3)  1.954557  2.915000
+   H (  4)  1.513248  0.958803  3.343230
+   H (  5)  2.420101  3.310497  0.960752  3.841844
+   H (  6)  2.420101  3.310497  0.960752  3.841844  1.516000
+
+ A cutoff of  1.0D-14 yielded    102 shell pairs
+ There are       366 function pairs
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                 45569
+ size of scratch memory is               800000
+ max col of scratch BK array                289
+ max len of scratch array in speh3           22
+ max len of scratch index in speh4            8
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                               164
+ max L of basis functions is                  1
+ order of int derivative is                   0
+ number of shells is                         14
+ number of basis is                          26
+ number of cartesian basis is                26
+ number of contracted shell pairs           102
+ number of primitive shell pairs            260
+ maxK2 (contraction) of shell pair            9
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair             19
+ max number of PS2 of shell pair             39
+ mem total for path MDJ                    5996
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 9.40E-02
+
+ Scale SEOQF with 1.000000e-01/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000011 hartrees
+ Guess from superposition of atomic densities
+ Warning:  Energy on first SCF cycle will be non-variational
+ A restricted Hartree-Fock SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ SCF converges when DIIS error is below 1.0E-10
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -151.0790651783      1.68E-01
+    2    -151.1262643283      2.87E-02
+    3    -151.1782565302      1.35E-02
+    4    -151.1872432124      1.54E-03
+    5    -151.1875915500      3.47E-04
+    6    -151.1876071550      9.92E-05
+    7    -151.1876079018      1.79E-05
+    8    -151.1876079393      2.88E-06
+    9    -151.1876079415      5.72E-07
+   10    -151.1876079416      1.03E-07
+   11    -151.1876079416      1.78E-08
+   12    -151.1876079416      3.12E-09
+   13    -151.1876079416      4.66E-10
+   14    -151.1876079416      7.69E-11 Convergence criterion met
+ ---------------------------------------
+ SCF time:  CPU 0.32 s  wall 0.15 s
+ SCF   energy in the final basis set = -151.1876079416
+ Total energy in the final basis set = -151.1876079416
+
+ --------------------------------------------------------------
+             Orbital Energies (a.u.) and Symmetries
+ --------------------------------------------------------------
+
+ Alpha MOs, Restricted
+ -- Occupied --                  
+-20.472 -20.387  -1.366  -1.290  -0.720  -0.654  -0.578  -0.525
+  1 A'    2 A'    3 A'    4 A'    1 A"    5 A'    6 A'    7 A'                 
+ -0.492  -0.443
+  8 A'    2 A"                                                                 
+ -- Virtual --                   
+  0.233   0.320   0.336   0.472   1.159   1.224   1.300   1.366
+  9 A'   10 A'    3 A"   11 A'    4 A"   12 A'   13 A'   14 A'                 
+  1.782   1.818   1.869   1.912   1.976   2.130   3.055   3.319
+ 15 A'    5 A"   16 A'   17 A'    6 A"   18 A'   19 A'   20 A'                 
+
+ Beta MOs, Restricted
+ -- Occupied --                  
+-20.472 -20.387  -1.366  -1.290  -0.720  -0.654  -0.578  -0.525
+  1 A'    2 A'    3 A'    4 A'    1 A"    5 A'    6 A'    7 A'                 
+ -0.492  -0.443
+  8 A'    2 A"                                                                 
+ -- Virtual --                   
+  0.233   0.320   0.336   0.472   1.159   1.224   1.300   1.366
+  9 A'   10 A'    3 A"   11 A'    4 A"   12 A'   13 A'   14 A'                 
+  1.782   1.818   1.869   1.912   1.976   2.130   3.055   3.319
+ 15 A'    5 A"   16 A'   17 A'    6 A"   18 A'   19 A'   20 A'                 
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)
+  ----------------------------------------
+      1 H                     0.378309
+      2 O                    -0.781854
+      3 O                    -0.715989
+      4 H                     0.347683
+      5 H                     0.385926
+      6 H                     0.385926
+  ----------------------------------------
+  Sum of atomic charges =     0.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                 0.0000
+    Dipole Moment (Debye)
+         X       3.1671      Y      -0.0185      Z      -0.0000
+       Tot       3.1672
+    Quadrupole Moments (Debye-Ang)
+        XX     -10.9890     XY      -7.3987     YY     -11.6680
+        XZ       0.0000     YZ       0.0000     ZZ     -10.8715
+    Octopole Moments (Debye-Ang^2)
+       XXX      11.8170    XXY       0.8752    XYY      -0.6436
+       YYY       0.4100    XXZ      -0.0000    XYZ       0.0000
+       YYZ      -0.0000    XZZ       5.0354    YZZ      -0.7709
+       ZZZ       0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -155.6040   XXXY     -24.8334   XXYY     -26.6766
+      XYYY      -4.5598   YYYY     -10.3533   XXXZ       0.0000
+      XXYZ       0.0000   XYYZ      -0.0000   YYYZ       0.0000
+      XXZZ     -25.0682   XYZZ      -2.3313   YYZZ      -3.2674
+      XZZZ       0.0000   YZZZ       0.0000   ZZZZ      -9.4029
+ -----------------------------------------------------------------
+Archival summary:
+1\1\copper\SP\HF\3-21G\24\eric\SatJan2313:19:382016SatJan2313:19:382016\0\\#,HF,3-21G,\\0,1\O\H,1,0.960752\H,1,0.960752,2,104.178\H,1,1.95456,2,107.247,3,113.493,0\O,4,0.965157,1,173.077,2,-55.7015,0\H,5,0.958803,4,103.724,1,-180,0\\HF=-151.187608\\@
+
+ Total job time:  0.32s(wall), 0.66s(cpu) 
+ Sat Jan 23 13:19:38 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 
+ 
+User input: 2 of 2 
+ 
+/home/eric/opt/apps/qchem/trunk_gcc_release_r19341_20151031/exe/qcprog.exe .read_molecule.in.10694.qcin.2 /tmp/qchem/qchem10694/
+
+Process 0 of 1 is on copper - thread support 0
+initial socket setup ...start
+initial socket setup ...done 
+now start server 0 ... 
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 4.3, Q-Chem, Inc., Pleasanton, CA (2015)
+
+ Y. Shao,  Z. Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  J. Deng,  X. Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  R. Z. Khaliullin,  
+ T. Kus,  A. Landau,  J. Liu,  E. I. Proynov,  Y. M. Rhee,  R. M. Richard,  
+ M. A. Rohrdanz,  R. P. Steele,  E. J. Sundstrom,  H. L. Woodcock III,  
+ P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  B. Austin,  
+ S. A. Baeppler,  G. J. O. Beran,  Y. A. Bernard,  E. Berquist,  
+ K. Brandhorst,  K. B. Bravaya,  S. T. Brown,  D. Casanova,  C.-M. Chang,  
+ Y. Chen,  S. H. Chien,  K. D. Closser,  D. L. Crittenden,  M. Diedenhofen,  
+ R. A. DiStasio Jr.,  H. Do,  A. D. Dutoi,  R. G. Edgar,  P.-T. Fang,  
+ S. Fatehi,  Q. Feng,  L. Fusti-Molnar,  A. Ghysels,  
+ A. Golubeva-Zadorozhnaya,  J. Gomes,  A. Gunina,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  E. G. Hohenstein,  Z. C. Holden,  K. Hui,  
+ T.-C. Jagau,  H. Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  Jihan Kim,  
+ R. A. King,  P. Klunzinger,  D. Kosenkov,  T. Kowalczyk,  C. M. Krauter,  
+ K. U. Lao,  A. Laurent,  K. V. Lawler,  S. Lehtola,  S. V. Levchenko,  
+ C. Y. Lin,  Y.-S. Lin,  F. Liu,  E. Livshits,  R. C. Lochan,  A. Luenser,  
+ P. Manohar,  S. F. Manzer,  S.-P. Mao,  N. Mardirossian,  A. V. Marenich,  
+ L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  K. Nanda,  
+ C. M. Oana,  R. Olivares-Amaya,  D. P. O'Neill,  J. A. Parkhill,  
+ T. M. Perrine,  R. Peverati,  P. A. Pieniazek,  F. Plasser,  A. Prociuk,  
+ D. R. Rehn,  E. Rosta,  N. J. Russ,  N. Sergueev,  S. M. Sharada,  
+ S. Sharma,  D. W. Small,  A. Sodt,  T. Stauch,  T. Stein,  D. Stuck,  
+ Y.-C. Su,  A. J. W. Thom,  T. Tsuchimochi,  L. Vogt,  O. Vydrov,  T. Wang,  
+ M. A. Watson,  J. Wenzel,  A. White,  C. F. Williams,  V. Vanovschi,  
+ S. Yeganeh,  S. R. Yost,  Z.-Q. You,  I. Y. Zhang,  X. Zhang,  Y. Zhao,  
+ B. R. Brooks,  G. K. L. Chan,  D. M. Chipman,  C. J. Cramer,  
+ W. A. Goddard III,  M. S. Gordon,  W. J. Hehre,  A. Klamt,  
+ H. F. Schaefer III,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Warshel,  X. Xu,  A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  
+ J.-D. Chai,  A. Dreuw,  B. D. Dunietz,  T. R. Furlani,  S. R. Gwaltney,  
+ C.-P. Hsu,  Y. Jung,  J. Kong,  D. S. Lambrecht,  W. Liang,  C. Ochsenfeld,  
+ V. A. Rassolov,  L. V. Slipchenko,  J. E. Subotnik,  T. Van Voorhis,  
+ J. M. Herbert,  A. I. Krylov,  P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  J. Baker,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ H. Dachsel,  R. J. Doerksen,  G. Hawkins,  A. Heyden,  S. Hirata,  
+ G. Kedziora,  F. J. Keil,  C. Kelley,  P. P. Korambath,  W. Kurlancheek,  
+ A. M. Lee,  M. S. Lee,  D. Liotard,  I. Lotan,  P. E. Maslen,  N. Nair,  
+ D. Neuhauser,  R. Olson,  B. Peters,  J. Ritchie,  N. E. Schultz,  
+ N. Shenvi,  A. C. Simmonett,  K. S. Thanthiriwatte,  Q. Wu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 4.3.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 5.200.1 (Boston Tea Smuggler).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Sat Jan 23 13:19:39 2016  
+
+copper
+Host: 0
+
+     Scratch files written to /tmp/qchem/qchem10694//
+ Parallel job on  1  processors
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+
+$rem
+ method = hf
+ basis = 6-31g
+ scf_convergence = 10
+ thresh = 14
+ scf_guess = read
+$end
+
+$molecule
+read molecule_cation
+$end
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      H      -0.5596989552     0.0357358296    -0.0000000000
+    2      O      -1.5120945103    -0.1206953267     0.0000000000
+    3      O       1.3931364000     0.1177545793    -0.0000000000
+    4      H      -1.8875213197     0.7615510735    -0.0000000000
+    5      H       1.6994425787    -0.3868804620     0.7580000000
+    6      H       1.6994425787    -0.3868804620    -0.7580000000
+ ----------------------------------------------------------------
+ Molecular Point Group                 Cs    NOp =  2
+ Largest Abelian Subgroup              Cs    NOp =  2
+ Nuclear Repulsion Energy =    36.6338958500 hartrees
+ There are       10 alpha and        9 beta electrons
+ Requested basis set is 6-31G
+ There are 14 shells and 26 basis functions
+
+ Total QAlloc Memory Limit   2000 MB
+ Mega-Array Size        61 MB
+ MEM_STATIC part        62 MB
+
+                       Distance Matrix (Angstroms)
+             H (  1)   O (  2)   O (  3)   H (  4)   H (  5)
+   O (  2)  0.965157
+   O (  3)  1.954557  2.915000
+   H (  4)  1.513248  0.958803  3.343230
+   H (  5)  2.420101  3.310497  0.960752  3.841844
+   H (  6)  2.420101  3.310497  0.960752  3.841844  1.516000
+
+ A cutoff of  1.0D-14 yielded    104 shell pairs
+ There are       374 function pairs
+
+ -------------------------------------------------------
+ OpenMP Integral Computing Module                       
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ Integral Job Info:
+ Integral job number is                      11
+ Integral operator is                         1
+ short-range coefficients                     0
+ long-range coefficients              100000000
+ Omega coefficients                           0
+ if combine SR and LR in K                    0
+ Integral screening is                        0
+ Integral computing path is                   2
+ max size of driver memory is            800000
+ size of driver memory is                 45569
+ size of scratch memory is              1939132
+ max col of scratch BK array                289
+ max len of scratch array in speh3           22
+ max len of scratch index in speh4            8
+ max int batch size is                      520
+ min int batch size is                       52
+ fixed nKL is                                52
+ max L of basis functions is                  1
+ order of int derivative is                   0
+ number of shells is                         14
+ number of basis is                          26
+ number of cartesian basis is                26
+ number of contracted shell pairs           104
+ number of primitive shell pairs            549
+ maxK2 (contraction) of shell pair           36
+ max number of K2 of shell pair               1
+ max number of CS2 of shell pair             18
+ max number of PS2 of shell pair             78
+ mem total for path MDJ                    6690
+ -------------------------------------------------------
+ Smallest overlap matrix eigenvalue = 4.56E-02
+
+ Scale SEOQF with 1.000000e-01/1.000000e+00/1.000000e+00
+
+ Standard Electronic Orientation quadrupole field applied
+ Nucleus-field energy     =     0.0000000011 hartrees
+ Guess MOs from SCF MO coefficient file
+ Reading MOs from coefficient file
+ Reading MOs from coefficient file
+ An unrestricted Hartree-Fock SCF calculation will be
+ performed using Pulay DIIS extrapolation
+ SCF converges when DIIS error is below 1.0E-10
+ ---------------------------------------
+  Cycle       Energy         DIIS Error
+ ---------------------------------------
+    1    -151.3692924408      1.95E-01
+    2    -151.4201094003      5.34E-02
+    3    -151.5991101198      1.42E-02
+    4    -151.6108177052      2.37E-03
+    5    -151.6112972881      4.49E-04
+    6    -151.6113773971      7.75E-05
+    7    -151.6114015840      1.65E-05
+    8    -151.6114065074      4.19E-06
+    9    -151.6114075065      1.20E-06
+   10    -151.6114076488      2.97E-07
+   11    -151.6114076541      4.97E-08
+   12    -151.6114076542      1.11E-08
+   13    -151.6114076542      2.65E-09
+   14    -151.6114076543      7.45E-10
+   15    -151.6114076543      2.48E-10
+   16    -151.6114076543      5.68E-11 Convergence criterion met
+ ---------------------------------------
+ <S^2> = 0.7550
+ SCF time:  CPU 0.60 s  wall 0.27 s
+ SCF   energy in the final basis set = -151.6114076543
+ Total energy in the final basis set = -151.6114076543
+
+ --------------------------------------------------------------
+             Orbital Energies (a.u.) and Symmetries
+ --------------------------------------------------------------
+
+ Alpha MOs, Unrestricted
+ -- Occupied --                  
+-21.094 -20.786  -1.885  -1.574  -1.180  -1.089  -1.054  -0.924
+  1 A'    2 A'    3 A'    4 A'    5 A'    1 A"    6 A'    2 A"                 
+ -0.791  -0.724
+  7 A'    8 A'                                                                 
+ -- Virtual --                   
+ -0.087   0.004   0.094   0.120   0.675   0.705   0.765   0.835
+  9 A'   10 A'   11 A'    3 A"    4 A"   12 A'   13 A'   14 A'                 
+  0.853   0.956   1.005   1.009   1.085   1.163   1.370   1.694
+  5 A"   15 A'   16 A'   17 A'   18 A'    6 A"   19 A'   20 A'                 
+
+ Beta MOs, Unrestricted
+ -- Occupied --                  
+-21.049 -20.786  -1.726  -1.574  -1.138  -0.993  -0.924  -0.791
+  1 A'    2 A'    3 A'    4 A'    5 A'    6 A'    1 A"    7 A'                 
+ -0.725
+  8 A'                                                                         
+ -- Virtual --                   
+ -0.284  -0.074   0.008   0.104   0.120   0.700   0.789   0.829
+  2 A"    9 A'   10 A'   11 A'    3 A"   12 A'   13 A'    4 A"                 
+  0.850   0.895   0.964   1.006   1.023   1.100   1.163   1.389
+ 14 A'    5 A"   15 A'   16 A'   17 A'   18 A'    6 A"   19 A'                 
+  1.709
+ 20 A'                                                                         
+ --------------------------------------------------------------
+
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)    Spin (a.u.)
+  --------------------------------------------------------
+      1 H                     0.541514      -0.044123
+      2 O                    -0.158406       1.100056
+      3 O                    -0.825547      -0.003971
+      4 H                     0.538409      -0.052451
+      5 H                     0.452015       0.000245
+      6 H                     0.452015       0.000245
+  --------------------------------------------------------
+  Sum of atomic charges =     1.000000
+  Sum of spin   charges =     1.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                 4.8032
+    Dipole Moment (Debye)
+         X      -3.2552      Y      -0.0617      Z      -0.0000
+       Tot       3.2558
+    Quadrupole Moments (Debye-Ang)
+        XX       1.2689     XY      -8.4833     YY     -10.5487
+        XZ       0.0000     YZ       0.0000     ZZ      -8.7554
+    Octopole Moments (Debye-Ang^2)
+       XXX      -7.7960    XXY       1.5447    XYY      -3.1895
+       YYY       0.7458    XXZ      -0.0000    XYZ       0.0000
+       YYZ      -0.0000    XZZ       2.3776    YZZ      -1.0143
+       ZZZ       0.0000
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX    -114.1011   XXXY     -30.6354   XXYY     -23.0068
+      XYYY      -6.8235   YYYY      -9.8674   XXXZ       0.0000
+      XXYZ       0.0000   XYYZ      -0.0000   YYYZ       0.0000
+      XXZZ     -19.5210   XYZZ      -2.7831   YYZZ      -2.9328
+      XZZZ       0.0000   YZZZ       0.0000   ZZZZ      -7.7981
+ -----------------------------------------------------------------
+Archival summary:
+1\1\copper\SP\HF\6-31G\24(1+,2)\eric\SatJan2313:19:392016SatJan2313:19:392016\0\\#,HF,6-31G,\\1,2\O\H,1,0.960752\H,1,0.960752,2,104.178\H,1,1.95456,2,107.247,3,113.493,0\O,4,0.965157,1,173.077,2,-55.7015,0\H,5,0.958803,4,103.724,1,-180,0\\HF=-151.611408\\@
+
+ Total job time:  0.45s(wall), 0.94s(cpu) 
+ Sat Jan 23 13:19:39 2016
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+0 sent ACK to 0 
+now end server 0 ... 

--- a/regression.py
+++ b/regression.py
@@ -770,6 +770,21 @@ def testQChem_QChem4_2_qchem_tddft_rpa_out(logfile):
     assert logfile.data.etsecs[0][1] == [(27, 0), (39, 0), 0.1039]
     assert logfile.data.etsecs[0][2] == [(39, 0), (27, 0), 0.0605]
 
+
+def testQChem_QChem4_2_read_molecule_out(logfile):
+    """A two-calculation output with the charge/multiplicity not specified
+    in the user section."""
+
+    # These correspond to the second calculation.
+    assert logfile.data.charge == 1
+    assert logfile.data.mult == 2
+    assert len(logfile.data.moenergies) == 2
+
+    # However, we currently take data from both, since they aren't
+    # exactly fragment calculations.
+    assert len(logfile.data.scfenergies) == 2
+
+
 # These regression tests are for logfiles that are not to be parsed
 # for some reason, and the function should start with 'testnoparse'.
 

--- a/regression.py
+++ b/regression.py
@@ -42,6 +42,8 @@ import unittest
 
 import numpy
 
+from cclib.parser.utils import convertor
+
 from cclib.parser import ccopen
 
 from cclib.parser import ADF
@@ -443,21 +445,23 @@ def testQChem_QChem4_2_CH3___Na__RS_out(logfile):
 
     Contains only the Roothaan step energies for the CP correction.
 
-    For now, we only keep the final block of MO energies. This corresponds to
-    the section titled 'Done with counterpoise correction on fragments'.
+    The fragment SCF sections are printed.
+
+    This is to ensure only the supersystem is parsed.
     """
 
     assert logfile.data.charge == 1
     assert logfile.data.mult == 2
-    assert logfile.data.nbasis == logfile.data.nmo == 40
-
-    assert len(logfile.data.atomnos) == 5
     assert len(logfile.data.moenergies) == 2
+    assert len(logfile.data.atomcoords[0]) == 5
+    assert len(logfile.data.atomnos) == 5
 
     # Fragments: A, B, RS_CP(A), RS_CP(B), Full
-    assert len(logfile.data.scfenergies) == 5
+    assert len(logfile.data.scfenergies) == 1
+    scfenergy = convertor(-201.9388745658, "hartree", "eV")
+    assert abs(logfile.data.scfenergies[0] - scfenergy) < 1.0e-10
 
-    # There are 40 MOs in the supersystem.
+    assert logfile.data.nbasis == logfile.data.nmo == 40
     assert len(logfile.data.moenergies[0]) == 40
     assert len(logfile.data.moenergies[1]) == 40
     assert type(logfile.data.moenergies) == type([])
@@ -469,21 +473,23 @@ def testQChem_QChem4_2_CH3___Na__RS_SCF_out(logfile):
 
     Contains both the Roothaan step and full SCF energies for the CP correction.
 
-    For now, we only keep the final block of MO energies. This corresponds to
-    the section titled 'Done with counterpoise correction on fragments'.
+    The fragment SCF sections are printed.
+
+    This is to ensure only the supersystem is printed.
     """
 
     assert logfile.data.charge == 1
     assert logfile.data.mult == 2
-    assert logfile.data.nbasis == logfile.data.nmo == 40
-
-    assert len(logfile.data.atomnos) == 5
     assert len(logfile.data.moenergies) == 2
+    assert len(logfile.data.atomcoords[0]) == 5
+    assert len(logfile.data.atomnos) == 5
 
     # Fragments: A, B, RS_CP(A), RS_CP(B), SCF_CP(A), SCF_CP(B), Full
-    assert len(logfile.data.scfenergies) == 7
+    assert len(logfile.data.scfenergies) == 1
+    scfenergy = convertor(-201.9396979324, "hartree", "eV")
+    assert abs(logfile.data.scfenergies[0] - scfenergy) < 1.0e-10
 
-    # There are 40 MOs in the supersystem.
+    assert logfile.data.nbasis == logfile.data.nmo == 40
     assert len(logfile.data.moenergies[0]) == 40
     assert len(logfile.data.moenergies[1]) == 40
     assert type(logfile.data.moenergies) == type([])
@@ -493,22 +499,107 @@ def testQChem_QChem4_2_CH3___Na__RS_SCF_out(logfile):
 def testQChem_QChem4_2_CH4___Na__out(logfile):
     """A restricted fragment job with no BSSE correction.
 
-    For now, we only keep the final block of MO energies. This corresponds to
-    the section titled 'Done with SCF on isolated fragments'.
+    The fragment SCF sections are printed.
+
+    This is to ensure only the supersystem is parsed.
     """
 
     assert logfile.data.charge == 1
     assert logfile.data.mult == 1
-    assert logfile.data.nbasis == logfile.data.nmo == 42
-
-    assert len(logfile.data.atomnos) == 6
-    assert len(logfile.data.scfenergies) == 3
     assert len(logfile.data.moenergies) == 1
+    assert len(logfile.data.atomcoords[0]) == 6
+    assert len(logfile.data.atomnos) == 6
 
-    # There are 42 MOs in the supersystem.
+    # Fragments: A, B, Full
+    assert len(logfile.data.scfenergies) == 1
+    scfenergy = convertor(-202.6119443654, "hartree", "eV")
+    assert abs(logfile.data.scfenergies[0] - scfenergy) < 1.0e-10
+
+    assert logfile.data.nbasis == logfile.data.nmo == 42
     assert len(logfile.data.moenergies[0]) == 42
     assert type(logfile.data.moenergies) == type([])
     assert type(logfile.data.moenergies[0]) == type(numpy.array([]))
+
+
+def testQChem_QChem4_2_CH3___Na__RS_SCF_noprint_out(logfile):
+    """An unrestricted fragment job with BSSE correction.
+
+    Contains both the Roothaan step and full SCF energies for the CP correction.
+
+    The fragment SCF sections are not printed.
+
+    This is to ensure only the supersystem is parsed.
+    """
+
+    assert logfile.data.charge == 1
+    assert logfile.data.mult == 2
+    assert len(logfile.data.moenergies) == 2
+    assert len(logfile.data.atomcoords[0]) == 5
+    assert len(logfile.data.atomnos) == 5
+
+    assert len(logfile.data.scfenergies) == 1
+    scfenergy = convertor(-201.9396979324, "hartree", "eV")
+    assert abs(logfile.data.scfenergies[0] - scfenergy) < 1.0e-10
+
+    assert logfile.data.nbasis == logfile.data.nmo == 40
+    assert len(logfile.data.moenergies[0]) == 40
+    assert len(logfile.data.moenergies[1]) == 40
+    assert type(logfile.data.moenergies) == type([])
+    assert type(logfile.data.moenergies[0]) == type(numpy.array([]))
+    assert type(logfile.data.moenergies[1]) == type(numpy.array([]))
+
+
+def testQChem_QChem4_2_CH3___Na__RS_noprint_out(logfile):
+    """An unrestricted fragment job with BSSE correction.
+
+    Contains only the Roothaan step energies for the CP correction.
+
+    The fragment SCF sections are not printed.
+
+    This is to ensure only the supersystem is parsed.
+    """
+
+    assert logfile.data.charge == 1
+    assert logfile.data.mult == 2
+    assert len(logfile.data.moenergies) == 2
+    assert len(logfile.data.atomcoords[0]) == 5
+    assert len(logfile.data.atomnos) == 5
+
+    assert len(logfile.data.scfenergies) == 1
+    scfenergy = convertor(-201.9388582085, "hartree", "eV")
+    assert abs(logfile.data.scfenergies[0] - scfenergy) < 1.0e-10
+
+    assert logfile.data.nbasis == logfile.data.nmo == 40
+    assert len(logfile.data.moenergies[0]) == 40
+    assert len(logfile.data.moenergies[1]) == 40
+    assert type(logfile.data.moenergies) == type([])
+    assert type(logfile.data.moenergies[0]) == type(numpy.array([]))
+    assert type(logfile.data.moenergies[1]) == type(numpy.array([]))
+
+
+def testQChem_QChem4_2_CH4___Na__noprint_out(logfile):
+    """A restricted fragment job with no BSSE correction.
+
+    The fragment SCF sections are not printed.
+
+    This is to ensure only the supersystem is parsed.
+    """
+
+    assert logfile.data.charge == 1
+    assert logfile.data.mult == 1
+    assert len(logfile.data.moenergies) == 1
+    assert len(logfile.data.atomcoords[0]) == 6
+    assert len(logfile.data.atomnos) == 6
+
+    assert len(logfile.data.scfenergies) == 1
+    scfenergy = convertor(-202.6119443654, "hartree", "eV")
+    assert abs(logfile.data.scfenergies[0] - scfenergy) < 1.0e-10
+
+    assert logfile.data.nbasis == logfile.data.nmo == 42
+    assert len(logfile.data.moenergies[0]) == 42
+    assert type(logfile.data.moenergies) == type([])
+    assert type(logfile.data.moenergies[0]) == type(numpy.array([]))
+
 
 def testQChem_QChem4_2_CO2_out(logfile):
     """A job containing a specific number of orbitals requested for
@@ -588,6 +679,67 @@ def testQChem_QChem4_2_dvb_sp_multipole_10_out(logfile):
     assert numpy.isnan(logfile.data.moments[8][0])
     assert abs(logfile.data.moments[9][0] - 10.1638) < tol
     assert numpy.isnan(logfile.data.moments[10][0])
+
+
+def testQChem_QChem4_2_print_frgm_false_opt_out(logfile):
+    """Fragment calculation: geometry optimization.
+
+    Fragment sections are not printed.
+    """
+
+    assert logfile.data.charge == -1
+    assert logfile.data.mult == 1
+
+    assert len(logfile.data.scfenergies) == 11
+    assert len(logfile.data.grads) == 11
+
+
+def testQChem_QChem4_2_print_frgm_true_opt_out(logfile):
+    """Fragment calculation: geometry optimization.
+
+    Fragment sections are printed.
+    """
+
+    assert logfile.data.charge == -1
+    assert logfile.data.mult == 1
+
+    assert len(logfile.data.scfenergies) == 11
+    assert len(logfile.data.grads) == 11
+
+
+def testQChem_QChem4_2_print_frgm_false_sp_out(logfile):
+    """Fragment calculation: single point energy.
+
+    Fragment sections are not printed.
+    """
+
+    assert logfile.data.charge == -1
+    assert logfile.data.mult == 1
+
+    assert len(logfile.data.scfenergies) == 1
+
+
+def testQChem_QChem4_2_print_frgm_true_sp_out(logfile):
+    """Fragment calculation: single point energy.
+
+    Fragment sections are printed.
+    """
+
+    assert logfile.data.charge == -1
+    assert logfile.data.mult == 1
+
+    assert len(logfile.data.scfenergies) == 1
+
+
+def testQChem_QChem4_2_print_frgm_true_sp_ccsdt_out(logfile):
+    """Fragment calculation: single point energy, CCSD(T).
+
+    Fragment sections are printed.
+    """
+
+    assert len(logfile.data.mpenergies[0]) == 1
+    assert len(logfile.data.ccenergies) == 1
+
 
 def testQChem_QChem4_2_qchem_tddft_rpa_out(logfile):
     """An RPA/TD-DFT job.

--- a/regressionfiles.txt
+++ b/regressionfiles.txt
@@ -240,3 +240,4 @@ QChem/QChem4.2/print_frgm_false_sp.out
 QChem/QChem4.2/print_frgm_true_sp.out
 QChem/QChem4.2/print_frgm_true_sp_ccsdt.out
 QChem/QChem4.2/qchem_tddft_rpa.out
+QChem/QChem4.2/read_molecule.out

--- a/regressionfiles.txt
+++ b/regressionfiles.txt
@@ -219,6 +219,9 @@ Psi/Psi4/psi4.0b5_samples_scf4.out
 QChem/QChem4.2/CH3---Na+_RS.out
 QChem/QChem4.2/CH3---Na+_RS_SCF.out
 QChem/QChem4.2/CH4---Na+.out
+QChem/QChem4.2/CH3---Na+_RS_SCF_noprint.out
+QChem/QChem4.2/CH3---Na+_RS_noprint.out
+QChem/QChem4.2/CH4---Na+_noprint.out
 QChem/QChem4.2/CO2.out
 QChem/QChem4.2/CO2_cation_ROHF.out
 QChem/QChem4.2/CO2_cation_ROHF_bigprint.out
@@ -231,4 +234,9 @@ QChem/QChem4.2/dvb_gopt_unconverged.out
 QChem/QChem4.2/dvb_sp_multipole_10.out
 QChem/QChem4.2/dvb_sp_omp.out
 QChem/QChem4.2/dvb_sp_unconverged.out
+QChem/QChem4.2/print_frgm_false_opt.out
+QChem/QChem4.2/print_frgm_true_opt.out
+QChem/QChem4.2/print_frgm_false_sp.out
+QChem/QChem4.2/print_frgm_true_sp.out
+QChem/QChem4.2/print_frgm_true_sp_ccsdt.out
 QChem/QChem4.2/qchem_tddft_rpa.out


### PR DESCRIPTION
These tests ensure that only the supersystem in a fragment-based calculation is parsed, regardless of whether or not the fragment sections are printed.

Also ensures the charge/multiplicity are handled properly, calculating them from number of electrons and atomic number rather than reading them from the user input.