### PR TITLE
ORCA: adding example PES scan that fails due to an assert

### DIFF
--- a/regressionfiles.txt
+++ b/regressionfiles.txt
@@ -217,6 +217,7 @@ ORCA/ORCA2.9/PCB_1_122.out
 ORCA/ORCA2.9/prova.out
 ORCA/ORCA3.0/benzene_td_singlets.out
 ORCA/ORCA3.0/dvb_gopt_unconverged.out
+ORCA/ORCA3.0/CuI-MePY2-CH3CN_optxes.out.gz
 Psi/Psi3/water_psi3.log
 Psi/Psi4/dvb_gopt_hf_unconverged.out
 Psi/Psi4/dvb_sp_hf_git.out


### PR DESCRIPTION
* See cclib #253.