### PR TITLE
Add ORCA example with mocoeffs glued together (from cclib/cclib#629)

### DIFF
--- a/regressionfiles.txt
+++ b/regressionfiles.txt
@@ -322,6 +322,7 @@ ORCA/ORCA3.0/stopiter_orca_scf_compact.out
 ORCA/ORCA3.0/stopiter_orca_scf_large.out
 ORCA/ORCA3.0/trithiolane_polar.out
 ORCA/ORCA4.0/1-ttt_td.out
+ORCA/ORCA4.0/invalid-literal-for-float.out
 ORCA/ORCA4.0/IrCl6_sp.out
 ORCA/ORCA4.0/CO2_freqs.out
 ORCA/ORCA4.0/H2-_CASSCF_opt.out


### PR DESCRIPTION
Regression data from cclib/cclib#629, courtesy of Felipe S. S. Schneider (@dudektria) needs to be submitted before cclib/cclib#630.