### PR TITLE
ORCA: adding example PES scan that fails due to an assert

### DIFF
--- a/regressionfiles.txt
+++ b/regressionfiles.txt
@@ -216,6 +216,7 @@ ORCA/ORCA2.9/job.out
 ORCA/ORCA2.9/PCB_1_122.out
 ORCA/ORCA2.9/prova.out
 ORCA/ORCA3.0/benzene_td_singlets.out
+ORCA/ORCA3.0/CuI-MePY2-CH3CN_optxes.out
 ORCA/ORCA3.0/dvb_gopt_unconverged.out
 Psi/Psi3/water_psi3.log
 Psi/Psi4/dvb_gopt_hf_unconverged.out


### PR DESCRIPTION
* See cclib #253.