### PR TITLE
ORCA: adding example PES scan that fails due to an assert

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+ORCA/ORCA3.0/CuI-MePY2-CH3CN_optxes.out filter=lfs diff=lfs merge=lfs -text

--- a/ORCA/ORCA3.0/CuI-MePY2-CH3CN_optxes.out
+++ b/ORCA/ORCA3.0/CuI-MePY2-CH3CN_optxes.out
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc22cd6a9ba68b46cbe686df6d9bfbbb31c1ed76c14a469b7896d613bb4d6c6f
+size 70327698


### PR DESCRIPTION
* See cclib Issue #253.