### PR TITLE
Loosen precision on some old ORCA IR unit tests.

### DIFF
--- a/regression.py
+++ b/regression.py
@@ -1383,7 +1383,18 @@ class OrcaTDDFTTest_error(OrcaTDDFTTest):
         self.assertEqual(len(self.data.etoscs), self.number)
         self.assertAlmostEquals(max(self.data.etoscs), 1.0, delta=0.2)
 
+class OrcaIRTest_old_coordsOK(OrcaIRTest):
+
+    enthalpy_places = -1
+    entropy_places = 2
+    freeenergy_places = -1
+
 class OrcaIRTest_old(OrcaIRTest):
+
+    enthalpy_places = -1
+    entropy_places = 2
+    freeenergy_places = -1
+
     @unittest.skip('These values were wrong due to wrong input coordinates.')
     def testfreqval(self):
         """These values were wrong due to wrong input coordinates."""
@@ -1494,7 +1505,7 @@ old_unittests = {
     "ORCA/ORCA2.6/dvb_gopt.out":    OrcaGeoOptTest_3_21g,
     "ORCA/ORCA2.6/dvb_sp.out":      OrcaSPTest_3_21g,
     "ORCA/ORCA2.6/dvb_td.out":      OrcaTDDFTTest_error,
-    "ORCA/ORCA2.6/dvb_ir.out":      OrcaIRTest,
+    "ORCA/ORCA2.6/dvb_ir.out":      OrcaIRTest_old_coordsOK,
 
     "ORCA/ORCA2.8/dvb_gopt.out":    OrcaGeoOptTest,
     "ORCA/ORCA2.8/dvb_sp.out":      GenericBasisTest,


### PR DESCRIPTION
This is a follow up to cclib/cclib#393 and cclib/cclib#397 and needs to be merged before cclib/cclib#402