### PR TITLE
Adding outputfile corresponding to issue 962

### DIFF
--- a/regressionfiles.txt
+++ b/regressionfiles.txt
@@ -275,6 +275,7 @@ Gaussian/Gaussian09/water_gaussian.inp.log
 Gaussian/Gaussian16/naturalspinorbitals_parsing.log
 Gaussian/Gaussian16/output.txt.issue754.log
 Gaussian/Gaussian16/issue851.log
+Gaussian/Gaussian16/issue962.log
 Gaussian/Gaussian98/C_bigmult.log
 Gaussian/Gaussian98/NIST_CCCBDB_1himidaz_m21b0.out
 Gaussian/Gaussian98/NIST_CCCBDB_1himidaz_m23b6.out


### PR DESCRIPTION
Reverts cclib/cclib-data#139 and re-adds the regression file - which needs to be merged in after the fix is in (or right before).