### PR TITLE
NWChem: v6.0 with fixed-width mass-weighted Hessian

### DIFF
--- a/NWChem/NWChem6.0/dvb_ir_hf.out
+++ b/NWChem/NWChem6.0/dvb_ir_hf.out
@@ -1,0 +1,2949 @@
+    nwchem, len=6
+ dvb_ir.in, len=9
+ argument  1 = dvb_ir.in
+                                         
+                                         
+
+
+              Northwest Computational Chemistry Package (NWChem) 6.0
+              ------------------------------------------------------
+
+
+                    Environmental Molecular Sciences Laboratory
+                       Pacific Northwest National Laboratory
+                                Richland, WA 99352
+
+                              Copyright (c) 1994-2010
+                       Pacific Northwest National Laboratory
+                            Battelle Memorial Institute
+
+             NWChem is an open-source computational chemistry package
+                        distributed under the terms of the
+                      Educational Community License (ECL) 2.0
+             A copy of the license is included with this distribution
+                              in the LICENSE.TXT file
+
+                                  ACKNOWLEDGMENT
+                                  --------------
+
+            This software and its documentation were developed at the
+            EMSL at Pacific Northwest National Laboratory, a multiprogram
+            national laboratory, operated for the U.S. Department of Energy
+            by Battelle under Contract Number DE-AC05-76RL01830. Support
+            for this work was provided by the Department of Energy Office
+            of Biological and Environmental Research, Office of Basic
+            Energy Sciences, and the Office of Advanced Scientific Computing.
+
+
+           Job information
+           ---------------
+
+    hostname      = osmium
+    program       = nwchem
+    date          = Wed Oct 23 12:02:39 2024
+
+    compiled      = Tue_Nov_09_10:54:15_2010
+    source        = /home/d3y133/nwchem-releases/nwchem-6.0-linux
+    nwchem branch = 6.0
+    input         = dvb_ir.in
+    prefix        = dvb_ir.
+    data base     = ./dvb_ir.db
+    status        = startup
+    nproc         =        1
+    time left     =     -1s
+
+
+
+           Memory information
+           ------------------
+
+    heap     =  134217729 doubles =   1024.0 Mbytes
+    stack    =  134217729 doubles =   1024.0 Mbytes
+    global   =  268435456 doubles =   2048.0 Mbytes (distinct from heap & stack)
+    total    =  536870914 doubles =   4096.0 Mbytes
+    verify   = yes
+    hardfail = no 
+
+
+           Directory information
+           ---------------------
+
+  0 permanent = .
+  0 scratch   = .
+
+
+
+
+                                NWChem Input Module
+                                -------------------
+
+
+
+ Scaling coordinates for geometry "geometry" by  1.889725989
+ (inverse scale =  0.529177249)
+
+ C2H symmetry detected
+
+          ------
+          auto-z
+          ------
+
+
+                             Geometry "geometry" -> ""
+                             -------------------------
+
+ Output coordinates in angstroms (scale by  1.889725989 to convert to a.u.)
+
+  No.       Tag          Charge          X              Y              Z
+ ---- ---------------- ---------- -------------- -------------- --------------
+    1 C                    6.0000     0.22718562    -1.39293283     0.00000000
+    2 C                    6.0000     1.28896808    -0.48658405     0.00000000
+    3 C                    6.0000     1.06947876     0.87774341     0.00000000
+    4 C                    6.0000    -0.22718562     1.39293283     0.00000000
+    5 C                    6.0000    -1.28896808     0.48658405     0.00000000
+    6 C                    6.0000    -1.06947876    -0.87774341     0.00000000
+    7 H                    1.0000     2.30443310    -0.86173403     0.00000000
+    8 H                    1.0000     1.91843911     1.54733997     0.00000000
+    9 H                    1.0000    -2.30443310     0.86173403     0.00000000
+   10 H                    1.0000    -1.91843911    -1.54733997     0.00000000
+   11 C                    6.0000    -0.52058577     2.85994625     0.00000000
+   12 C                    6.0000     0.35579953     3.83839997     0.00000000
+   13 H                    1.0000    -1.57769586     3.10157149     0.00000000
+   14 H                    1.0000     0.04202054     4.87295155     0.00000000
+   15 H                    1.0000     1.42359617     3.67431499     0.00000000
+   16 C                    6.0000     0.52058577    -2.85994625     0.00000000
+   17 C                    6.0000    -0.35579953    -3.83839997     0.00000000
+   18 H                    1.0000     1.57769586    -3.10157149     0.00000000
+   19 H                    1.0000    -0.04202054    -4.87295155     0.00000000
+   20 H                    1.0000    -1.42359617    -3.67431499     0.00000000
+
+      Atomic Mass 
+      ----------- 
+
+      C                 12.000000
+      H                  1.007825
+
+
+ Effective nuclear repulsion energy (a.u.)     452.1489986121
+
+            Nuclear Dipole moment (a.u.) 
+            ----------------------------
+        X                 Y               Z
+ ---------------- ---------------- ----------------
+     0.0000000000     0.0000000000     0.0000000000
+
+      Symmetry information
+      --------------------
+
+ Group name             C2h       
+ Group number             21
+ Group order               4
+ No. of unique centers    10
+
+      Symmetry unique atoms
+
+     1    2    3    7    8   11   12   13   14   15
+
+
+
+                                Z-matrix (autoz)
+                                -------- 
+
+ Units are Angstrom for bonds and degrees for angles
+
+      Type          Name      I     J     K     L     M      Value
+      ----------- --------  ----- ----- ----- ----- ----- ----------
+    1 Stretch                  1     2                       1.39601
+    2 Stretch                  1     6                       1.39526
+    3 Stretch                  1    16                       1.49607
+    4 Stretch                  2     3                       1.38187
+    5 Stretch                  2     7                       1.08255
+    6 Stretch                  3     4                       1.39526
+    7 Stretch                  3     8                       1.08125
+    8 Stretch                  4     5                       1.39601
+    9 Stretch                  4    11                       1.49607
+   10 Stretch                  5     6                       1.38187
+   11 Stretch                  5     9                       1.08255
+   12 Stretch                  6    10                       1.08125
+   13 Stretch                 11    12                       1.31355
+   14 Stretch                 11    13                       1.08437
+   15 Stretch                 12    14                       1.08109
+   16 Stretch                 12    15                       1.08033
+   17 Stretch                 16    17                       1.31355
+   18 Stretch                 16    18                       1.08437
+   19 Stretch                 17    19                       1.08109
+   20 Stretch                 17    20                       1.08033
+   21 Bend                     1     2     3               121.34514
+   22 Bend                     1     2     7               119.23950
+   23 Bend                     1     6     5               120.80815
+   24 Bend                     1     6    10               120.06739
+   25 Bend                     1    16    17               126.83987
+   26 Bend                     1    16    18               114.18484
+   27 Bend                     2     1     6               117.84671
+   28 Bend                     2     1    16               119.17459
+   29 Bend                     2     3     4               120.80815
+   30 Bend                     2     3     8               119.12446
+   31 Bend                     3     2     7               119.41536
+   32 Bend                     3     4     5               117.84671
+   33 Bend                     3     4    11               122.97870
+   34 Bend                     4     3     8               120.06739
+   35 Bend                     4     5     6               121.34514
+   36 Bend                     4     5     9               119.23950
+   37 Bend                     4    11    12               126.83987
+   38 Bend                     4    11    13               114.18484
+   39 Bend                     5     4    11               119.17459
+   40 Bend                     5     6    10               119.12446
+   41 Bend                     6     1    16               122.97870
+   42 Bend                     6     5     9               119.41536
+   43 Bend                    11    12    14               121.27718
+   44 Bend                    11    12    15               123.11417
+   45 Bend                    12    11    13               118.97529
+   46 Bend                    14    12    15               115.60865
+   47 Bend                    16    17    19               121.27718
+   48 Bend                    16    17    20               123.11417
+   49 Bend                    17    16    18               118.97529
+   50 Bend                    19    17    20               115.60865
+   51 Torsion                  1     2     3     4           0.00000
+   52 Torsion                  1     2     3     8         180.00000
+   53 Torsion                  1     6     5     4           0.00000
+   54 Torsion                  1     6     5     9         180.00000
+   55 Torsion                  1    16    17    19         180.00000
+   56 Torsion                  1    16    17    20           0.00000
+   57 Torsion                  2     1     6     5           0.00000
+   58 Torsion                  2     1     6    10         180.00000
+   59 Torsion                  2     1    16    17         180.00000
+   60 Torsion                  2     1    16    18           0.00000
+   61 Torsion                  2     3     4     5           0.00000
+   62 Torsion                  2     3     4    11         180.00000
+   63 Torsion                  3     2     1     6           0.00000
+   64 Torsion                  3     2     1    16         180.00000
+   65 Torsion                  3     4     5     6           0.00000
+   66 Torsion                  3     4     5     9         180.00000
+   67 Torsion                  3     4    11    12           0.00000
+   68 Torsion                  3     4    11    13         180.00000
+   69 Torsion                  4     3     2     7         180.00000
+   70 Torsion                  4     5     6    10         180.00000
+   71 Torsion                  4    11    12    14         180.00000
+   72 Torsion                  4    11    12    15           0.00000
+   73 Torsion                  5     4     3     8         180.00000
+   74 Torsion                  5     4    11    12         180.00000
+   75 Torsion                  5     4    11    13           0.00000
+   76 Torsion                  5     6     1    16         180.00000
+   77 Torsion                  6     1     2     7         180.00000
+   78 Torsion                  6     1    16    17           0.00000
+   79 Torsion                  6     1    16    18         180.00000
+   80 Torsion                  6     5     4    11         180.00000
+   81 Torsion                  7     2     1    16           0.00000
+   82 Torsion                  7     2     3     8           0.00000
+   83 Torsion                  8     3     4    11           0.00000
+   84 Torsion                  9     5     4    11           0.00000
+   85 Torsion                  9     5     6    10           0.00000
+   86 Torsion                 10     6     1    16           0.00000
+   87 Torsion                 13    11    12    14           0.00000
+   88 Torsion                 13    11    12    15         180.00000
+   89 Torsion                 18    16    17    19           0.00000
+   90 Torsion                 18    16    17    20         180.00000
+
+
+            XYZ format geometry
+            -------------------
+    20
+ geometry
+ C                     0.22718562    -1.39293283     0.00000000
+ C                     1.28896808    -0.48658405     0.00000000
+ C                     1.06947876     0.87774341     0.00000000
+ C                    -0.22718562     1.39293283     0.00000000
+ C                    -1.28896808     0.48658405     0.00000000
+ C                    -1.06947876    -0.87774341     0.00000000
+ H                     2.30443310    -0.86173403     0.00000000
+ H                     1.91843911     1.54733997     0.00000000
+ H                    -2.30443310     0.86173403     0.00000000
+ H                    -1.91843911    -1.54733997     0.00000000
+ C                    -0.52058577     2.85994625     0.00000000
+ C                     0.35579953     3.83839997     0.00000000
+ H                    -1.57769586     3.10157149     0.00000000
+ H                     0.04202054     4.87295155     0.00000000
+ H                     1.42359617     3.67431499     0.00000000
+ C                     0.52058577    -2.85994625     0.00000000
+ C                    -0.35579953    -3.83839997     0.00000000
+ H                     1.57769586    -3.10157149     0.00000000
+ H                    -0.04202054    -4.87295155     0.00000000
+ H                    -1.42359617    -3.67431499     0.00000000
+
+ ==============================================================================
+                                internuclear distances
+ ------------------------------------------------------------------------------
+       center one      |      center two      | atomic units |  angstroms
+ ------------------------------------------------------------------------------
+    2 C                |   1 C                |     2.63808  |     1.39601
+    3 C                |   2 C                |     2.61136  |     1.38187
+    4 C                |   3 C                |     2.63666  |     1.39526
+    5 C                |   4 C                |     2.63808  |     1.39601
+    6 C                |   1 C                |     2.63666  |     1.39526
+    6 C                |   5 C                |     2.61136  |     1.38187
+    7 H                |   2 C                |     2.04572  |     1.08255
+    8 H                |   3 C                |     2.04326  |     1.08125
+    9 H                |   5 C                |     2.04572  |     1.08255
+   10 H                |   6 C                |     2.04326  |     1.08125
+   11 C                |   4 C                |     2.82715  |     1.49607
+   12 C                |  11 C                |     2.48226  |     1.31355
+   13 H                |  11 C                |     2.04917  |     1.08437
+   14 H                |  12 C                |     2.04296  |     1.08109
+   15 H                |  12 C                |     2.04153  |     1.08033
+   16 C                |   1 C                |     2.82715  |     1.49607
+   17 C                |  16 C                |     2.48226  |     1.31355
+   18 H                |  16 C                |     2.04917  |     1.08437
+   19 H                |  17 C                |     2.04296  |     1.08109
+   20 H                |  17 C                |     2.04153  |     1.08033
+ ------------------------------------------------------------------------------
+                         number of included internuclear distances:         20
+ ==============================================================================
+
+
+
+ ==============================================================================
+                                 internuclear angles
+ ------------------------------------------------------------------------------
+        center 1       |       center 2       |       center 3       |  degrees
+ ------------------------------------------------------------------------------
+    2 C                |   1 C                |   6 C                |   117.85
+    2 C                |   1 C                |  16 C                |   119.17
+    6 C                |   1 C                |  16 C                |   122.98
+    1 C                |   2 C                |   3 C                |   121.35
+    1 C                |   2 C                |   7 H                |   119.24
+    3 C                |   2 C                |   7 H                |   119.42
+    2 C                |   3 C                |   4 C                |   120.81
+    2 C                |   3 C                |   8 H                |   119.12
+    4 C                |   3 C                |   8 H                |   120.07
+    3 C                |   4 C                |   5 C                |   117.85
+    3 C                |   4 C                |  11 C                |   122.98
+    5 C                |   4 C                |  11 C                |   119.17
+    4 C                |   5 C                |   6 C                |   121.35
+    4 C                |   5 C                |   9 H                |   119.24
+    6 C                |   5 C                |   9 H                |   119.42
+    1 C                |   6 C                |   5 C                |   120.81
+    1 C                |   6 C                |  10 H                |   120.07
+    5 C                |   6 C                |  10 H                |   119.12
+    4 C                |  11 C                |  12 C                |   126.84
+    4 C                |  11 C                |  13 H                |   114.18
+   12 C                |  11 C                |  13 H                |   118.98
+   11 C                |  12 C                |  14 H                |   121.28
+   11 C                |  12 C                |  15 H                |   123.11
+   14 H                |  12 C                |  15 H                |   115.61
+    1 C                |  16 C                |  17 C                |   126.84
+    1 C                |  16 C                |  18 H                |   114.18
+   17 C                |  16 C                |  18 H                |   118.98
+   16 C                |  17 C                |  19 H                |   121.28
+   16 C                |  17 C                |  20 H                |   123.11
+   19 H                |  17 C                |  20 H                |   115.61
+ ------------------------------------------------------------------------------
+                            number of included internuclear angles:         30
+ ==============================================================================
+
+
+
+  library name resolved from: environment
+  library file name is: </home/eric/data/opt/apps/nwchem/6.0-binary/usr.local.lib.nwchem/libraries/>
+  
+
+
+ Summary of "ao basis" -> "" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ *                           sto-3g                   on all atoms 
+
+
+
+
+                   NWChem Nuclear Hessian and Frequency Analysis
+                   ---------------------------------------------
+
+
+
+                              NWChem Analytic Hessian
+                              -----------------------
+
+                      Basis "ao basis" -> "ao basis" (cartesian)
+                      -----
+  C (Carbon)
+  ----------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  7.16168370E+01  0.154329
+  1 S  1.30450960E+01  0.535328
+  1 S  3.53051220E+00  0.444635
+
+  2 S  2.94124940E+00 -0.099967
+  2 S  6.83483100E-01  0.399513
+  2 S  2.22289900E-01  0.700115
+
+  3 P  2.94124940E+00  0.155916
+  3 P  6.83483100E-01  0.607684
+  3 P  2.22289900E-01  0.391957
+
+  H (Hydrogen)
+  ------------
+            Exponent  Coefficients 
+       -------------- ---------------------------------------------------------
+  1 S  3.42525091E+00  0.154329
+  1 S  6.23913730E-01  0.535328
+  1 S  1.68855400E-01  0.444635
+
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ C                           sto-3g                  3        5   2s1p
+ H                           sto-3g                  1        1   1s
+
+
+                                 NWChem SCF Module
+                                 -----------------
+
+
+
+  ao basis        = "ao basis"
+  functions       =    60
+  atoms           =    20
+  closed shells   =    35
+  open shells     =     0
+  charge          =   0.00
+  wavefunction    = RHF 
+  input vectors   = atomic
+  output vectors  = ./dvb_ir.movecs
+  use symmetry    = F
+  symmetry adapt  = F
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ C                           sto-3g                  3        5   2s1p
+ H                           sto-3g                  1        1   1s
+
+
+
+ Forming initial guess at       0.4s
+
+
+      Superposition of Atomic Density Guess
+      -------------------------------------
+
+ Sum of atomic energies:        -376.44825176
+
+      Non-variational initial energy
+      ------------------------------
+
+ Total energy =    -379.964379
+ 1-e energy   =   -1413.610620
+ 2-e energy   =     581.497242
+ HOMO         =      -0.049009
+ LUMO         =       0.169016
+
+
+ Starting SCF solution at       0.8s
+
+
+
+ ----------------------------------------------
+         Quadratically convergent ROHF
+
+ Convergence threshold     :          1.000E-06
+ Maximum no. of iterations :           30
+ Final Fock-matrix accuracy:          1.000E-08
+ ----------------------------------------------
+
+
+              iter       energy          gnorm     gmax       time
+             ----- ------------------- --------- --------- --------
+                 1     -379.7132523830  7.59D-01  1.88D-01      1.4
+                 2     -379.7762574150  1.44D-01  4.15D-02      3.2
+                 3     -379.7779486904  5.98D-03  2.18D-03      5.0
+                 4     -379.7779548936  2.97D-05  8.35D-06      7.9
+                 5     -379.7779548937  5.98D-08  1.47D-08     11.4
+
+
+       Final RHF  results 
+       ------------------ 
+
+         Total SCF energy =   -379.777954893702
+      One-electron energy =  -1412.204493740054
+      Two-electron energy =    580.277540234233
+ Nuclear repulsion energy =    452.148998612118
+
+        Time for solution =     11.0s
+
+
+             Final eigenvalues
+             -----------------
+
+              1      
+    1  -11.0409
+    2  -11.0408
+    3  -11.0324
+    4  -11.0324
+    5  -11.0289
+    6  -11.0288
+    7  -11.0283
+    8  -11.0283
+    9  -11.0180
+   10  -11.0180
+   11   -1.1067
+   12   -1.0318
+   13   -0.9885
+   14   -0.9610
+   15   -0.9227
+   16   -0.8064
+   17   -0.7713
+   18   -0.7330
+   19   -0.7073
+   20   -0.6392
+   21   -0.6151
+   22   -0.5776
+   23   -0.5638
+   24   -0.5629
+   25   -0.5325
+   26   -0.5074
+   27   -0.4981
+   28   -0.4773
+   29   -0.4487
+   30   -0.4259
+   31   -0.4182
+   32   -0.3869
+   33   -0.3269
+   34   -0.2856
+   35   -0.2332
+   36    0.2070
+   37    0.2732
+   38    0.3186
+   39    0.4061
+   40    0.5375
+   41    0.5686
+   42    0.5828
+   43    0.6324
+   44    0.6349
+   45    0.6825
+
+                       ROHF Final Molecular Orbital Analysis
+                       -------------------------------------
+
+ Vector   11  Occ=2.000000D+00  E=-1.106673D+00
+              MO Center= -1.0D-13,  2.5D-13,  5.4D-16, r^2= 2.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    17      0.271017   4 C  s                 2      0.271017   1 C  s         
+    22      0.245740   5 C  s                 7      0.245740   2 C  s         
+    12      0.245627   3 C  s                27      0.245627   6 C  s         
+
+ Vector   12  Occ=2.000000D+00  E=-1.031757D+00
+              MO Center=  6.4D-14, -7.1D-13,  4.7D-17, r^2= 7.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      0.295363  16 C  s                36     -0.295363  11 C  s         
+     2      0.264556   1 C  s                17     -0.264556   4 C  s         
+    54      0.216172  17 C  s                41     -0.216172  12 C  s         
+
+ Vector   13  Occ=2.000000D+00  E=-9.884779D-01
+              MO Center= -2.4D-14,  4.2D-13,  3.0D-16, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    36      0.313045  11 C  s                49      0.313045  16 C  s         
+    41      0.309271  12 C  s                54      0.309271  17 C  s         
+
+ Vector   14  Occ=2.000000D+00  E=-9.609571D-01
+              MO Center=  1.7D-13,  7.4D-14, -1.8D-17, r^2= 3.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7      0.354296   2 C  s                22     -0.354296   5 C  s         
+    12      0.320670   3 C  s                27     -0.320670   6 C  s         
+
+ Vector   15  Occ=2.000000D+00  E=-9.226743D-01
+              MO Center= -1.3D-14, -6.8D-14,  8.3D-18, r^2= 8.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    54      0.282826  17 C  s                41     -0.282826  12 C  s         
+     2     -0.279987   1 C  s                17      0.279987   4 C  s         
+    27     -0.200980   6 C  s                12      0.200980   3 C  s         
+
+ Vector   16  Occ=2.000000D+00  E=-8.064234D-01
+              MO Center= -2.1D-14, -2.4D-13, -5.8D-17, r^2= 8.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      0.233410   3 C  s                27      0.233410   6 C  s         
+    41      0.226407  12 C  s                54      0.226407  17 C  s         
+    17     -0.207427   4 C  s                 2     -0.207427   1 C  s         
+    24     -0.166893   5 C  py                9      0.166893   2 C  py        
+    49     -0.156371  16 C  s                36     -0.156371  11 C  s         
+
+ Vector   17  Occ=2.000000D+00  E=-7.712625D-01
+              MO Center=  5.7D-14,  1.1D-13,  3.0D-18, r^2= 4.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     7      0.319559   2 C  s                22      0.319559   5 C  s         
+    18     -0.189492   4 C  px                3      0.189492   1 C  px        
+    14     -0.173879   3 C  py               29      0.173879   6 C  py        
+    33      0.172215   9 H  s                31      0.172215   7 H  s         
+    12     -0.165462   3 C  s                27     -0.165462   6 C  s         
+
+ Vector   18  Occ=2.000000D+00  E=-7.329963D-01
+              MO Center=  1.0D-13, -4.9D-13, -2.1D-16, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      0.293354  16 C  s                36     -0.293354  11 C  s         
+    54     -0.246608  17 C  s                41      0.246608  12 C  s         
+    58      0.177512  18 H  s                45     -0.177512  13 H  s         
+    47      0.166405  15 H  s                60     -0.166405  20 H  s         
+
+ Vector   19  Occ=2.000000D+00  E=-7.072559D-01
+              MO Center= -2.3D-14,  5.2D-13, -9.1D-17, r^2= 7.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    28      0.195997   6 C  px               13     -0.195997   3 C  px        
+    36     -0.180436  11 C  s                49     -0.180436  16 C  s         
+    23      0.178166   5 C  px                8     -0.178166   2 C  px        
+    32     -0.171307   8 H  s                34     -0.171307  10 H  s         
+    41      0.162953  12 C  s                54      0.162953  17 C  s         
+
+ Vector   20  Occ=2.000000D+00  E=-6.391909D-01
+              MO Center=  2.9D-14, -3.3D-13, -1.1D-16, r^2= 9.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    55      0.210520  17 C  px               42     -0.210520  12 C  px        
+    51     -0.182984  16 C  py               38      0.182984  11 C  py        
+    47     -0.181944  15 H  s                60     -0.181944  20 H  s         
+    58      0.153461  18 H  s                45      0.153461  13 H  s         
+
+ Vector   21  Occ=2.000000D+00  E=-6.151222D-01
+              MO Center=  5.0D-14,  3.3D-13,  2.6D-17, r^2= 1.0D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    50      0.216067  16 C  px               37      0.216067  11 C  px        
+    56     -0.215364  17 C  py               43     -0.215364  12 C  py        
+     9     -0.188113   2 C  py               24     -0.188113   5 C  py        
+    46     -0.187579  14 H  s                59      0.187579  19 H  s         
+    45     -0.156496  13 H  s                58      0.156496  18 H  s         
+
+ Vector   22  Occ=2.000000D+00  E=-5.776194D-01
+              MO Center= -9.4D-14, -1.3D-13, -1.3D-17, r^2= 6.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    31      0.234786   7 H  s                33     -0.234786   9 H  s         
+    32     -0.234760   8 H  s                34      0.234760  10 H  s         
+     8      0.227345   2 C  px               23      0.227345   5 C  px        
+     2     -0.221396   1 C  s                17      0.221396   4 C  s         
+    29     -0.177830   6 C  py               14     -0.177830   3 C  py        
+
+ Vector   23  Occ=2.000000D+00  E=-5.638389D-01
+              MO Center= -6.5D-15,  5.0D-13, -1.4D-18, r^2= 8.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    28      0.257060   6 C  px               13      0.257060   3 C  px        
+    55      0.246900  17 C  px               42      0.246900  12 C  px        
+    18     -0.216786   4 C  px                3     -0.216786   1 C  px        
+    60     -0.215142  20 H  s                47      0.215142  15 H  s         
+    51     -0.174165  16 C  py               38     -0.174165  11 C  py        
+
+ Vector   24  Occ=2.000000D+00  E=-5.628982D-01
+              MO Center= -3.7D-14, -2.5D-13,  9.3D-17, r^2= 1.4D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    56      0.337820  17 C  py               43     -0.337820  12 C  py        
+    59     -0.264459  19 H  s                46     -0.264459  14 H  s         
+    37      0.253726  11 C  px               50     -0.253726  16 C  px        
+    45     -0.153523  13 H  s                58     -0.153523  18 H  s         
+
+ Vector   25  Occ=2.000000D+00  E=-5.325205D-01
+              MO Center=  1.7D-14,  1.1D-13,  4.7D-18, r^2= 4.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    23      0.304422   5 C  px                8      0.304422   2 C  px        
+    31      0.255590   7 H  s                33     -0.255590   9 H  s         
+    29      0.226740   6 C  py               14      0.226740   3 C  py        
+    32      0.220983   8 H  s                34     -0.220983  10 H  s         
+    13      0.186270   3 C  px               28      0.186270   6 C  px        
+
+ Vector   26  Occ=2.000000D+00  E=-5.074081D-01
+              MO Center=  3.2D-13, -6.6D-13,  2.8D-17, r^2= 8.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    43      0.237612  12 C  py               56      0.237612  17 C  py        
+     9     -0.226856   2 C  py               24     -0.226856   5 C  py        
+    50     -0.210479  16 C  px               37     -0.210479  11 C  px        
+    14      0.192026   3 C  py               29      0.192026   6 C  py        
+    51     -0.185962  16 C  py               38     -0.185962  11 C  py        
+
+ Vector   27  Occ=2.000000D+00  E=-4.981374D-01
+              MO Center= -4.6D-13,  1.8D-13, -7.5D-16, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    42      0.295871  12 C  px               55     -0.295871  17 C  px        
+    60      0.268805  20 H  s                47      0.268805  15 H  s         
+    37     -0.205404  11 C  px               50      0.205404  16 C  px        
+    45      0.201168  13 H  s                58      0.201168  18 H  s         
+    33     -0.156846   9 H  s                31     -0.156846   7 H  s         
+
+ Vector   28  Occ=2.000000D+00  E=-4.772792D-01
+              MO Center= -7.2D-14,  1.3D-14,  3.7D-16, r^2= 3.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      0.328876   4 C  pz                5      0.328876   1 C  pz        
+    25      0.301996   5 C  pz               10      0.301996   2 C  pz        
+    30      0.301190   6 C  pz               15      0.301190   3 C  pz        
+    39      0.159153  11 C  pz               52      0.159153  16 C  pz        
+
+ Vector   29  Occ=2.000000D+00  E=-4.486789D-01
+              MO Center= -9.5D-14,  5.8D-13,  5.3D-18, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    45      0.255071  13 H  s                58     -0.255071  18 H  s         
+     4     -0.249357   1 C  py               19     -0.249357   4 C  py        
+    47      0.227216  15 H  s                60     -0.227216  20 H  s         
+    46     -0.218961  14 H  s                59      0.218961  19 H  s         
+    37     -0.211820  11 C  px               50     -0.211820  16 C  px        
+
+ Vector   30  Occ=2.000000D+00  E=-4.259332D-01
+              MO Center=  1.1D-13, -7.5D-14,  7.9D-17, r^2= 4.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    32      0.283894   8 H  s                34      0.283894  10 H  s         
+     3      0.255125   1 C  px               18     -0.255125   4 C  px        
+     8     -0.228167   2 C  px               23      0.228167   5 C  px        
+     9     -0.217172   2 C  py               24      0.217172   5 C  py        
+    28     -0.211385   6 C  px               13      0.211385   3 C  px        
+
+ Vector   31  Occ=2.000000D+00  E=-4.182141D-01
+              MO Center= -5.8D-14, -1.1D-13,  2.7D-17, r^2= 7.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    51      0.219470  16 C  py               38     -0.219470  11 C  py        
+    19      0.216681   4 C  py                4     -0.216681   1 C  py        
+    33     -0.215467   9 H  s                31     -0.215467   7 H  s         
+    28     -0.205981   6 C  px               13      0.205981   3 C  px        
+     3      0.200239   1 C  px               18     -0.200239   4 C  px        
+
+ Vector   32  Occ=2.000000D+00  E=-3.868615D-01
+              MO Center=  2.2D-15, -7.1D-15, -3.4D-17, r^2= 8.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    52      0.381771  16 C  pz               39     -0.381771  11 C  pz        
+    20     -0.312269   4 C  pz                5      0.312269   1 C  pz        
+    57      0.310309  17 C  pz               44     -0.310309  12 C  pz        
+
+ Vector   33  Occ=2.000000D+00  E=-3.269296D-01
+              MO Center= -8.3D-14,  5.4D-14, -1.9D-16, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    44      0.426172  12 C  pz               57      0.426172  17 C  pz        
+    39      0.414985  11 C  pz               52      0.414985  16 C  pz        
+    30     -0.158725   6 C  pz               15     -0.158725   3 C  pz        
+    25     -0.158591   5 C  pz               10     -0.158591   2 C  pz        
+
+ Vector   34  Occ=2.000000D+00  E=-2.856037D-01
+              MO Center=  1.5D-13,  1.1D-14, -4.7D-17, r^2= 2.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      0.460789   3 C  pz               30     -0.460789   6 C  pz        
+    10      0.459023   2 C  pz               25     -0.459023   5 C  pz        
+
+ Vector   35  Occ=2.000000D+00  E=-2.332206D-01
+              MO Center=  9.0D-15, -5.3D-14,  4.5D-17, r^2= 6.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      0.420777   4 C  pz                5     -0.420777   1 C  pz        
+    57      0.350509  17 C  pz               44     -0.350509  12 C  pz        
+    10     -0.233526   2 C  pz               25      0.233526   5 C  pz        
+    30     -0.232138   6 C  pz               15      0.232138   3 C  pz        
+    52      0.216643  16 C  pz               39     -0.216643  11 C  pz        
+
+ Vector   36  Occ=0.000000D+00  E= 2.069590D-01
+              MO Center=  2.0D-15, -1.6D-14,  1.7D-16, r^2= 7.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.479196   1 C  pz               20      0.479196   4 C  pz        
+    57     -0.411126  17 C  pz               44     -0.411126  12 C  pz        
+    15     -0.284393   3 C  pz               30     -0.284393   6 C  pz        
+    25     -0.250517   5 C  pz               10     -0.250517   2 C  pz        
+    39      0.249742  11 C  pz               52      0.249742  16 C  pz        
+
+ Vector   37  Occ=0.000000D+00  E= 2.731963D-01
+              MO Center= -1.6D-13, -6.8D-15, -1.2D-17, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    25      0.583602   5 C  pz               10      0.583602   2 C  pz        
+    30     -0.559964   6 C  pz               15     -0.559964   3 C  pz        
+
+ Vector   38  Occ=0.000000D+00  E= 3.186210D-01
+              MO Center=  8.7D-14,  3.3D-14,  2.7D-16, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    44      0.537719  12 C  pz               57     -0.537719  17 C  pz        
+    39     -0.531801  11 C  pz               52      0.531801  16 C  pz        
+    10     -0.221759   2 C  pz               25      0.221759   5 C  pz        
+    15      0.216129   3 C  pz               30     -0.216129   6 C  pz        
+
+ Vector   39  Occ=0.000000D+00  E= 4.060615D-01
+              MO Center=  4.0D-15, -5.7D-14,  3.2D-16, r^2= 8.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    52      0.539468  16 C  pz               39      0.539468  11 C  pz        
+     5     -0.472294   1 C  pz               20     -0.472294   4 C  pz        
+    57     -0.416314  17 C  pz               44     -0.416314  12 C  pz        
+    30      0.189483   6 C  pz               15      0.189483   3 C  pz        
+    25      0.162234   5 C  pz               10      0.162234   2 C  pz        
+
+ Vector   40  Occ=0.000000D+00  E= 5.375256D-01
+              MO Center=  5.9D-14,  3.3D-14,  1.2D-16, r^2= 3.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    20      0.545453   4 C  pz                5     -0.545453   1 C  pz        
+    15     -0.479469   3 C  pz               30      0.479469   6 C  pz        
+    10      0.477131   2 C  pz               25     -0.477131   5 C  pz        
+    39     -0.274974  11 C  pz               52      0.274974  16 C  pz        
+    44      0.158164  12 C  pz               57     -0.158164  17 C  pz        
+
+ Vector   41  Occ=0.000000D+00  E= 5.685549D-01
+              MO Center= -2.8D-13,  1.5D-12, -2.7D-16, r^2= 8.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    33      0.416952   9 H  s                31      0.416952   7 H  s         
+    32      0.415631   8 H  s                34      0.415631  10 H  s         
+    17     -0.396160   4 C  s                 2     -0.396160   1 C  s         
+    46      0.352166  14 H  s                59      0.352166  19 H  s         
+    38     -0.349945  11 C  py               51      0.349945  16 C  py        
+
+ Vector   42  Occ=0.000000D+00  E= 5.828069D-01
+              MO Center=  5.7D-13, -1.1D-12, -2.8D-17, r^2= 1.0D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    58      0.433734  18 H  s                45     -0.433734  13 H  s         
+    50     -0.355182  16 C  px               37     -0.355182  11 C  px        
+     8     -0.338823   2 C  px               23     -0.338823   5 C  px        
+    60     -0.337980  20 H  s                47      0.337980  15 H  s         
+    59      0.321942  19 H  s                46     -0.321942  14 H  s         
+
+ Vector   43  Occ=0.000000D+00  E= 6.323686D-01
+              MO Center= -3.4D-13, -6.6D-13,  1.7D-17, r^2= 6.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      0.533870  16 C  s                36     -0.533870  11 C  s         
+    34      0.462399  10 H  s                32     -0.462399   8 H  s         
+     4      0.456260   1 C  py               19      0.456260   4 C  py        
+    29      0.334378   6 C  py               14      0.334378   3 C  py        
+    51      0.321178  16 C  py               38      0.321178  11 C  py        
+
+ Vector   44  Occ=0.000000D+00  E= 6.348794D-01
+              MO Center=  6.8D-13, -1.9D-13, -2.0D-17, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    58      0.583580  18 H  s                45      0.583580  13 H  s         
+    36     -0.409874  11 C  s                49     -0.409874  16 C  s         
+    47     -0.390079  15 H  s                60     -0.390079  20 H  s         
+     7      0.386409   2 C  s                22      0.386409   5 C  s         
+    50     -0.336511  16 C  px               37      0.336511  11 C  px        
+
+ Vector   45  Occ=0.000000D+00  E= 6.824801D-01
+              MO Center=  2.0D-11,  7.9D-11, -5.0D-18, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    41      0.721224  12 C  s                54      0.721224  17 C  s         
+    12      0.573372   3 C  s                27      0.573372   6 C  s         
+    47     -0.554580  15 H  s                60     -0.554580  20 H  s         
+     7     -0.419344   2 C  s                22     -0.419344   5 C  s         
+    46     -0.379491  14 H  s                59     -0.379491  19 H  s         
+
+
+ center of mass
+ --------------
+ x =   0.00000000 y =   0.00000000 z =   0.00000000
+
+ moments of inertia (a.u.)
+ ------------------
+        2576.272265588504           0.000000000000           0.000000000000
+           0.000000000000         376.156742222134           0.000000000000
+           0.000000000000           0.000000000000        2952.429007810638
+
+  Mulliken analysis of the total density
+  --------------------------------------
+
+    Atom       Charge   Shell Charges
+ -----------   ------   -------------------------------------------------------
+    1 C    6     6.00   1.99  1.12  2.88
+    2 C    6     6.06   1.99  1.13  2.94
+    3 C    6     6.06   1.99  1.13  2.94
+    4 C    6     6.00   1.99  1.12  2.88
+    5 C    6     6.06   1.99  1.13  2.94
+    6 C    6     6.06   1.99  1.13  2.94
+    7 H    1     0.94   0.94
+    8 H    1     0.94   0.94
+    9 H    1     0.94   0.94
+   10 H    1     0.94   0.94
+   11 C    6     6.06   1.99  1.14  2.93
+   12 C    6     6.13   1.99  1.15  2.99
+   13 H    1     0.94   0.94
+   14 H    1     0.94   0.94
+   15 H    1     0.94   0.94
+   16 C    6     6.06   1.99  1.14  2.93
+   17 C    6     6.13   1.99  1.15  2.99
+   18 H    1     0.94   0.94
+   19 H    1     0.94   0.94
+   20 H    1     0.94   0.94
+
+       Multipole analysis of the density wrt the origin
+       ------------------------------------------------
+
+     L   x y z        total         open         nuclear
+     -   - - -        -----         ----         -------
+     0   0 0 0      0.000000      0.000000     70.000000
+
+     1   1 0 0      0.000000      0.000000      0.000000
+     1   0 1 0      0.000000      0.000000      0.000000
+     1   0 0 1      0.000000      0.000000      0.000000
+
+     2   2 0 0    -38.489240      0.000000    235.940038
+     2   1 1 0     -0.093687      0.000000      5.402683
+     2   1 0 1      0.000000      0.000000      0.000000
+     2   0 2 0    -39.168479      0.000000   1465.302231
+     2   0 1 1      0.000000      0.000000      0.000000
+     2   0 0 2    -43.441498      0.000000      0.000000
+
+
+ HESSIAN: the one electron contributions are done in       0.3s
+
+
+ HESSIAN: 2-el 1st deriv. term done in                     2.6s
+
+
+ HESSIAN: 2-el 2nd deriv. term done in                     7.6s
+
+  stpr_wrt_fd_from_sq: overwrite of existing file:./dvb_ir.hess
+ stpr_wrt_fd_dipole: overwrite of existing file./dvb_ir.fd_ddipole
+
+ HESSIAN: the two electron contributions are done in      10.2s
+
+                                NWChem CPHF Module
+                                ------------------
+
+
+  scftype          =     RHF 
+  nclosed          =       35
+  nopen            =        0
+  variables        =      875
+  # of vectors     =       60
+  tolerance        = 0.10D-03
+  level shift      = 0.00D+00
+  max iterations   =       50
+  max subspace     =      600
+
+
+
+Iterative solution of linear equations
+  No. of variables      875
+  No. of equations       60
+  Maximum subspace      600
+        Iterations       50
+       Convergence  1.0D-04
+        Start time     25.1
+
+
+   iter   nsub   residual    time
+   ----  ------  --------  ---------
+     1     60    1.39D-01      26.3
+     2    120    2.06D-02      27.4
+     3    180    1.15D-03      28.5
+     4    240    9.32D-05      29.7
+ HESSIAN: the CPHF contributions are done
+  stpr_wrt_fd_from_sq: overwrite of existing file:./dvb_ir.hess
+ stpr_wrt_fd_dipole: overwrite of existing file./dvb_ir.fd_ddipole
+ HESSIAN: the Hessian is done
+
+
+  Vibrational analysis via the FX method 
+
+  See chapter 2 in "Molecular Vibrations" by Wilson, Decius and Cross
+
+  Vib: Default input used 
+
+  Nuclear Hessian passed symmetry test 
+
+
+
+ ---------------------------- Atom information ----------------------------
+     atom    #        X              Y              Z            mass
+ --------------------------------------------------------------------------
+    C        1  4.2931857D-01 -2.6322614D+00  0.0000000D+00  1.2000000D+01
+    C        2  2.4357965D+00 -9.1951053D-01  0.0000000D+00  1.2000000D+01
+    C        3  2.0210218D+00  1.6586945D+00  0.0000000D+00  1.2000000D+01
+    C        4 -4.2931857D-01  2.6322614D+00  0.0000000D+00  1.2000000D+01
+    C        5 -2.4357965D+00  9.1951053D-01  0.0000000D+00  1.2000000D+01
+    C        6 -2.0210218D+00 -1.6586945D+00  0.0000000D+00  1.2000000D+01
+    H        7  4.3547471D+00 -1.6284412D+00  0.0000000D+00  1.0078250D+00
+    H        8  3.6253242D+00  2.9240486D+00  0.0000000D+00  1.0078250D+00
+    H        9 -4.3547471D+00  1.6284412D+00  0.0000000D+00  1.0078250D+00
+    H       10 -3.6253242D+00 -2.9240486D+00  0.0000000D+00  1.0078250D+00
+    C       11 -9.8376446D-01  5.4045148D+00  0.0000000D+00  1.2000000D+01
+    C       12  6.7236362D-01  7.2535242D+00  0.0000000D+00  1.2000000D+01
+    H       13 -2.9814129D+00  5.8611202D+00  0.0000000D+00  1.0078250D+00
+    H       14  7.9407301D-02  9.2085432D+00  0.0000000D+00  1.0078250D+00
+    H       15  2.6902067D+00  6.9434485D+00  0.0000000D+00  1.0078250D+00
+    C       16  9.8376446D-01 -5.4045148D+00  0.0000000D+00  1.2000000D+01
+    C       17 -6.7236362D-01 -7.2535242D+00  0.0000000D+00  1.2000000D+01
+    H       18  2.9814129D+00 -5.8611202D+00  0.0000000D+00  1.0078250D+00
+    H       19 -7.9407301D-02 -9.2085432D+00  0.0000000D+00  1.0078250D+00
+    H       20 -2.6902067D+00 -6.9434485D+00  0.0000000D+00  1.0078250D+00
+ --------------------------------------------------------------------------
+
+
+
+
+          ----------------------------------------------------
+          MASS-WEIGHTED NUCLEAR HESSIAN (Hartree/Bohr/Bohr/Kamu)
+          ----------------------------------------------------
+
+
+              1           2           3           4           5           6           7           8           9          10
+   ----- ----- ----- ----- -----
+    1   7.05014D+01
+    2  -1.09211D+00 7.26269D+01
+    3   3.97190D-14-2.57643D-15 1.69348D+01
+    4  -2.61766D+01-1.48427D+01 6.28060D-14 8.19411D+01
+    5  -1.21861D+00-2.17763D+01 2.09707D-14-5.84301D+00 7.29077D+01
+    6  -7.67560D-14 5.60385D-15-7.33654D+00 4.66435D-14-4.35855D-14 1.55444D+01
+    7   9.47737D+00-5.03111D-01-1.45267D-14-1.67947D+01-4.48182D+00 9.62267D-14 7.78893D+01
+    8  -1.21875D+01-5.69370D+00 3.93073D-14 1.03368D+01-3.49961D+01-5.72392D-14 7.67660D+00 7.70056D+01
+    9   7.66244D-15-6.57017D-14 8.94745D-01-4.86099D-14 8.25937D-14-7.03678D+00 8.64805D-14-2.11213D-14 1.55689D+01
+   10  -1.35564D+01-2.39734D+00 9.42485D-14 4.16535D+00 1.56893D+01-7.81826D-14-3.07661D+01-1.61525D+00 3.51046D-15 7.05014D+01
+   11  -2.39731D+00 5.21295D-01 4.40707D-14 3.91634D+00-2.29222D-01 2.03522D-14 1.16007D+01-1.73496D+01 1.72059D-13-1.09211D+00
+   12  -5.10530D-14-1.53789D-14-1.01781D+00-3.91893D-14-2.96980D-14 8.88893D-01-4.91369D-14 6.92411D-14-7.40471D+00 1.10520D-13
+   13   4.16539D+00 3.91626D+00-7.25694D-14-1.65684D+00-4.53830D+00 3.12342D-14-6.90560D+00 2.25760D+00 8.08841D-15-2.61766D+01
+   14   1.56892D+01-2.29290D-01-1.69008D-13-4.53836D+00-1.27492D+01 6.17217D-14-8.58215D+00 1.17747D+01-1.51479D-13-1.21861D+00
+   15  -5.12811D-14-6.50887D-14 8.88919D-01 1.82765D-14 7.16959D-14-9.01784D-01-1.88631D-14-6.87287D-14 8.25239D-01 1.34663D-13
+   16  -3.07662D+01 1.16007D+01-7.16923D-14-6.90564D+00-8.58224D+00-2.20815D-14-5.41936D+00 6.88915D+00-4.23480D-14 9.47737D+00
+   17  -1.61514D+00-1.73496D+01 5.43208D-14 2.25761D+00 1.17747D+01 2.44582D-14 6.88910D+00-8.64421D+00 2.49578D-14-1.21875D+01
+   18   9.95273D-14 9.14562D-14-7.40477D+00 5.02602D-14 3.04466D-14 8.25196D-01 6.61393D-15-8.02164D-14-8.35506D-01-6.67000D-14
+   19  -4.69783D+00 4.70130D+00-3.28970D-14-1.22580D+02 3.64921D+01-1.07749D-13 8.13445D-01-2.23943D+00 1.34645D-13 1.97967D-01
+   20  -7.98530D+00 3.67128D+00-1.98519D-13 3.66393D+01-3.67393D+01 6.26464D-14 1.13272D+01-1.72561D+00 1.08988D-13-3.71667D-01
+   21  -1.73160D-13-6.89291D-14 1.16497D+00-1.94863D-15-6.25944D-14-1.52113D+01-1.45203D-13 2.19230D-13 1.51687D+00 2.28194D-13
+   22  -2.90613D-02 4.53402D-01-1.65205D-14 3.26685D+00 3.86873D+00 5.48650D-14-9.34219D+01-5.53142D+01 2.94640D-14-4.62863D+00
+   23   1.02479D+00-1.60849D+00-3.64162D-14-9.82109D+00-4.27976D+00-2.19770D-15-5.50435D+01-6.66432D+01-2.01710D-14 4.92989D+00
+   24   9.63757D-14 3.69993D-14 3.11396D+00-1.22539D-15-1.56136D-13 1.62713D+00-2.30869D-14 8.57134D-14-1.53630D+01 1.78899D-14
+   25   1.97967D-01 1.47973D-01-2.99142D-14 5.39076D-01-3.21177D-01 4.78245D-14-8.31128D-01-1.37526D+00-3.84529D-14-4.69783D+00
+   26  -3.71667D-01-1.91161D+00 2.05514D-14-2.67318D-01-1.28977D-01-2.20740D-14-8.24551D-01-1.22795D+00 2.43060D-14-7.98530D+00
+   27  -9.39569D-15 1.05413D-13 3.09271D+00 3.40586D-14-4.46530D-14-2.69509D-01-9.02782D-15 2.51690D-14 2.76130D+00 5.09095D-14
+   28  -4.62863D+00-7.63654D+00 1.24167D-13-1.50039D+00 1.30064D+00-1.71000D-14 2.92529D-01 4.31642D-01 6.29110D-14-2.90613D-02
+   29   4.92989D+00 4.55354D+00 3.25201D-16 7.67269D-01-5.59924D-01-4.08239D-14 4.18406D-01 9.84986D-02 4.12856D-14 1.02479D+00
+   30   2.31136D-14 1.70999D-13 1.25246D+00 6.26248D-15-8.05368D-14 2.87557D+00 3.37690D-14-2.72969D-14-2.75669D-01-1.05726D-13
+   31   2.44932D-02-1.31582D-01-1.40442D-14-7.00333D-01 4.23591D-02-1.49620D-14 1.91672D-01 3.33172D+00 4.75285D-14-1.22204D+01
+   32   5.50193D-02-3.12389D-01-2.21596D-14 1.61502D-01 5.92348D-01-2.81400D-14 1.38985D+00-1.87486D+00-3.86918D-14 2.87391D+00
+   33   1.17498D-14-4.43407D-15-8.91164D-02-9.85573D-15-2.61666D-14 7.54458D-01 5.48436D-14 2.79941D-14 3.94627D-01-1.09244D-13
+   34  -1.28952D-02 1.14825D-01 1.70898D-14-1.53146D-02-1.72811D-01 5.46021D-15-3.22040D-01 3.49021D-01 1.22645D-14 1.64349D+00
+   35  -8.17689D-02 7.88156D-02 2.54867D-15-1.32849D-01-5.44205D-02 3.57602D-15-4.36246D-01 2.95316D-01 3.37906D-14-2.29595D+00
+   36   3.08754D-15-3.57566D-15-2.18946D-03-3.71349D-16 1.92418D-14-4.49625D-02-1.98819D-14 1.88996D-15 2.99695D-02 1.22493D-14
+   37   3.93309D-02 8.29628D-03 1.65307D-14-3.44397D-03-5.86990D-02 3.89254D-15 8.99068D-02 1.65312D-02-3.85843D-14-5.52312D-01
+   38  -5.18330D-02 2.91894D-02 1.42891D-14 5.34570D-01 1.10050D-01 4.06695D-14-5.21486D-01-1.89154D+00-2.85319D-14 1.06631D+01
+   39   2.50149D-14 2.55362D-14 2.87713D-02-2.61817D-14-5.43032D-14-4.52153D-02 9.53619D-14-3.37939D-14 6.05717D-01-5.59152D-14
+   40   2.88050D-02 3.91137D-03-1.07407D-14 4.29133D-02 1.00014D-02 9.83156D-15-1.66178D-01 3.82576D-02 3.66110D-16-1.14656D+00
+   41  -6.39234D-02 5.68991D-02 1.34896D-15 9.25409D-02 5.26511D-03-6.39587D-15-8.08658D-02 1.76647D-01-1.67191D-14-8.96950D-01
+   42  -7.50534D-15 2.22919D-14 4.09027D-02-4.93068D-15-6.52119D-14-1.35988D-01 3.69408D-14 1.62466D-14-1.56275D-01-7.43124D-14
+   43  -4.29651D-02 5.84030D-02-1.57061D-14 1.48823D-01 3.22601D-03 1.51034D-14 6.76080D-02 3.19652D-01-6.74426D-14 2.04338D-01
+   44   1.57437D-02-2.20096D-02 1.75242D-14 3.40137D-02 3.95076D-02-3.11995D-14-2.58039D-01-3.43020D-01-3.07003D-15 5.69845D-01
+   45   1.29785D-14-5.04029D-14-2.26751D-02 4.15665D-14 1.76808D-13 6.57616D-02-4.88310D-14-9.75762D-14 6.70904D-02 8.31076D-14
+   46  -1.22204D+01 5.11956D+00-3.43213D-14 7.43323D-01-3.16667D+00-3.22597D-14-4.44066D-01-6.75975D-02 2.44690D-14 2.44932D-02
+   47   2.87391D+00-2.49923D+01-8.28051D-14-2.00324D-01-3.68312D+00-5.88172D-14-5.65363D-01 4.53973D-01 3.86705D-15 5.50193D-02
+   48   3.73918D-14-8.31584D-14-6.92055D+00-1.39029D-14-5.07586D-14 4.94964D-01-2.41648D-14 5.16347D-14 7.89090D-01 5.13560D-15
+   49   1.64349D+00-6.67610D-01-1.41281D-14-2.41869D-03 5.80504D-01 2.11854D-14 1.52785D-01-1.12197D-01-1.60775D-14-1.28952D-02
+   50  -2.29595D+00-3.78983D+00 1.87547D-14 5.52918D-01 6.72867D-02 1.13756D-14 6.30079D-02-2.29484D-01 2.06520D-15-8.17689D-02
+   51  -1.79988D-14 2.76328D-14 7.02038D-01-8.55864D-15-1.13630D-14 8.23959D-02 2.99111D-15-6.77341D-15-2.01076D-02-5.06083D-15
+   52  -5.52312D-01-1.44740D+00 5.66126D-14 4.65508D-01-7.35926D-01-1.39635D-15-6.80030D-02-1.40240D-02 2.07287D-15 3.93309D-02
+   53   1.06631D+01-1.85648D+00-1.26184D-14 6.03744D-01 7.28398D-01 2.37132D-14 5.24254D-02 4.30116D-02-4.15803D-15-5.18330D-02
+   54   3.39277D-14 4.69770D-14 1.21937D+00-1.17755D-14 2.27137D-14-2.02550D-01 1.16191D-14-3.26442D-14-1.83894D-02-9.80753D-15
+   55  -1.14656D+00-3.58937D-01 1.16759D-14 2.45529D-01-3.23032D-01-9.31674D-15-7.29282D-02 1.36049D-03 2.04382D-14 2.88051D-02
+   56  -8.96950D-01-2.84894D-01-4.01017D-15 1.76191D-01-9.53562D-02-1.11566D-14-1.41208D-01-8.51293D-02-7.87008D-15-6.39233D-02
+   57  -2.64803D-14 7.43168D-14 4.65155D+00-1.78736D-14 6.79916D-14-4.07027D-02 4.92899D-14-7.55987D-14-2.98064D-01-1.82663D-14
+   58   2.04338D-01 2.15294D-01 1.45777D-14-9.42608D-03 1.05884D-01-5.23447D-15-7.52186D-02-3.67381D-02-4.68679D-15-4.29651D-02
+   59   5.69845D-01 5.34879D-01 4.76173D-15-8.60670D-03 1.72395D-02-6.05127D-15 3.86868D-02 2.61287D-02 5.57398D-15 1.57437D-02
+   60   1.80605D-14 3.43839D-14-2.98082D+00 1.75807D-15-5.38117D-14 5.24241D-02-2.38498D-14 5.40228D-14 9.96993D-02 8.68500D-15
+
+
+             11          12          13          14          15          16          17          18          19          20
+   ----- ----- ----- ----- -----
+   11   7.26269D+01
+   12   1.28400D-13 1.69348D+01
+   13  -1.48427D+01-3.80423D-14 8.19411D+01
+   14  -2.17763D+01 5.19760D-14-5.84301D+00 7.29077D+01
+   15   4.34419D-14-7.33654D+00-5.22700D-14-7.54110D-14 1.55444D+01
+   16  -5.03111D-01-9.42380D-14-1.67947D+01-4.48182D+00 6.24072D-14 7.78893D+01
+   17  -5.69370D+00 5.77108D-14 1.03368D+01-3.49961D+01-1.21828D-13 7.67660D+00 7.70056D+01
+   18  -3.96012D-14 8.94745D-01-3.12153D-14-7.45711D-14-7.03678D+00-8.29048D-15 4.12039D-14 1.55689D+01
+   19   1.47973D-01-3.70205D-14 5.39076D-01-3.21177D-01-5.26481D-14-8.31128D-01-1.37526D+00 9.41827D-14 4.33742D+02
+   20  -1.91161D+00 2.49583D-14-2.67318D-01-1.28977D-01-1.33359D-14-8.24551D-01-1.22795D+00 1.82265D-14-1.31850D+02 1.27130D+02
+   21   2.07988D-14 3.09271D+00-6.30606D-14 8.13058D-15-2.69509D-01 1.33561D-13-1.32384D-13 2.76130D+00 3.13903D-13-1.59057D-13
+   22  -7.63654D+00 3.77667D-14-1.50039D+00 1.30064D+00 8.72973D-14 2.92529D-01 4.31642D-01 7.74602D-15 1.48038D+00-8.36234D-02
+   23   4.55354D+00 8.67765D-14 7.67269D-01-5.59924D-01 3.56162D-14 4.18406D-01 9.84986D-02-4.87996D-14-1.44691D-01 2.35864D+00
+   24   6.80060D-14 1.25246D+00-2.11210D-15-6.63554D-14 2.87557D+00-7.61723D-14 4.71077D-14-2.75669D-01 3.57417D-14-4.96331D-14
+   25   4.70130D+00 1.11147D-13-1.22580D+02 3.64921D+01 2.78879D-14 8.13445D-01-2.23943D+00-1.43276D-13-3.45760D-01 2.25593D-01
+   26   3.67128D+00-4.87514D-14 3.66393D+01-3.67393D+01 2.84878D-14 1.13272D+01-1.72561D+00 2.57229D-14 2.25628D-01 1.07628D-01
+   27  -7.29783D-14 1.16497D+00 7.70776D-15-8.05243D-14-1.52113D+01-1.24452D-13 1.64014D-14 1.51687D+00-5.47645D-14 1.06877D-14
+   28   4.53402D-01 9.17735D-15 3.26685D+00 3.86873D+00-1.84052D-13-9.34219D+01-5.53142D+01 8.20779D-14-7.28807D-01-1.26944D+00
+   29  -1.60849D+00-4.93081D-14-9.82109D+00-4.27976D+00-2.29848D-14-5.50435D+01-6.66432D+01-3.12435D-14 8.28737D-01 7.31987D-01
+   30  -5.21401D-14 3.11396D+00-1.30391D-14 8.40339D-14 1.62713D+00 1.91562D-15-3.04131D-14-1.53630D+01-5.35898D-14 8.36012D-14
+   31   5.11957D+00-2.18773D-14 7.43323D-01-3.16667D+00-2.51068D-14-4.44066D-01-6.75975D-02-2.13359D-15 8.82862D-02 4.71274D-01
+   32  -2.49923D+01-3.86930D-14-2.00324D-01-3.68312D+00 1.74799D-15-5.65363D-01 4.53973D-01-1.10133D-13-5.75158D-02 6.80154D-02
+   33   1.28410D-13-6.92055D+00-6.32431D-15-4.11604D-14 4.94964D-01-7.93131D-15-3.04264D-15 7.89090D-01-1.56830D-14 1.06918D-14
+   34  -6.67610D-01 9.12728D-14-2.41869D-03 5.80504D-01-1.08286D-14 1.52785D-01-1.12197D-01 1.18117D-14-1.64895D-02 1.53467D-02
+   35  -3.78983D+00 1.85031D-14 5.52918D-01 6.72867D-02-1.32771D-14 6.30079D-02-2.29484D-01 2.01780D-14 2.59645D-02 1.41787D-02
+   36  -1.11670D-13 7.02038D-01 1.88352D-14 2.16745D-14 8.23957D-02 3.46058D-15 3.56412D-15-2.01074D-02-1.68560D-15-1.27875D-15
+   37  -1.44740D+00 3.87902D-14 4.65508D-01-7.35926D-01 7.13430D-14-6.80030D-02-1.40240D-02-2.21096D-14 1.40705D-02 4.31819D-02
+   38  -1.85648D+00 1.54156D-13 6.03744D-01 7.28398D-01 9.64150D-15 5.24254D-02 4.30116D-02 2.04700D-14-1.33696D-02-5.08340D-01
+   39   3.94411D-13 1.21937D+00-7.22691D-14-3.74830D-14-2.02550D-01 8.12377D-15-2.76632D-14-1.83895D-02-1.09631D-14 1.17101D-14
+   40  -3.58937D-01-1.33708D-14 2.45529D-01-3.23032D-01 8.51174D-15-7.29282D-02 1.36049D-03-1.25411D-15 2.80961D-02-6.31629D-02
+   41  -2.84894D-01-4.34690D-14 1.76191D-01-9.53563D-02 1.61213D-15-1.41207D-01-8.51294D-02 1.73242D-14-4.29824D-02 4.43887D-03
+   42   1.94601D-13 4.65155D+00-3.07763D-14 4.44647D-14-4.07026D-02 4.53444D-14-8.35505D-14-2.98064D-01-2.00777D-14 9.39958D-15
+   43   2.15294D-01-6.95612D-14-9.42608D-03 1.05884D-01 1.29937D-14-7.52186D-02-3.67381D-02-3.84903D-15-2.90956D-02 5.11493D-02
+   44   5.34879D-01 3.96223D-14-8.60670D-03 1.72395D-02 2.19780D-14 3.86868D-02 2.61287D-02 1.76894D-15 3.08301D-02-3.82658D-02
+   45  -3.46395D-13-2.98082D+00 6.94231D-14-1.02115D-13 5.24240D-02-1.00002D-13 1.72489D-13 9.96993D-02 2.85290D-16-1.12027D-14
+   46  -1.31582D-01-8.10961D-15-7.00333D-01 4.23591D-02 2.97907D-15 1.91672D-01 3.33172D+00 3.61777D-14 6.00514D-01-5.27839D-01
+   47  -3.12389D-01-1.91460D-14 1.61502D-01 5.92348D-01 3.10370D-14 1.38985D+00-1.87486D+00 7.84450D-14 5.85690D-01 4.78133D-01
+   48  -2.98447D-14-8.91157D-02-3.65756D-15 6.01764D-14 7.54458D-01 3.56551D-14-1.58735D-14 3.94627D-01 1.26717D-16 2.52232D-14
+   49   1.14825D-01 5.32398D-15-1.53146D-02-1.72811D-01-2.07123D-15-3.22040D-01 3.49021D-01-1.45989D-14 3.25215D-02 6.15795D-02
+   50   7.88156D-02 7.08678D-15-1.32849D-01-5.44205D-02 6.89467D-15-4.36246D-01 2.95316D-01-8.78406D-15 8.41215D-02-2.15899D-02
+   51   8.43198D-15-2.18960D-03 2.62034D-15-2.30457D-14-4.49622D-02-5.84566D-15 1.93343D-14 2.99695D-02 1.59318D-15-5.80028D-16
+   52   8.29627D-03 4.13762D-15-3.44397D-03-5.86990D-02-2.10291D-14 8.99068D-02 1.65312D-02-6.88730D-15 1.51098D-01-6.98740D-02
+   53   2.91894D-02 7.29513D-15 5.34570D-01 1.10050D-01 2.04671D-14-5.21486D-01-1.89154D+00-2.61292D-14-2.54101D-01-3.61534D-01
+   54   1.61086D-14 2.87715D-02 2.04831D-14 5.64573D-15-4.52153D-02 8.82712D-15-1.65723D-14 6.05717D-01 1.46122D-14-3.86184D-14
+   55   3.91136D-03-3.08271D-15 4.29133D-02 1.00014D-02-1.49105D-15-1.66178D-01 3.82576D-02-7.13849D-16 7.04392D-02-3.02398D-04
+   56   5.68991D-02 4.92765D-15 9.25408D-02 5.26508D-03-3.44864D-14-8.08657D-02 1.76647D-01 2.39177D-15-1.30877D-01-8.39322D-03
+   57   2.03247D-14 4.09032D-02-3.86988D-15-7.49703D-14-1.35988D-01 5.37745D-15 4.31181D-14-1.56275D-01-1.87496D-14-4.94720D-15
+   58   5.84031D-02 2.32732D-15 1.48823D-01 3.22601D-03-3.41954D-14 6.76080D-02 3.19652D-01 3.88801D-16-1.09305D-01 3.61755D-02
+   59  -2.20096D-02-1.08454D-15 3.40137D-02 3.95076D-02-2.35031D-14-2.58039D-01-3.43020D-01 8.24654D-16 7.57628D-02 6.32233D-02
+   60  -2.95185D-14-2.26769D-02-1.51945D-15 6.29968D-15 6.57616D-02 2.60160D-15-1.61924D-14 6.70904D-02-5.16694D-15 3.46012D-14
+
+
+             21          22          23          24          25          26          27          28          29          30
+   ----- ----- ----- ----- -----
+   21   3.63808D+01
+   22   8.53591D-14 3.27594D+02
+   23   1.42586D-13 1.99130D+02 2.37359D+02
+   24  -6.33588D+00-2.87197D-14-1.22250D-13 3.55643D+01
+   25   1.09303D-13-7.28704D-01 8.28706D-01 5.90240D-14 4.33742D+02
+   26  -4.63883D-14-1.26947D+00 7.32007D-01-4.26748D-15-1.31850D+02 1.27130D+02
+   27  -1.25062D+00 5.59456D-14-4.62616D-14-9.66353D-02 9.83199D-14 1.36283D-13 3.63808D+01
+   28  -7.59811D-14-1.61918D-01-3.24631D-01 2.35801D-14 1.48038D+00-8.36234D-02-1.02629D-14 3.27594D+02
+   29  -5.86983D-14-3.24626D-01-7.88856D-02 2.47486D-14-1.44691D-01 2.35864D+00 4.71119D-14 1.99130D+02 2.37359D+02
+   30  -9.65687D-02 4.89952D-14 2.92303D-14-1.36864D+00 1.16117D-13-5.13053D-14-6.33588D+00 3.93948D-14-2.60000D-13 3.55643D+01
+   31   2.22597D-14 4.52619D-01-4.51896D-01 5.87225D-15 6.00514D-01-5.27839D-01 2.13711D-14 1.28061D-01-4.76041D-01-1.18142D-14
+   32   4.18253D-14-4.21805D-01 8.52287D-02 1.40916D-13 5.85690D-01 4.78133D-01 5.28145D-14 1.05974D-01-8.69304D-02 4.99545D-14
+   33  -2.17791D-02-1.18834D-15-2.01308D-14-1.47170D+00 2.45611D-14 9.83036D-15-1.44950D+00 8.83226D-15-1.17001D-14-5.70927D-02
+   34  -1.66932D-14 2.51004D-02 4.65729D-01-4.87713D-14 3.25216D-02 6.15795D-02-3.07011D-14-1.59565D-02 1.05562D-01-1.04584D-14
+   35  -5.23732D-15-1.24761D-01-3.76221D-01-4.27098D-14 8.41215D-02-2.15899D-02-1.40639D-14 2.56580D-02-1.24009D-01-1.44258D-14
+   36   7.11722D-03-1.14265D-14-8.92716D-15 8.95382D-02-5.42670D-15-9.19345D-15 7.07714D-02-2.82174D-15-4.16026D-15-2.45273D-02
+   37  -5.02825D-15 1.56623D-01-1.48624D-02-1.64160D-14 1.51098D-01-6.98740D-02-7.19769D-14 2.44842D-02-2.17612D-02-7.54001D-15
+   38  -3.64898D-14-1.00970D-01 1.06376D-02-6.48394D-14-2.54101D-01-3.61534D-01-1.74182D-14-3.59687D-02 2.37017D-03-1.26438D-14
+   39  -1.83909D-01-1.56293D-14-1.48638D-15 2.54773D-02 1.64321D-14-6.36053D-15-2.50159D-02-2.04852D-15 2.41158D-15 1.40835D-02
+   40   5.57690D-15 2.58169D-01-1.78047D-01-1.28747D-14 7.04392D-02-3.02397D-04 4.01669D-15 2.54912D-02-1.36548D-01-6.13662D-15
+   41  -2.81649D-15 2.19035D-02 1.85506D-01 2.07014D-14-1.30877D-01-8.39319D-03 5.11582D-15 5.76252D-02-3.13788D-02 2.35893D-15
+   42   2.39394D-02 1.15257D-14 2.45923D-14 2.06076D-01 7.16304D-15 1.65126D-14 3.87169D-01 8.77617D-16-6.34125D-16 2.53277D-02
+   43   2.19654D-14 6.27194D-01 1.23462D+00 1.38764D-13-1.09305D-01 3.61755D-02 2.66513D-14 2.06835D-02 4.27073D-02 1.77423D-14
+   44  -6.48543D-15 3.77260D-01-2.64145D+00-5.74481D-14 7.57628D-02 6.32233D-02-5.29097D-15-1.23522D-02-5.57416D-03-3.45484D-15
+   45   7.64603D-03-1.82983D-14-2.74634D-14 3.97329D-01 3.03878D-14-3.59384D-14-1.34265D-01 1.98260D-14-1.11088D-14-2.10157D-02
+   46  -3.10041D-14 1.28061D-01-4.76041D-01-2.67040D-14 8.82862D-02 4.71274D-01 2.76119D-14 4.52619D-01-4.51896D-01 8.30593D-15
+   47  -4.02684D-14 1.05974D-01-8.69304D-02 1.13862D-14-5.75158D-02 6.80154D-02-7.07761D-15-4.21805D-01 8.52287D-02 1.36670D-15
+   48  -1.44950D+00-1.68375D-15-2.22676D-14-5.70929D-02-2.55025D-16 5.22951D-15-2.17790D-02-2.09699D-14-3.40984D-14-1.47170D+00
+   49   2.23447D-14-1.59565D-02 1.05562D-01 1.09911D-14-1.64895D-02 1.53467D-02 1.57833D-15 2.51003D-02 4.65729D-01 1.18133D-14
+   50   1.22063D-15 2.56580D-02-1.24009D-01-1.40965D-14 2.59645D-02 1.41787D-02 3.34971D-15-1.24761D-01-3.76221D-01-6.36426D-15
+   51   7.07716D-02-3.01734D-15 2.16922D-14-2.45274D-02-2.19924D-15 5.18912D-15 7.11716D-03 1.16881D-14 4.80103D-15 8.95381D-02
+   52  -2.68728D-14 2.44842D-02-2.17612D-02 5.52037D-15 1.40705D-02 4.31819D-02-1.49956D-14 1.56623D-01-1.48624D-02-1.38657D-14
+   53   8.11468D-15-3.59687D-02 2.37017D-03-1.20876D-14-1.33696D-02-5.08340D-01-1.35094D-15-1.00970D-01 1.06377D-02-1.76347D-14
+   54  -2.50159D-02-1.09619D-14 3.75029D-14 1.40835D-02-3.75983D-14-2.31762D-16-1.83909D-01 3.52559D-15 2.80898D-15 2.54772D-02
+   55  -3.46796D-14 2.54912D-02-1.36548D-01-1.37897D-14 2.80961D-02-6.31629D-02 1.95399D-14 2.58169D-01-1.78047D-01-5.22870D-15
+   56   3.25067D-14 5.76252D-02-3.13789D-02 1.72187D-14-4.29824D-02 4.43890D-03-1.26759D-14 2.19035D-02 1.85506D-01 2.28992D-15
+   57   3.87169D-01-2.13226D-14 4.39507D-15 2.53278D-02 1.08124D-15 1.01413D-14 2.39395D-02 3.00996D-14 2.22561D-14 2.06076D-01
+   58   2.61038D-14 2.06835D-02 4.27073D-02 1.72488D-14-2.90956D-02 5.11493D-02-1.77309D-14 6.27194D-01 1.23462D+00 8.82342D-15
+   59  -1.18603D-14-1.23522D-02-5.57417D-03 1.04792D-14 3.08301D-02-3.82658D-02 4.64241D-15 3.77260D-01-2.64145D+00 1.97068D-14
+   60  -1.34265D-01-1.20348D-14-2.29509D-14-2.10157D-02 2.34769D-14-2.18345D-15 7.64600D-03-9.05531D-15 8.43377D-15 3.97329D-01
+
+
+             31          32          33          34          35          36          37          38          39          40
+   ----- ----- ----- ----- -----
+   31   8.82997D+01
+   32   1.69497D+01 8.05453D+01
+   33  -2.15329D-14-1.57805D-13 1.50366D+01
+   34  -3.88801D+01-2.57196D+01-3.66090D-14 8.77129D+01
+   35  -2.74260D+01-4.24687D+01 2.74636D-15 1.37029D+01 9.00991D+01
+   36   2.92033D-14 5.26479D-14-6.09200D+00-3.53101D-14-3.24909D-14 1.30272D+01
+   37  -1.28685D+02 2.42406D+01-1.22583D-13-4.79872D+00 3.39665D+00 1.32531D-13 4.59485D+02
+   38   2.51884D+01-2.84445D+01 8.00194D-15-1.09921D+01 3.00625D+00-1.06619D-13-8.51453D+01 1.00835D+02
+   39  -1.01448D-13-2.97495D-13-1.65068D+01 4.14553D-14-1.43996D-14 2.53404D+00 2.86777D-13-2.18964D-14 3.73744D+01
+   40   3.65591D+00-9.80306D+00-5.89802D-14-3.44620D+01 3.38987D+01-6.30757D-15 2.28263D+00 1.49322D-01 1.11224D-14 1.08538D+02
+   41   4.30678D+00-5.09563D+00-5.57585D-14 3.25813D+01-1.26820D+02 1.01024D-13-4.57440D-02 2.06585D+00-9.93373D-14-1.16043D+02
+   42   2.86009D-14-2.26099D-13 2.68512D+00 2.16104D-14 3.19486D-14-1.41089D+01 4.52645D-14 7.68386D-15-1.20257D+01-1.23513D-13
+   43  -3.95189D+00 2.80062D+00-1.59393D-14-1.34303D+02 1.80972D+01 1.07298D-13-1.45589D+00-2.38629D+00-1.06553D-13-1.20019D+00
+   44  -1.01491D+01 4.10098D+00 1.64085D-13 1.90345D+01-2.73713D+01-9.86892D-14-2.40561D+00-4.45165D+00-6.57174D-14 3.52807D+01
+   45  -5.32478D-14 3.72246D-13 2.04250D+00 1.21899D-13-5.41133D-14-1.50974D+01-8.98147D-14-9.58923D-15 1.75581D+01-9.42991D-14
+   46  -3.88269D-02 7.22986D-02-1.48294D-14 1.58152D-02-4.00681D-02-4.06795D-15 2.75689D-02-5.87125D-02-1.46577D-14-2.69321D-02
+   47   7.23629D-02 1.40957D-01 6.08848D-15-6.44503D-02-2.77695D-02 6.22397D-15-1.61887D-02 2.47616D-02-1.43709D-14 2.72086D-02
+   48  -3.32105D-15-5.64777D-15-9.66441D-02 4.31002D-15 5.83967D-15 6.75539D-03 1.09024D-15 2.15523D-14-6.28975D-04-3.51392D-15
+   49   1.57795D-02-6.44102D-02 8.75023D-16 5.60567D-03 2.78918D-02 1.52810D-16-8.41058D-03 1.50928D-02 6.55735D-15 1.20821D-02
+   50  -4.01267D-02-2.77645D-02-7.89592D-15 2.79224D-02-6.27709D-03-5.11219D-15 1.46887D-02-3.09433D-02-5.50480D-16-2.02371D-02
+   51  -5.56423D-16-4.67939D-15 6.75276D-03-1.14814D-16-1.78633D-15 3.67728D-04 1.84207D-15 1.83673D-15-9.71314D-04-4.11864D-16
+   52   2.76441D-02-1.62242D-02 1.13568D-14-8.43721D-03 1.46964D-02 3.59644D-15-1.21375D-02 1.11993D-02 2.28442D-15 1.43807D-02
+   53  -5.87493D-02 2.47794D-02-8.30556D-15 1.51071D-02-3.09441D-02 1.90511D-15 1.11991D-02-2.12280D-02-5.06198D-15-3.18320D-02
+   54   4.49992D-15-3.96236D-15-5.80952D-04-3.65632D-15-1.66422D-14-9.65392D-04-8.39033D-15-4.96645D-15 6.92754D-04-3.91765D-15
+   55  -2.69392D-02 2.71750D-02 1.31140D-15 1.20917D-02-2.02234D-02-3.41881D-15 1.43789D-02-3.18270D-02-5.43235D-15-1.84455D-02
+   56   3.74077D-02-2.94746D-02 1.69351D-14-1.35740D-02 2.02335D-02 3.22983D-15-1.35803D-02 2.40562D-02 1.55012D-14 2.12668D-02
+   57  -2.42095D-15 8.35180D-15 4.38124D-03-1.29396D-15-1.41132D-15-2.52422D-03-4.48462D-15 3.04794D-15 3.34948D-03 3.21306D-16
+   58   6.79857D-02-4.48967D-02 2.08982D-14-2.39650D-02 4.01753D-02 7.01240D-17-2.46672D-02 4.71404D-02 1.85547D-14 3.94024D-02
+   59   4.05011D-03 5.88949D-03 3.54222D-15 1.06912D-03 2.79968D-04-2.82376D-15 9.90693D-04-5.76828D-03 4.51496D-15 6.47712D-04
+   60  -1.08336D-14 8.24697D-15 1.29193D-02 5.29700D-15 1.10573D-14-7.52207D-04 1.03217D-15 1.38753D-14 8.59419D-05-1.78634D-15
+
+
+             41          42          43          44          45          46          47          48          49          50
+   ----- ----- ----- ----- -----
+   41   4.51067D+02
+   42   3.91051D-14 3.27245D+01
+   43  -8.00115D+00-6.64046D-14 4.78107D+02
+   44   2.72216D+00-2.38161D-13-6.53797D+01 8.37585D+01
+   45  -3.48616D-14 4.05136D+00-2.97528D-13-6.65957D-15 3.25272D+01
+   46   3.73044D-02 1.19708D-14 6.79030D-02 4.04987D-03 5.74656D-15 8.82997D+01
+   47  -2.94729D-02-5.58777D-14-4.49195D-02 5.87602D-03 8.73888D-14 1.69497D+01 8.05453D+01
+   48  -7.63708D-15 4.36302D-03-3.64392D-15 6.14323D-15 1.29962D-02 1.11408D-15 5.82130D-14 1.50366D+01
+   49  -1.35232D-02 2.80184D-15-2.39294D-02 1.06431D-03-1.18241D-14-3.88801D+01-2.57196D+01 4.39517D-14 8.77129D+01
+   50   2.02392D-02 1.53848D-14 4.01791D-02 2.76714D-04-1.75164D-14-2.74260D+01-4.24687D+01 7.17572D-14 1.37029D+01 9.00991D+01
+   51   6.90835D-15-2.49786D-03 1.33554D-14-1.52226D-15-7.53028D-04 4.93901D-15-2.40852D-14-6.09200D+00 2.12639D-14 2.13459D-15
+   52  -1.35844D-02-7.64976D-15-2.46593D-02 1.00479D-03-4.35662D-15-1.28685D+02 2.42406D+01-5.06757D-14-4.79872D+00 3.39665D+00
+   53   2.40439D-02 1.44976D-14 4.71369D-02-5.76680D-03-6.86259D-15 2.51884D+01-2.84445D+01 2.09791D-15-1.09921D+01 3.00625D+00
+   54   3.69887D-14 3.24011D-03 1.62115D-14 6.86113D-15 1.12298D-04-4.53946D-14-2.65486D-14-1.65068D+01 1.36745D-14 3.64675D-14
+   55   2.12564D-02 1.78048D-15 3.94091D-02 6.66342D-04-1.64982D-15 3.65591D+00-9.80306D+00-7.77223D-15-3.44620D+01 3.38987D+01
+   56  -2.57416D-02-1.11092D-14-3.83941D-02 3.39405D-03-1.49947D-14 4.30678D+00-5.09563D+00-3.28212D-15 3.25813D+01-1.26820D+02
+   57  -1.76371D-16 1.62215D-02 1.28365D-14 4.36403D-15-1.37799D-02 5.93152D-15-5.66833D-14 2.68512D+00 1.38222D-14-8.23844D-15
+   58  -3.83989D-02-1.49963D-14-7.10880D-02 2.30228D-03-1.31718D-14-3.95189D+00 2.80062D+00-2.48309D-14-1.34303D+02 1.80972D+01
+   59   3.38449D-03 3.53484D-16 2.31547D-03-5.70168D-04-5.58921D-16-1.01491D+01 4.10098D+00-1.73873D-15 1.90345D+01-2.73713D+01
+   60  -1.41885D-14-1.36975D-02 1.15196D-14-3.80583D-15 1.33770D-02-1.62453D-14-5.64381D-14 2.04250D+00 5.36803D-15-3.84434D-15
+
+
+             51          52          53          54          55          56          57          58          59          60
+   ----- ----- ----- ----- -----
+   51   1.30272D+01
+   52  -7.47187D-15 4.59485D+02
+   53   4.81240D-14-8.51453D+01 1.00835D+02
+   54   2.53404D+00-1.96019D-14-1.25733D-13 3.73744D+01
+   55   2.09694D-14 2.28263D+00 1.49322D-01-2.70437D-14 1.08538D+02
+   56  -4.93580D-14-4.57440D-02 2.06585D+00 1.17992D-13-1.16043D+02 4.51067D+02
+   57  -1.41089D+01 4.10872D-15-3.17647D-14-1.20257D+01 1.05580D-14-1.52156D-14 3.27245D+01
+   58  -4.61613D-14-1.45589D+00-2.38629D+00 5.34276D-14-1.20019D+00-8.00115D+00 1.74716D-14 4.78107D+02
+   59   1.58075D-14-2.40561D+00-4.45165D+00 6.27142D-14 3.52807D+01 2.72216D+00-3.10025D-15-6.53797D+01 8.37585D+01
+   60  -1.50974D+01 2.14021D-14 3.50865D-14 1.75581D+01-4.05288D-14 4.90461D-14 4.05136D+00 4.79870D-14 6.01049D-14 3.25272D+01
+
+
+
+          -------------------------------------------------
+          NORMAL MODE EIGENVECTORS IN CARTESIAN COORDINATES
+          -------------------------------------------------
+                 (Frequencies expressed in cm-1)
+
+                    1           2           3           4           5           6
+ 
+ Frequency         -7.92       -5.13       -4.09       -1.33        0.43        0.68
+ 
+           1     0.00000     0.04918     0.00000    -0.06591     0.00000    -0.05719
+           2     0.00000     0.00778     0.00000    -0.05747     0.00000     0.06623
+           3    -0.00739     0.00000     0.05659     0.00000     0.08731     0.00000
+           4     0.00000     0.01767     0.00000    -0.06608     0.00000    -0.05740
+           5     0.00000     0.04470     0.00000    -0.05727     0.00000     0.06647
+           6    -0.11486     0.00000     0.05277     0.00000     0.08765     0.00000
+           7     0.00000    -0.02977     0.00000    -0.06635     0.00000    -0.05772
+           8     0.00000     0.03707     0.00000    -0.05731     0.00000     0.06642
+           9    -0.10760     0.00000    -0.00197     0.00000     0.08802     0.00000
+          10     0.00000    -0.04768     0.00000    -0.06645     0.00000    -0.05783
+          11     0.00000    -0.00802     0.00000    -0.05756     0.00000     0.06612
+          12     0.00792     0.00000    -0.05533     0.00000     0.08805     0.00000
+          13     0.00000    -0.01617     0.00000    -0.06627     0.00000    -0.05763
+          14     0.00000    -0.04493     0.00000    -0.05777     0.00000     0.06588
+          15     0.11539     0.00000    -0.05151     0.00000     0.08770     0.00000
+          16     0.00000     0.03127     0.00000    -0.06601     0.00000    -0.05731
+          17     0.00000    -0.03730     0.00000    -0.05772     0.00000     0.06593
+          18     0.10813     0.00000     0.00323     0.00000     0.08734     0.00000
+          19     0.00000     0.03071     0.00000    -0.06601     0.00000    -0.05732
+          20     0.00000     0.08001     0.00000    -0.05707     0.00000     0.06671
+          21    -0.20564     0.00000     0.09357     0.00000     0.08764     0.00000
+          22     0.00000    -0.05306     0.00000    -0.06648     0.00000    -0.05787
+          23     0.00000     0.06660     0.00000    -0.05715     0.00000     0.06662
+          24    -0.19289     0.00000    -0.00306     0.00000     0.08828     0.00000
+          25     0.00000    -0.02922     0.00000    -0.06634     0.00000    -0.05771
+          26     0.00000    -0.08025     0.00000    -0.05796     0.00000     0.06565
+          27     0.20618     0.00000    -0.09231     0.00000     0.08772     0.00000
+          28     0.00000     0.05456     0.00000    -0.06588     0.00000    -0.05716
+          29     0.00000    -0.06683     0.00000    -0.05789     0.00000     0.06574
+          30     0.19342     0.00000     0.00432     0.00000     0.08707     0.00000
+          31     0.00000    -0.09869     0.00000    -0.06673     0.00000    -0.05817
+          32     0.00000    -0.01822     0.00000    -0.05762     0.00000     0.06606
+          33     0.02099     0.00000    -0.11578     0.00000     0.08844     0.00000
+          34     0.00000    -0.13275     0.00000    -0.06692     0.00000    -0.05840
+          35     0.00000     0.01228     0.00000    -0.05745     0.00000     0.06626
+          36    -0.07408     0.00000    -0.12708     0.00000     0.08880     0.00000
+          37     0.00000    -0.10710     0.00000    -0.06678     0.00000    -0.05823
+          38     0.00000    -0.05500     0.00000    -0.05782     0.00000     0.06581
+          39     0.12053     0.00000    -0.15307     0.00000     0.08842     0.00000
+          40     0.00000    -0.16879     0.00000    -0.06712     0.00000    -0.05864
+          41     0.00000     0.00136     0.00000    -0.05751     0.00000     0.06619
+          42    -0.05460     0.00000    -0.17265     0.00000     0.08907     0.00000
+          43     0.00000    -0.12704     0.00000    -0.06689     0.00000    -0.05836
+          44     0.00000     0.04948     0.00000    -0.05724     0.00000     0.06651
+          45    -0.17581     0.00000    -0.09226     0.00000     0.08884     0.00000
+          46     0.00000     0.10019     0.00000    -0.06562     0.00000    -0.05686
+          47     0.00000     0.01799     0.00000    -0.05742     0.00000     0.06630
+          48    -0.02046     0.00000     0.11703     0.00000     0.08692     0.00000
+          49     0.00000     0.13425     0.00000    -0.06543     0.00000    -0.05663
+          50     0.00000    -0.01252     0.00000    -0.05759     0.00000     0.06610
+          51     0.07459     0.00000     0.12828     0.00000     0.08654     0.00000
+          52     0.00000     0.10860     0.00000    -0.06557     0.00000    -0.05680
+          53     0.00000     0.05477     0.00000    -0.05721     0.00000     0.06654
+          54    -0.11999     0.00000     0.15436     0.00000     0.08696     0.00000
+          55     0.00000     0.17029     0.00000    -0.06523     0.00000    -0.05639
+          56     0.00000    -0.00159     0.00000    -0.05753     0.00000     0.06617
+          57     0.05511     0.00000     0.17385     0.00000     0.08627     0.00000
+          58     0.00000     0.12854     0.00000    -0.06546     0.00000    -0.05667
+          59     0.00000    -0.04971     0.00000    -0.05780     0.00000     0.06585
+          60     0.17630     0.00000     0.09341     0.00000     0.08647     0.00000
+
+                    7           8           9          10          11          12
+ 
+ Frequency         37.57       57.38      154.88      197.50      292.24      330.23
+ 
+           1     0.00000     0.00000     0.00000    -0.05726    -0.06702     0.00000
+           2     0.00000     0.00000     0.00000     0.01044    -0.02413     0.00000
+           3    -0.04177    -0.04902    -0.02768     0.00000     0.00000    -0.12149
+           4     0.00000     0.00000     0.00000    -0.06229    -0.03576     0.00000
+           5     0.00000     0.00000     0.00000     0.01362    -0.05530     0.00000
+           6    -0.04960     0.03157    -0.06339     0.00000     0.00000    -0.07629
+           7     0.00000     0.00000     0.00000    -0.06115     0.04459     0.00000
+           8     0.00000     0.00000     0.00000     0.00630    -0.03774     0.00000
+           9    -0.04687     0.08277    -0.06874     0.00000     0.00000     0.06632
+          10     0.00000     0.00000     0.00000    -0.05726     0.06702     0.00000
+          11     0.00000     0.00000     0.00000     0.01044     0.02413     0.00000
+          12    -0.04178     0.04903    -0.02768     0.00000     0.00000     0.12149
+          13     0.00000     0.00000     0.00000    -0.06229     0.03576     0.00000
+          14     0.00000     0.00000     0.00000     0.01362     0.05530     0.00000
+          15    -0.04961    -0.03157    -0.06339     0.00000     0.00000     0.07629
+          16     0.00000     0.00000     0.00000    -0.06115    -0.04459     0.00000
+          17     0.00000     0.00000     0.00000     0.00630     0.03774     0.00000
+          18    -0.04687    -0.08276    -0.06874     0.00000     0.00000    -0.06632
+          19     0.00000     0.00000     0.00000    -0.06266    -0.05350     0.00000
+          20     0.00000     0.00000     0.00000     0.01443    -0.10328     0.00000
+          21    -0.05456     0.05966    -0.05129     0.00000     0.00000    -0.11633
+          22     0.00000     0.00000     0.00000    -0.05927     0.08120     0.00000
+          23     0.00000     0.00000     0.00000     0.00141    -0.08061     0.00000
+          24    -0.05257     0.15554    -0.05921     0.00000     0.00000     0.09168
+          25     0.00000     0.00000     0.00000    -0.06266     0.05350     0.00000
+          26     0.00000     0.00000     0.00000     0.01443     0.10328     0.00000
+          27    -0.05456    -0.05966    -0.05129     0.00000     0.00000     0.11634
+          28     0.00000     0.00000     0.00000    -0.05927    -0.08120     0.00000
+          29     0.00000     0.00000     0.00000     0.00141     0.08061     0.00000
+          30    -0.05256    -0.15553    -0.05921     0.00000     0.00000    -0.09168
+          31     0.00000     0.00000     0.00000     0.03149     0.03036     0.00000
+          32     0.00000     0.00000     0.00000     0.02842     0.02480     0.00000
+          33    -0.02632     0.08813     0.12199     0.00000     0.00000    -0.02979
+          34     0.00000     0.00000     0.00000     0.12650    -0.06620     0.00000
+          35     0.00000     0.00000     0.00000    -0.05484     0.11245     0.00000
+          36     0.14913    -0.09063     0.02173     0.00000     0.00000    -0.02510
+          37     0.00000     0.00000     0.00000     0.05185     0.01360     0.00000
+          38     0.00000     0.00000     0.00000     0.11779    -0.04693     0.00000
+          39    -0.16292     0.26489     0.34792     0.00000     0.00000    -0.25239
+          40     0.00000     0.00000     0.00000     0.23041    -0.18360     0.00000
+          41     0.00000     0.00000     0.00000    -0.02347     0.07753     0.00000
+          42     0.15089    -0.05169     0.16659     0.00000     0.00000    -0.23874
+          43     0.00000     0.00000     0.00000     0.11006    -0.04710     0.00000
+          44     0.00000     0.00000     0.00000    -0.15697     0.22686     0.00000
+          45     0.30272    -0.28851    -0.21245     0.00000     0.00000     0.19490
+          46     0.00000     0.00000     0.00000     0.03149    -0.03036     0.00000
+          47     0.00000     0.00000     0.00000     0.02842    -0.02480     0.00000
+          48    -0.02630    -0.08812     0.12199     0.00000     0.00000     0.02979
+          49     0.00000     0.00000     0.00000     0.12650     0.06620     0.00000
+          50     0.00000     0.00000     0.00000    -0.05484    -0.11244     0.00000
+          51     0.14919     0.09062     0.02173     0.00000     0.00000     0.02510
+          52     0.00000     0.00000     0.00000     0.05185    -0.01360     0.00000
+          53     0.00000     0.00000     0.00000     0.11779     0.04693     0.00000
+          54    -0.16292    -0.26487     0.34792     0.00000     0.00000     0.25240
+          55     0.00000     0.00000     0.00000     0.23041     0.18359     0.00000
+          56     0.00000     0.00000     0.00000    -0.02347    -0.07753     0.00000
+          57     0.15096     0.05167     0.16659     0.00000     0.00000     0.23875
+          58     0.00000     0.00000     0.00000     0.11007     0.04710     0.00000
+          59     0.00000     0.00000     0.00000    -0.15698    -0.22686     0.00000
+          60     0.30280     0.28847    -0.21245     0.00000     0.00000    -0.19490
+
+                   13          14          15          16          17          18
+ 
+ Frequency        444.36      477.06      525.72      528.45      629.23      738.22
+ 
+           1     0.06276     0.00000     0.00000     0.02051     0.03835    -0.03982
+           2    -0.05989     0.00000     0.00000     0.03341     0.06920     0.00070
+           3     0.00000     0.01129    -0.13079     0.00000     0.00000     0.00000
+           4     0.00354     0.00000     0.00000     0.04170     0.07879    -0.08846
+           5     0.02480     0.00000     0.00000     0.05029     0.03724     0.09868
+           6     0.00000     0.11960     0.06326     0.00000     0.00000     0.00000
+           7    -0.07025     0.00000     0.00000     0.04430    -0.01415     0.06277
+           8     0.02981     0.00000     0.00000     0.05464     0.01275     0.12241
+           9     0.00000    -0.12520     0.04108     0.00000     0.00000     0.00000
+          10    -0.06276     0.00000     0.00000     0.02051    -0.03835     0.03983
+          11     0.05989     0.00000     0.00000     0.03341    -0.06920    -0.00070
+          12     0.00000     0.01129    -0.13079     0.00000     0.00000     0.00000
+          13    -0.00354     0.00000     0.00000     0.04170    -0.07879     0.08846
+          14    -0.02480     0.00000     0.00000     0.05029    -0.03724    -0.09868
+          15     0.00000     0.11959     0.06326     0.00000     0.00000     0.00000
+          16     0.07025     0.00000     0.00000     0.04430     0.01414    -0.06277
+          17    -0.02981     0.00000     0.00000     0.05464    -0.01275    -0.12241
+          18     0.00000    -0.12520     0.04108     0.00000     0.00000     0.00000
+          19     0.03871     0.00000     0.00000     0.04528     0.08459    -0.10472
+          20     0.11542     0.00000     0.00000     0.05454     0.05019     0.05722
+          21     0.00000     0.23583     0.22478     0.00000     0.00000     0.00000
+          22    -0.07376     0.00000     0.00000     0.04535    -0.09270     0.08529
+          23     0.03511     0.00000     0.00000     0.05288     0.11109     0.09500
+          24     0.00000    -0.28418     0.18516     0.00000     0.00000     0.00000
+          25    -0.03871     0.00000     0.00000     0.04528    -0.08459     0.10472
+          26    -0.11542     0.00000     0.00000     0.05454    -0.05019    -0.05722
+          27     0.00000     0.23583     0.22478     0.00000     0.00000     0.00000
+          28     0.07375     0.00000     0.00000     0.04535     0.09270    -0.08529
+          29    -0.03511     0.00000     0.00000     0.05288    -0.11109    -0.09500
+          30     0.00000    -0.28418     0.18516     0.00000     0.00000     0.00000
+          31     0.00283     0.00000     0.00000    -0.09768     0.10251     0.02102
+          32     0.11042     0.00000     0.00000    -0.01438    -0.05606    -0.00414
+          33     0.00000    -0.00004    -0.04669     0.00000     0.00000     0.00000
+          34     0.03953     0.00000     0.00000    -0.01668     0.01229     0.01487
+          35     0.09029     0.00000     0.00000    -0.10291     0.03372     0.00831
+          36     0.00000    -0.00049     0.01921     0.00000     0.00000     0.00000
+          37     0.01263     0.00000     0.00000    -0.09898     0.10832     0.02214
+          38     0.16300     0.00000     0.00000    -0.02812    -0.03099     0.00098
+          39     0.00000    -0.01154     0.13496     0.00000     0.00000     0.00000
+          40     0.06901     0.00000     0.00000     0.14699    -0.19557    -0.01572
+          41     0.10055     0.00000     0.00000    -0.05532    -0.02818    -0.00066
+          42     0.00000    -0.02458     0.25673     0.00000     0.00000     0.00000
+          43     0.03670     0.00000     0.00000    -0.04521     0.04690     0.02069
+          44     0.06581     0.00000     0.00000    -0.27460     0.25384     0.04656
+          45     0.00000     0.02314    -0.15944     0.00000     0.00000     0.00000
+          46    -0.00283     0.00000     0.00000    -0.09768    -0.10250    -0.02102
+          47    -0.11041     0.00000     0.00000    -0.01438     0.05606     0.00414
+          48     0.00000    -0.00004    -0.04669     0.00000     0.00000     0.00000
+          49    -0.03953     0.00000     0.00000    -0.01668    -0.01229    -0.01487
+          50    -0.09029     0.00000     0.00000    -0.10291    -0.03372    -0.00831
+          51     0.00000    -0.00049     0.01921     0.00000     0.00000     0.00000
+          52    -0.01263     0.00000     0.00000    -0.09898    -0.10832    -0.02214
+          53    -0.16300     0.00000     0.00000    -0.02812     0.03099    -0.00098
+          54     0.00000    -0.01154     0.13496     0.00000     0.00000     0.00000
+          55    -0.06901     0.00000     0.00000     0.14699     0.19557     0.01572
+          56    -0.10055     0.00000     0.00000    -0.05532     0.02818     0.00066
+          57     0.00000    -0.02458     0.25673     0.00000     0.00000     0.00000
+          58    -0.03670     0.00000     0.00000    -0.04521    -0.04690    -0.02069
+          59    -0.06581     0.00000     0.00000    -0.27460    -0.25384    -0.04656
+          60     0.00000     0.02314    -0.15944     0.00000     0.00000     0.00000
+
+                   19          20          21          22          23          24
+ 
+ Frequency        739.97      795.11      797.73      918.47      945.82     1020.90
+ 
+           1     0.00000     0.00000     0.00308     0.00000    -0.00793     0.00000
+           2     0.00000     0.00000    -0.00759     0.00000     0.04086     0.00000
+           3    -0.02335     0.07154     0.00000     0.14182     0.00000     0.09529
+           4     0.00000     0.00000    -0.03876     0.00000     0.11540     0.00000
+           5     0.00000     0.00000     0.07241     0.00000    -0.00155     0.00000
+           6     0.08038     0.01224     0.00000    -0.05593     0.00000    -0.05688
+           7     0.00000     0.00000    -0.01463     0.00000     0.11653     0.00000
+           8     0.00000     0.00000     0.07546     0.00000     0.03272     0.00000
+           9    -0.07735     0.01556     0.00000     0.05473     0.00000    -0.06187
+          10     0.00000     0.00000     0.00308     0.00000     0.00793     0.00000
+          11     0.00000     0.00000    -0.00759     0.00000    -0.04086     0.00000
+          12     0.02335     0.07154     0.00000    -0.14182     0.00000     0.09529
+          13     0.00000     0.00000    -0.03876     0.00000    -0.11540     0.00000
+          14     0.00000     0.00000     0.07241     0.00000     0.00155     0.00000
+          15    -0.08038     0.01224     0.00000     0.05593     0.00000    -0.05688
+          16     0.00000     0.00000    -0.01463     0.00000    -0.11653     0.00000
+          17     0.00000     0.00000     0.07546     0.00000    -0.03272     0.00000
+          18     0.07735     0.01556     0.00000    -0.05473     0.00000    -0.06187
+          19     0.00000     0.00000    -0.02034     0.00000     0.08652     0.00000
+          20     0.00000     0.00000     0.12139     0.00000    -0.10016     0.00000
+          21     0.12472    -0.25783     0.00000    -0.17904     0.00000     0.35218
+          22     0.00000     0.00000    -0.04603     0.00000     0.07209     0.00000
+          23     0.00000     0.00000     0.11184     0.00000     0.10026     0.00000
+          24    -0.14092    -0.25368     0.00000     0.17869     0.00000     0.35839
+          25     0.00000     0.00000    -0.02034     0.00000    -0.08652     0.00000
+          26     0.00000     0.00000     0.12139     0.00000     0.10016     0.00000
+          27    -0.12472    -0.25783     0.00000     0.17904     0.00000     0.35216
+          28     0.00000     0.00000    -0.04603     0.00000    -0.07209     0.00000
+          29     0.00000     0.00000     0.11184     0.00000    -0.10026     0.00000
+          30     0.14092    -0.25368     0.00000    -0.17869     0.00000     0.35837
+          31     0.00000     0.00000     0.07190     0.00000    -0.03659     0.00000
+          32     0.00000     0.00000    -0.10274     0.00000     0.05176     0.00000
+          33     0.09852    -0.09541     0.00000     0.06505     0.00000    -0.04582
+          34     0.00000     0.00000    -0.00672     0.00000     0.00090     0.00000
+          35     0.00000     0.00000    -0.05090     0.00000     0.03624     0.00000
+          36    -0.01639     0.01410     0.00000    -0.00571     0.00000     0.00058
+          37     0.00000     0.00000     0.07554     0.00000    -0.03977     0.00000
+          38     0.00000     0.00000    -0.10824     0.00000     0.05562     0.00000
+          39    -0.12711     0.14285     0.00000    -0.07952     0.00000     0.01666
+          40     0.00000     0.00000    -0.20864     0.00000     0.15450     0.00000
+          41     0.00000     0.00000    -0.11382     0.00000     0.08404     0.00000
+          42    -0.35935     0.35689     0.00000    -0.22404     0.00000     0.15042
+          43     0.00000     0.00000     0.02241     0.00000    -0.01988     0.00000
+          44     0.00000     0.00000     0.14785     0.00000    -0.10100     0.00000
+          45     0.20487    -0.20285     0.00000     0.11151     0.00000    -0.05959
+          46     0.00000     0.00000     0.07190     0.00000     0.03659     0.00000
+          47     0.00000     0.00000    -0.10274     0.00000    -0.05176     0.00000
+          48    -0.09852    -0.09541     0.00000    -0.06505     0.00000    -0.04582
+          49     0.00000     0.00000    -0.00672     0.00000    -0.00090     0.00000
+          50     0.00000     0.00000    -0.05090     0.00000    -0.03624     0.00000
+          51     0.01639     0.01410     0.00000     0.00571     0.00000     0.00058
+          52     0.00000     0.00000     0.07554     0.00000     0.03977     0.00000
+          53     0.00000     0.00000    -0.10824     0.00000    -0.05562     0.00000
+          54     0.12711     0.14285     0.00000     0.07953     0.00000     0.01666
+          55     0.00000     0.00000    -0.20864     0.00000    -0.15450     0.00000
+          56     0.00000     0.00000    -0.11382     0.00000    -0.08404     0.00000
+          57     0.35935     0.35689     0.00000     0.22404     0.00000     0.15042
+          58     0.00000     0.00000     0.02241     0.00000     0.01988     0.00000
+          59     0.00000     0.00000     0.14785     0.00000     0.10100     0.00000
+          60    -0.20488    -0.20285     0.00000    -0.11151     0.00000    -0.05959
+
+                   25          26          27          28          29          30
+ 
+ Frequency       1022.63     1145.63     1145.69     1154.73     1162.74     1179.52
+ 
+           1     0.00000     0.00000     0.00000     0.10359     0.00000     0.01252
+           2     0.00000     0.00000     0.00000     0.00246     0.00000     0.03414
+           3     0.00150     0.00328    -0.00554     0.00000    -0.02527     0.00000
+           4     0.00000     0.00000     0.00000    -0.05480     0.00000     0.11460
+           5     0.00000     0.00000     0.00000    -0.07055     0.00000    -0.01877
+           6     0.06431     0.00260    -0.00164     0.00000     0.07166     0.00000
+           7     0.00000     0.00000     0.00000    -0.05489     0.00000    -0.12265
+           8     0.00000     0.00000     0.00000     0.07255     0.00000    -0.02036
+           9     0.06972    -0.00351     0.00559     0.00000    -0.07017     0.00000
+          10     0.00000     0.00000     0.00000     0.10359     0.00000     0.01252
+          11     0.00000     0.00000     0.00000     0.00246     0.00000     0.03414
+          12    -0.00149    -0.00328    -0.00555     0.00000     0.02527     0.00000
+          13     0.00000     0.00000     0.00000    -0.05480     0.00000     0.11460
+          14     0.00000     0.00000     0.00000    -0.07055     0.00000    -0.01877
+          15    -0.06431    -0.00260    -0.00164     0.00000    -0.07166     0.00000
+          16     0.00000     0.00000     0.00000    -0.05489     0.00000    -0.12265
+          17     0.00000     0.00000     0.00000     0.07255     0.00000    -0.02036
+          18    -0.06972     0.00351     0.00559     0.00000     0.07017     0.00000
+          19     0.00000     0.00000     0.00000    -0.03928     0.00000     0.18137
+          20     0.00000     0.00000     0.00000    -0.02394     0.00000     0.14426
+          21    -0.43564    -0.01927     0.01181     0.00000    -0.43522     0.00000
+          22     0.00000     0.00000     0.00000    -0.02808     0.00000    -0.24524
+          23     0.00000     0.00000     0.00000     0.03601     0.00000     0.12498
+          24    -0.44605     0.02953    -0.02725     0.00000     0.41696     0.00000
+          25     0.00000     0.00000     0.00000    -0.03928     0.00000     0.18137
+          26     0.00000     0.00000     0.00000    -0.02394     0.00000     0.14426
+          27     0.43565     0.01927     0.01181     0.00000     0.43522     0.00000
+          28     0.00000     0.00000     0.00000    -0.02808     0.00000    -0.24523
+          29     0.00000     0.00000     0.00000     0.03601     0.00000     0.12498
+          30     0.44606    -0.02953    -0.02725     0.00000    -0.41696     0.00000
+          31     0.00000     0.00000     0.00000     0.02381     0.00000     0.00056
+          32     0.00000     0.00000     0.00000    -0.01392     0.00000    -0.00227
+          33     0.00004     0.03170     0.03268     0.00000    -0.01048     0.00000
+          34     0.00000     0.00000     0.00000    -0.02289     0.00000     0.00331
+          35     0.00000     0.00000     0.00000     0.03412     0.00000    -0.01392
+          36    -0.00172    -0.10249    -0.10255     0.00000     0.00528     0.00000
+          37     0.00000     0.00000     0.00000    -0.01919     0.00000    -0.00109
+          38     0.00000     0.00000     0.00000    -0.20991     0.00000    -0.01487
+          39     0.00404     0.02224     0.02384     0.00000    -0.03031     0.00000
+          40     0.00000     0.00000     0.00000     0.20667     0.00000    -0.04344
+          41     0.00000     0.00000     0.00000     0.10408     0.00000    -0.02917
+          42     0.01270     0.39960     0.39637     0.00000     0.02090     0.00000
+          43     0.00000     0.00000     0.00000    -0.05828     0.00000     0.00898
+          44     0.00000     0.00000     0.00000    -0.19993     0.00000     0.02700
+          45    -0.00367     0.44415     0.44600     0.00000    -0.04985     0.00000
+          46     0.00000     0.00000     0.00000     0.02381     0.00000     0.00056
+          47     0.00000     0.00000     0.00000    -0.01392     0.00000    -0.00227
+          48    -0.00004    -0.03170     0.03268     0.00000     0.01048     0.00000
+          49     0.00000     0.00000     0.00000    -0.02290     0.00000     0.00331
+          50     0.00000     0.00000     0.00000     0.03413     0.00000    -0.01392
+          51     0.00172     0.10250    -0.10254     0.00000    -0.00528     0.00000
+          52     0.00000     0.00000     0.00000    -0.01919     0.00000    -0.00109
+          53     0.00000     0.00000     0.00000    -0.20991     0.00000    -0.01487
+          54    -0.00404    -0.02224     0.02383     0.00000     0.03031     0.00000
+          55     0.00000     0.00000     0.00000     0.20668     0.00000    -0.04344
+          56     0.00000     0.00000     0.00000     0.10408     0.00000    -0.02917
+          57    -0.01269    -0.39964     0.39633     0.00000    -0.02090     0.00000
+          58     0.00000     0.00000     0.00000    -0.05828     0.00000     0.00898
+          59     0.00000     0.00000     0.00000    -0.19993     0.00000     0.02700
+          60     0.00367    -0.44419     0.44596     0.00000     0.04985     0.00000
+
+                   31          32          33          34          35          36
+ 
+ Frequency       1187.57     1213.18     1234.91     1246.48     1246.73     1333.40
+ 
+           1     0.00000     0.01670    -0.03108     0.00000     0.00000    -0.06760
+           2     0.00000    -0.04870    -0.03579     0.00000     0.00000    -0.06314
+           3     0.00066     0.00000     0.00000     0.00226     0.00126     0.00000
+           4     0.00000     0.02018     0.00509     0.00000     0.00000     0.03843
+           5     0.00000    -0.02798     0.09156     0.00000     0.00000    -0.00320
+           6    -0.07615     0.00000     0.00000    -0.00293    -0.00341     0.00000
+           7     0.00000     0.03926    -0.00028     0.00000     0.00000     0.03999
+           8     0.00000     0.01769    -0.07157     0.00000     0.00000     0.03715
+           9     0.07479     0.00000     0.00000     0.00046     0.00077     0.00000
+          10     0.00000    -0.01670    -0.03108     0.00000     0.00000    -0.06760
+          11     0.00000     0.04870    -0.03579     0.00000     0.00000    -0.06314
+          12     0.00067     0.00000     0.00000     0.00226    -0.00126     0.00000
+          13     0.00000    -0.02018     0.00509     0.00000     0.00000     0.03843
+          14     0.00000     0.02798     0.09156     0.00000     0.00000    -0.00320
+          15    -0.07615     0.00000     0.00000    -0.00293     0.00341     0.00000
+          16     0.00000    -0.03926    -0.00028     0.00000     0.00000     0.03999
+          17     0.00000    -0.01769    -0.07157     0.00000     0.00000     0.03715
+          18     0.07479     0.00000     0.00000     0.00046    -0.00077     0.00000
+          19     0.00000     0.01007     0.06648     0.00000     0.00000    -0.04887
+          20     0.00000    -0.06747     0.26654     0.00000     0.00000    -0.26464
+          21     0.43125     0.00000     0.00000     0.00765     0.02830     0.00000
+          22     0.00000     0.07826    -0.00099     0.00000     0.00000    -0.24662
+          23     0.00000    -0.02080    -0.08141     0.00000     0.00000     0.40670
+          24    -0.41643     0.00000     0.00000     0.01298    -0.02680     0.00000
+          25     0.00000    -0.01007     0.06648     0.00000     0.00000    -0.04887
+          26     0.00000     0.06747     0.26654     0.00000     0.00000    -0.26464
+          27     0.43126     0.00000     0.00000     0.00765    -0.02830     0.00000
+          28     0.00000    -0.07826    -0.00099     0.00000     0.00000    -0.24662
+          29     0.00000     0.02080    -0.08141     0.00000     0.00000     0.40670
+          30    -0.41643     0.00000     0.00000     0.01298     0.02680     0.00000
+          31     0.00000    -0.04603     0.03972     0.00000     0.00000     0.01201
+          32     0.00000     0.02618    -0.02528     0.00000     0.00000    -0.01212
+          33    -0.00170     0.00000     0.00000    -0.06286     0.06310     0.00000
+          34     0.00000     0.03592    -0.03209     0.00000     0.00000    -0.00816
+          35     0.00000    -0.07056     0.04934     0.00000     0.00000     0.02962
+          36     0.00443     0.00000     0.00000     0.01253    -0.01258     0.00000
+          37     0.00000     0.01088     0.00178     0.00000     0.00000     0.00834
+          38     0.00000     0.27913    -0.19717     0.00000     0.00000    -0.01964
+          39     0.00031     0.00000     0.00000     0.54885    -0.54795     0.00000
+          40     0.00000    -0.32756     0.22662     0.00000     0.00000     0.13364
+          41     0.00000    -0.18321     0.12917     0.00000     0.00000     0.07471
+          42    -0.01513     0.00000     0.00000    -0.25311     0.25258     0.00000
+          43     0.00000     0.08907    -0.07198     0.00000     0.00000    -0.02123
+          44     0.00000     0.28679    -0.21543     0.00000     0.00000    -0.05788
+          45    -0.02423     0.00000     0.00000     0.28548    -0.28477     0.00000
+          46     0.00000     0.04603     0.03972     0.00000     0.00000     0.01201
+          47     0.00000    -0.02618    -0.02528     0.00000     0.00000    -0.01212
+          48    -0.00170     0.00000     0.00000    -0.06286    -0.06310     0.00000
+          49     0.00000    -0.03592    -0.03209     0.00000     0.00000    -0.00816
+          50     0.00000     0.07056     0.04934     0.00000     0.00000     0.02962
+          51     0.00443     0.00000     0.00000     0.01253     0.01258     0.00000
+          52     0.00000    -0.01088     0.00178     0.00000     0.00000     0.00834
+          53     0.00000    -0.27913    -0.19717     0.00000     0.00000    -0.01965
+          54     0.00031     0.00000     0.00000     0.54885     0.54795     0.00000
+          55     0.00000     0.32756     0.22663     0.00000     0.00000     0.13364
+          56     0.00000     0.18320     0.12917     0.00000     0.00000     0.07471
+          57    -0.01513     0.00000     0.00000    -0.25311    -0.25259     0.00000
+          58     0.00000    -0.08907    -0.07199     0.00000     0.00000    -0.02123
+          59     0.00000    -0.28678    -0.21544     0.00000     0.00000    -0.05788
+          60    -0.02422     0.00000     0.00000     0.28548     0.28477     0.00000
+
+                   37          38          39          40          41          42
+ 
+ Frequency       1386.61     1418.31     1428.80     1534.04     1552.45     1565.66
+ 
+           1    -0.00314    -0.00059     0.04149    -0.07030     0.00521     0.05289
+           2     0.04863     0.13361    -0.11893     0.01310    -0.01368     0.00373
+           3     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           4    -0.03327    -0.04270    -0.02975    -0.00647    -0.01134     0.01105
+           5    -0.02657     0.05671    -0.01373    -0.00972     0.01363     0.02071
+           6     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           7    -0.03286    -0.00348     0.01276     0.01038     0.00678    -0.01422
+           8     0.01380    -0.07164     0.02618    -0.03291    -0.01302     0.01754
+           9     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          10     0.00313     0.00059     0.04149     0.07030     0.00521    -0.05289
+          11    -0.04863    -0.13361    -0.11893    -0.01310    -0.01368    -0.00373
+          12     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          13     0.03327     0.04270    -0.02975     0.00647    -0.01134    -0.01105
+          14     0.02657    -0.05671    -0.01373     0.00972     0.01363    -0.02071
+          15     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          16     0.03286     0.00348     0.01276    -0.01038     0.00678     0.01422
+          17    -0.01380     0.07164     0.02618     0.03291    -0.01302    -0.01755
+          18     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          19    -0.19009    -0.05485     0.11988     0.10849    -0.01491    -0.09313
+          20    -0.44112     0.06402     0.38343     0.30107     0.00936    -0.25944
+          21     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          22    -0.28330     0.08356    -0.06458    -0.21422    -0.04083     0.17251
+          23     0.32447    -0.19721     0.12018     0.24308     0.04469    -0.21388
+          24     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          25     0.19009     0.05485     0.11988    -0.10849    -0.01491     0.09313
+          26     0.44112    -0.06402     0.38344    -0.30107     0.00936     0.25944
+          27     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          28     0.28330    -0.08356    -0.06458     0.21422    -0.04083    -0.17251
+          29    -0.32447     0.19721     0.12018    -0.24308     0.04469     0.21388
+          30     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          31    -0.01827    -0.04556    -0.04596    -0.05611    -0.06437    -0.03806
+          32     0.01394     0.03022     0.02929     0.02954     0.02140     0.00271
+          33     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          34     0.00528     0.01593     0.01379     0.04947     0.07166     0.05417
+          35     0.00191     0.01541     0.00634    -0.00671     0.00524     0.01317
+          36     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          37    -0.00642    -0.00724    -0.00719    -0.13026    -0.19036    -0.14108
+          38     0.08020     0.24133     0.23747    -0.26391    -0.48931    -0.41938
+          39     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          40     0.01765     0.01006     0.01386    -0.00824     0.02658     0.03759
+          41     0.00665     0.01801     0.00964    -0.02012    -0.00011     0.01560
+          42     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          43     0.01076     0.03119     0.02935     0.08766     0.12493     0.09249
+          44     0.03554     0.09053     0.09281     0.19927     0.27395     0.19543
+          45     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          46     0.01827     0.04556    -0.04596     0.05611    -0.06437     0.03806
+          47    -0.01394    -0.03022     0.02929    -0.02954     0.02140    -0.00271
+          48     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          49    -0.00528    -0.01593     0.01379    -0.04947     0.07166    -0.05417
+          50    -0.00191    -0.01541     0.00634     0.00671     0.00524    -0.01317
+          51     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          52     0.00642     0.00724    -0.00719     0.13026    -0.19036     0.14109
+          53    -0.08020    -0.24133     0.23747     0.26391    -0.48930     0.41939
+          54     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          55    -0.01765    -0.01006     0.01386     0.00824     0.02658    -0.03760
+          56    -0.00665    -0.01802     0.00964     0.02012    -0.00011    -0.01560
+          57     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          58    -0.01076    -0.03119     0.02935    -0.08767     0.12493    -0.09249
+          59    -0.03554    -0.09053     0.09281    -0.19927     0.27395    -0.19543
+          60     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+
+                   43          44          45          46          47          48
+ 
+ Frequency       1666.82     1716.32     1724.92     1819.25     1888.97     1948.39
+ 
+           1     0.09685     0.01358    -0.04321     0.02673    -0.13607    -0.01872
+           2     0.00576    -0.02498    -0.01766    -0.10344    -0.01793     0.08143
+           3     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           4    -0.04859    -0.00726     0.00302     0.05089     0.07522    -0.01155
+           5     0.06639    -0.02505    -0.03870     0.07455     0.06057    -0.12194
+           6     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           7     0.00306     0.00937     0.02054    -0.07435    -0.08780    -0.05431
+           8    -0.08982     0.00844     0.02730     0.04320     0.02279     0.11265
+           9     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          10     0.09685    -0.01358    -0.04321     0.02673     0.13607     0.01872
+          11     0.00576     0.02498    -0.01766    -0.10344     0.01793    -0.08143
+          12     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          13    -0.04859     0.00726     0.00302     0.05089    -0.07522     0.01155
+          14     0.06639     0.02505    -0.03870     0.07455    -0.06057     0.12194
+          15     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          16     0.00306    -0.00937     0.02054    -0.07435     0.08780     0.05431
+          17    -0.08982    -0.00844     0.02730     0.04320    -0.02279    -0.11265
+          18     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          19    -0.13751     0.01826     0.06887    -0.06867     0.01708     0.08682
+          20    -0.12667     0.04116     0.12341    -0.27393    -0.13286     0.12063
+          21     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          22    -0.24117     0.00957     0.02994     0.12933     0.02002     0.11895
+          23     0.19358     0.01471     0.02654    -0.23061    -0.13476    -0.09424
+          24     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          25    -0.13751    -0.01826     0.06887    -0.06867    -0.01708    -0.08682
+          26    -0.12667    -0.04116     0.12341    -0.27393     0.13286    -0.12063
+          27     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          28    -0.24117    -0.00957     0.02994     0.12933    -0.02002    -0.11895
+          29     0.19358    -0.01471     0.02654    -0.23061     0.13476     0.09424
+          30     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          31     0.00079    -0.02097     0.02552    -0.01665    -0.00183    -0.00729
+          32     0.04416    -0.07787     0.06178     0.01672     0.01641     0.00896
+          33     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          34    -0.00463    -0.02369     0.02562     0.01674    -0.01611     0.00603
+          35    -0.01930    -0.00538     0.01297     0.01574    -0.02365     0.00494
+          36     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          37     0.00260     0.03247    -0.03247    -0.02092     0.01101    -0.01169
+          38     0.04161     0.16785    -0.20419     0.02364     0.06203     0.00389
+          39     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          40    -0.16247     0.43827    -0.40019    -0.08635     0.05592    -0.02096
+          41    -0.07398     0.14456    -0.12409    -0.01341    -0.00523    -0.00230
+          42     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          43    -0.02671     0.04599    -0.04133     0.00660    -0.00240     0.00434
+          44    -0.12020     0.38129    -0.36570    -0.06255     0.07863    -0.01081
+          45     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          46     0.00079     0.02097     0.02552    -0.01665     0.00183     0.00729
+          47     0.04416     0.07787     0.06178     0.01672    -0.01641    -0.00896
+          48     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          49    -0.00463     0.02369     0.02562     0.01674     0.01611    -0.00603
+          50    -0.01930     0.00538     0.01297     0.01574     0.02365    -0.00494
+          51     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          52     0.00260    -0.03247    -0.03247    -0.02092    -0.01101     0.01169
+          53     0.04161    -0.16785    -0.20419     0.02364    -0.06203    -0.00389
+          54     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          55    -0.16247    -0.43827    -0.40019    -0.08635    -0.05592     0.02096
+          56    -0.07398    -0.14456    -0.12409    -0.01341     0.00523     0.00230
+          57     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          58    -0.02671    -0.04599    -0.04133     0.00660     0.00240    -0.00434
+          59    -0.12020    -0.38129    -0.36570    -0.06255    -0.07863     0.01081
+          60     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+
+                   49          50          51          52          53          54
+ 
+ Frequency       2038.83     2040.51     3658.61     3659.68     3711.79     3711.88
+ 
+           1    -0.02607     0.01085     0.00015     0.00012     0.00052     0.00053
+           2    -0.02487     0.02952     0.00031     0.00041    -0.00169    -0.00166
+           3     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           4     0.01230    -0.00590     0.00144     0.00003     0.00049    -0.00093
+           5     0.00183     0.00284    -0.00028    -0.00001    -0.00004     0.00036
+           6     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           7    -0.01251     0.00321    -0.00256     0.00195    -0.00074     0.00106
+           8     0.00387    -0.01138    -0.00192     0.00140    -0.00080     0.00098
+           9     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          10     0.02607     0.01085     0.00015    -0.00012     0.00052    -0.00053
+          11     0.02487     0.02952     0.00031    -0.00041    -0.00169     0.00166
+          12     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          13    -0.01230    -0.00590     0.00144    -0.00003     0.00049     0.00093
+          14    -0.00183     0.00284    -0.00028     0.00001    -0.00004    -0.00036
+          15     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          16     0.01251     0.00321    -0.00256    -0.00195    -0.00074    -0.00106
+          17    -0.00387    -0.01138    -0.00192    -0.00140    -0.00080    -0.00098
+          18     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          19     0.01007    -0.00948    -0.01676     0.00062    -0.00474     0.01116
+          20    -0.01396     0.00189     0.00602    -0.00010     0.00198    -0.00390
+          21     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          22    -0.01050    -0.02631     0.02721    -0.01886     0.00832    -0.01089
+          23    -0.00322     0.02203     0.02005    -0.01353     0.00643    -0.00807
+          24     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          25    -0.01007    -0.00948    -0.01676    -0.00062    -0.00474    -0.01116
+          26     0.01396     0.00189     0.00602     0.00010     0.00198     0.00390
+          27     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          28     0.01050    -0.02631     0.02721     0.01886     0.00832     0.01089
+          29     0.00322     0.02203     0.02005     0.01353     0.00643     0.00807
+          30     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          31    -0.07346    -0.07255     0.01263    -0.01241    -0.05809     0.05816
+          32    -0.11599    -0.11794    -0.00910     0.00910     0.00828    -0.00834
+          33     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          34     0.07763     0.07777     0.02930    -0.02933     0.01482    -0.01469
+          35     0.09341     0.09405     0.03692    -0.03707     0.01317    -0.01295
+          36     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          37    -0.03649    -0.03621    -0.19887     0.19555     0.62483    -0.62568
+          38     0.13468     0.12943     0.04434    -0.04377    -0.14134     0.14157
+          39     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          40    -0.14941    -0.14876     0.14153    -0.14203     0.03682    -0.03602
+          41     0.04984     0.05079    -0.45174     0.45294    -0.11952     0.11708
+          42     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          43     0.06155     0.06143    -0.44078     0.44194    -0.15319     0.15100
+          44    -0.16789    -0.16944     0.07258    -0.07277     0.02738    -0.02703
+          45     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          46     0.07346    -0.07255     0.01263     0.01241    -0.05809    -0.05816
+          47     0.11599    -0.11794    -0.00910    -0.00910     0.00828     0.00834
+          48     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          49    -0.07763     0.07777     0.02930     0.02933     0.01482     0.01469
+          50    -0.09342     0.09405     0.03692     0.03707     0.01317     0.01295
+          51     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          52     0.03649    -0.03621    -0.19887    -0.19556     0.62484     0.62567
+          53    -0.13468     0.12943     0.04434     0.04377    -0.14134    -0.14157
+          54     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          55     0.14942    -0.14876     0.14153     0.14203     0.03682     0.03602
+          56    -0.04984     0.05079    -0.45174    -0.45294    -0.11952    -0.11708
+          57     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          58    -0.06155     0.06143    -0.44078    -0.44194    -0.15320    -0.15100
+          59     0.16789    -0.16944     0.07258     0.07277     0.02738     0.02703
+          60     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+
+                   55          56          57          58          59          60
+ 
+ Frequency       3716.38     3723.48     3742.09     3745.37     3816.86     3816.89
+ 
+           1    -0.00092     0.00341    -0.00429    -0.00175     0.00008    -0.00011
+           2    -0.00250     0.00159    -0.00009     0.00198     0.00028    -0.00030
+           3     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           4     0.05015    -0.05180     0.02628    -0.02358     0.00013     0.00026
+           5    -0.01695     0.01801    -0.01289     0.01170    -0.00014    -0.00020
+           6     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           7    -0.02263     0.02010     0.04132    -0.04287     0.00131     0.00149
+           8    -0.01414     0.01237     0.03480    -0.03570     0.00103     0.00121
+           9     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          10    -0.00092    -0.00341    -0.00429     0.00175     0.00008     0.00011
+          11    -0.00250    -0.00159    -0.00009    -0.00198     0.00028     0.00030
+          12     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          13     0.05015     0.05180     0.02628     0.02358     0.00013    -0.00026
+          14    -0.01695    -0.01800    -0.01289    -0.01170    -0.00014     0.00020
+          15     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          16    -0.02263    -0.02010     0.04132     0.04287     0.00131    -0.00149
+          17    -0.01414    -0.01237     0.03480     0.03570     0.00103    -0.00121
+          18     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          19    -0.55991     0.57572    -0.28972     0.25636    -0.00184    -0.00224
+          20     0.20673    -0.21297     0.10881    -0.09609     0.00064     0.00084
+          21     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          22     0.24408    -0.21650    -0.46481     0.47822    -0.01560    -0.01771
+          23     0.19273    -0.17135    -0.37166     0.38208    -0.01307    -0.01482
+          24     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          25    -0.55991    -0.57572    -0.28972    -0.25635    -0.00184     0.00224
+          26     0.20674     0.21296     0.10882     0.09608     0.00064    -0.00084
+          27     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          28     0.24407     0.21650    -0.46481    -0.47822    -0.01560     0.01771
+          29     0.19273     0.17135    -0.37166    -0.38208    -0.01307     0.01482
+          30     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          31     0.00003    -0.00113     0.00008     0.00009     0.00208     0.00209
+          32     0.00033     0.00018    -0.00008     0.00012    -0.00051    -0.00051
+          33     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          34    -0.00084     0.00010    -0.00060     0.00080     0.05109     0.05108
+          35    -0.00237     0.00141     0.00262    -0.00275    -0.04324    -0.04323
+          36     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          37    -0.00005     0.01262     0.00102    -0.00206    -0.02702    -0.02708
+          38     0.00050    -0.00303    -0.00098     0.00141     0.00405     0.00407
+          39     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          40    -0.00854     0.00453     0.00880    -0.00909    -0.13348    -0.13344
+          41     0.02782    -0.01419    -0.02826     0.03005     0.44076     0.44065
+          42     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          43     0.01741    -0.00541    -0.00294     0.00028    -0.47317    -0.47315
+          44    -0.00374     0.00155     0.00189    -0.00153     0.07456     0.07456
+          45     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          46     0.00003     0.00113     0.00008    -0.00009     0.00208    -0.00209
+          47     0.00033    -0.00018    -0.00008    -0.00012    -0.00051     0.00051
+          48     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          49    -0.00084    -0.00010    -0.00060    -0.00080     0.05109    -0.05108
+          50    -0.00237    -0.00141     0.00262     0.00275    -0.04324     0.04323
+          51     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          52    -0.00005    -0.01262     0.00102     0.00206    -0.02702     0.02708
+          53     0.00050     0.00303    -0.00098    -0.00141     0.00405    -0.00407
+          54     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          55    -0.00854    -0.00453     0.00880     0.00909    -0.13348     0.13344
+          56     0.02782     0.01419    -0.02826    -0.03005     0.44076    -0.44065
+          57     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          58     0.01741     0.00541    -0.00294    -0.00028    -0.47317     0.47315
+          59    -0.00374    -0.00155     0.00189     0.00153     0.07456    -0.07456
+          60     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+
+
+
+ ----------------------------------------------------------------------------
+ Normal Eigenvalue ||         Derivative Dipole Moments (debye/angs)
+  Mode   [cm**-1]  ||      [d/dqX]             [d/dqY]           [d/dqZ]
+ ------ ---------- || ------------------ ------------------ -----------------
+    1       -7.915 ||       0.000               0.000             0.000
+    2       -5.128 ||       0.000               0.000             0.000
+    3       -4.087 ||       0.000               0.000             0.000
+    4       -1.332 ||       0.000               0.000             0.000
+    5        0.431 ||       0.000               0.000             0.000
+    6        0.676 ||       0.000               0.000             0.000
+    7       37.565 ||       0.000               0.000             0.006
+    8       57.381 ||       0.000               0.000             0.000
+    9      154.879 ||       0.000               0.000             0.079
+   10      197.502 ||       0.024               0.069             0.000
+   11      292.242 ||       0.000               0.000             0.000
+   12      330.233 ||       0.000               0.000             0.000
+   13      444.361 ||       0.000               0.000             0.000
+   14      477.063 ||       0.000               0.000            -0.041
+   15      525.723 ||       0.000               0.000             0.274
+   16      528.447 ||       0.030               0.232             0.000
+   17      629.228 ||       0.000               0.000             0.000
+   18      738.216 ||       0.000               0.000             0.000
+   19      739.974 ||       0.000               0.000             0.000
+   20      795.109 ||       0.000               0.000            -0.073
+   21      797.729 ||       0.000              -0.364             0.000
+   22      918.468 ||       0.000               0.000             0.000
+   23      945.824 ||       0.000               0.000             0.000
+   24     1020.898 ||       0.000               0.000             0.657
+   25     1022.633 ||       0.000               0.000             0.000
+   26     1145.632 ||       0.000               0.000             0.000
+   27     1145.693 ||       0.000               0.000             0.854
+   28     1154.734 ||      -0.022              -0.103             0.000
+   29     1162.740 ||       0.000               0.000             0.000
+   30     1179.521 ||       0.022               0.051             0.000
+   31     1187.569 ||       0.000               0.000            -0.032
+   32     1213.179 ||       0.000               0.000             0.000
+   33     1234.906 ||      -0.013              -0.487             0.000
+   34     1246.480 ||       0.000               0.000             0.423
+   35     1246.732 ||       0.000               0.000             0.000
+   36     1333.402 ||      -0.008              -0.337             0.000
+   37     1386.605 ||       0.000               0.000             0.000
+   38     1418.305 ||       0.000               0.000             0.000
+   39     1428.796 ||      -0.011               0.028             0.000
+   40     1534.038 ||       0.000               0.000             0.000
+   41     1552.453 ||       0.055               0.629             0.000
+   42     1565.663 ||       0.000               0.000             0.000
+   43     1666.818 ||      -0.638               0.183             0.000
+   44     1716.321 ||       0.000               0.000             0.000
+   45     1724.924 ||       0.008               0.187             0.000
+   46     1819.245 ||      -0.053              -0.663             0.000
+   47     1888.970 ||       0.000               0.000             0.000
+   48     1948.387 ||       0.000               0.000             0.000
+   49     2038.826 ||       0.000               0.000             0.000
+   50     2040.513 ||      -0.120              -0.035             0.000
+   51     3658.607 ||      -0.586              -1.698             0.000
+   52     3659.683 ||       0.000               0.000             0.000
+   53     3711.794 ||       0.102               0.471             0.000
+   54     3711.882 ||       0.000               0.000             0.000
+   55     3716.376 ||      -0.165              -0.059             0.000
+   56     3723.485 ||       0.000               0.000             0.000
+   57     3742.085 ||      -0.404              -0.113             0.000
+   58     3745.374 ||       0.000               0.000             0.000
+   59     3816.865 ||      -0.069              -0.044             0.000
+   60     3816.889 ||       0.000               0.000             0.000
+ ----------------------------------------------------------------------------
+
+
+
+  
+  
+ ----------------------------------------------------------------------------
+ Normal Eigenvalue ||                 Infra Red Intensities
+  Mode   [cm**-1]  || [atomic units] [(debye/angs)**2] [(KM/mol)] [arbitrary]
+ ------ ---------- || -------------- ----------------- ---------- -----------
+    1       -7.915 ||    0.000000           0.000         0.000       0.000
+    2       -5.128 ||    0.000000           0.000         0.000       0.000
+    3       -4.087 ||    0.000000           0.000         0.000       0.000
+    4       -1.332 ||    0.000000           0.000         0.000       0.000
+    5        0.431 ||    0.000000           0.000         0.000       0.000
+    6        0.676 ||    0.000000           0.000         0.000       0.000
+    7       37.565 ||    0.000001           0.000         0.001       0.003
+    8       57.381 ||    0.000000           0.000         0.000       0.000
+    9      154.879 ||    0.000270           0.006         0.264       0.535
+   10      197.502 ||    0.000232           0.005         0.227       0.460
+   11      292.242 ||    0.000000           0.000         0.000       0.000
+   12      330.233 ||    0.000000           0.000         0.000       0.000
+   13      444.361 ||    0.000000           0.000         0.000       0.000
+   14      477.063 ||    0.000072           0.002         0.070       0.143
+   15      525.723 ||    0.003243           0.075         3.161       6.418
+   16      528.447 ||    0.002372           0.055         2.312       4.694
+   17      629.228 ||    0.000000           0.000         0.000       0.000
+   18      738.216 ||    0.000000           0.000         0.000       0.000
+   19      739.974 ||    0.000000           0.000         0.000       0.000
+   20      795.109 ||    0.000230           0.005         0.225       0.456
+   21      797.729 ||    0.005739           0.132         5.594      11.357
+   22      918.468 ||    0.000000           0.000         0.000       0.000
+   23      945.824 ||    0.000000           0.000         0.000       0.000
+   24     1020.898 ||    0.018736           0.432        18.265      37.082
+   25     1022.633 ||    0.000000           0.000         0.000       0.000
+   26     1145.632 ||    0.000000           0.000         0.000       0.000
+   27     1145.693 ||    0.031625           0.730        30.829      62.590
+   28     1154.734 ||    0.000481           0.011         0.469       0.953
+   29     1162.740 ||    0.000000           0.000         0.000       0.000
+   30     1179.521 ||    0.000132           0.003         0.129       0.262
+   31     1187.569 ||    0.000045           0.001         0.044       0.089
+   32     1213.179 ||    0.000000           0.000         0.000       0.000
+   33     1234.906 ||    0.010294           0.238        10.036      20.374
+   34     1246.480 ||    0.007750           0.179         7.555      15.338
+   35     1246.732 ||    0.000000           0.000         0.000       0.000
+   36     1333.402 ||    0.004937           0.114         4.813       9.771
+   37     1386.605 ||    0.000000           0.000         0.000       0.000
+   38     1418.305 ||    0.000000           0.000         0.000       0.000
+   39     1428.796 ||    0.000039           0.001         0.038       0.077
+   40     1534.038 ||    0.000000           0.000         0.000       0.000
+   41     1552.453 ||    0.017294           0.399        16.859      34.227
+   42     1565.663 ||    0.000000           0.000         0.000       0.000
+   43     1666.818 ||    0.019068           0.440        18.589      37.739
+   44     1716.321 ||    0.000000           0.000         0.000       0.000
+   45     1724.924 ||    0.001525           0.035         1.486       3.018
+   46     1819.245 ||    0.019151           0.442        18.669      37.903
+   47     1888.970 ||    0.000000           0.000         0.000       0.000
+   48     1948.387 ||    0.000000           0.000         0.000       0.000
+   49     2038.826 ||    0.000000           0.000         0.000       0.000
+   50     2040.513 ||    0.000676           0.016         0.659       1.337
+   51     3658.607 ||    0.139934           3.228       136.415     276.952
+   52     3659.683 ||    0.000000           0.000         0.000       0.000
+   53     3711.794 ||    0.010077           0.232         9.823      19.943
+   54     3711.882 ||    0.000000           0.000         0.000       0.000
+   55     3716.376 ||    0.001329           0.031         1.296       2.631
+   56     3723.485 ||    0.000000           0.000         0.000       0.000
+   57     3742.085 ||    0.007617           0.176         7.425      15.075
+   58     3745.374 ||    0.000000           0.000         0.000       0.000
+   59     3816.865 ||    0.000289           0.007         0.282       0.572
+   60     3816.889 ||    0.000000           0.000         0.000       0.000
+ ----------------------------------------------------------------------------
+
+
+
+
+
+        Vibrational analysis via the FX method 
+  --- with translations and rotations projected out ---
+  --- via the Eckart algorithm                      ---
+ Projected Nuclear Hessian trans-rot subspace norm:3.4681D-33
+                         (should be close to zero!) 
+
+
+From the projected analysis 
+The Zero-Point Energy (Kcal/mol) =         121.46052697
+
+ center of mass
+ --------------
+ x =   0.00000000 y =   0.00000000 z =   0.00000000
+
+ moments of inertia (a.u.)
+ ------------------
+        2576.272265588504           0.000000000000           0.000000000000
+           0.000000000000         376.156742222134           0.000000000000
+           0.000000000000           0.000000000000        2952.429007810638
+
+ Rotational Constants
+ --------------------
+ A=   0.160040 cm-1  (  0.230257 K)
+ B=   0.023367 cm-1  (  0.033619 K)
+ C=   0.020390 cm-1  (  0.029336 K)
+
+
+ Temperature                      =   298.15K
+ frequency scaling parameter      =   1.0000
+
+ Zero-Point correction to Energy  =  121.366 kcal/mol  (  0.193409 au)
+ Thermal correction to Energy     =  126.595 kcal/mol  (  0.201743 au)
+ Thermal correction to Enthalpy   =  127.188 kcal/mol  (  0.202687 au)
+
+ Total Entropy                    =   90.977 cal/mol-K
+   - Translational                =   40.484 cal/mol-K (mol. weight = 130.0782)
+   - Rotational                   =   28.048 cal/mol-K (symmetry #  =        2)
+   - Vibrational                  =   22.445 cal/mol-K
+
+ Cv (constant volume heat capacity) =   30.353 cal/mol-K
+   - Translational                  =    2.979 cal/mol-K
+   - Rotational                     =    2.979 cal/mol-K
+   - Vibrational                    =   24.394 cal/mol-K
+
+
+
+          -------------------------------------------------
+          NORMAL MODE EIGENVECTORS IN CARTESIAN COORDINATES
+          -------------------------------------------------
+             (Projected Frequencies expressed in cm-1)
+
+                    1           2           3           4           5           6
+ 
+ P.Frequency        0.00        0.00        0.00        0.00        0.00        0.00
+ 
+           1     0.00413     0.00000     0.07154     0.00000     0.00000     0.06999
+           2     0.08798     0.00000    -0.00193     0.00000     0.00000     0.00224
+           3     0.00000    -0.00280     0.00000     0.06849     0.07854     0.00000
+           4     0.00041     0.00000     0.04157     0.00000     0.00000     0.07903
+           5     0.09234     0.00000     0.03318     0.00000     0.00000    -0.00834
+           6     0.00000    -0.11044     0.00000     0.08193     0.06985     0.00000
+           7    -0.00518     0.00000    -0.00354     0.00000     0.00000     0.09263
+           8     0.09144     0.00000     0.02592     0.00000     0.00000    -0.00615
+           9     0.00000    -0.09977     0.00000     0.09666     0.01783     0.00000
+          10    -0.00730     0.00000    -0.02057     0.00000     0.00000     0.09777
+          11     0.08612     0.00000    -0.01695     0.00000     0.00000     0.00677
+          12     0.00000     0.01958     0.00000     0.09854    -0.02782     0.00000
+          13    -0.00358     0.00000     0.00940     0.00000     0.00000     0.08873
+          14     0.08177     0.00000    -0.05206     0.00000     0.00000     0.01736
+          15     0.00000     0.12721     0.00000     0.08509    -0.01913     0.00000
+          16     0.00202     0.00000     0.05451     0.00000     0.00000     0.07513
+          17     0.08267     0.00000    -0.04480     0.00000     0.00000     0.01517
+          18     0.00000     0.11654     0.00000     0.07036     0.03289     0.00000
+          19     0.00195     0.00000     0.05398     0.00000     0.00000     0.07529
+          20     0.09651     0.00000     0.06676     0.00000     0.00000    -0.01846
+          21     0.00000    -0.20411     0.00000     0.08078     0.10462     0.00000
+          22    -0.00793     0.00000    -0.02568     0.00000     0.00000     0.09930
+          23     0.09492     0.00000     0.05399     0.00000     0.00000    -0.01462
+          24     0.00000    -0.18541     0.00000     0.10679     0.01279     0.00000
+          25    -0.00512     0.00000    -0.00301     0.00000     0.00000     0.09247
+          26     0.07760     0.00000    -0.08564     0.00000     0.00000     0.02748
+          27     0.00000     0.22088     0.00000     0.08624    -0.05390     0.00000
+          28     0.00477     0.00000     0.07665     0.00000     0.00000     0.06845
+          29     0.07918     0.00000    -0.07287     0.00000     0.00000     0.02363
+          30     0.00000     0.20219     0.00000     0.06023     0.03793     0.00000
+          31    -0.01331     0.00000    -0.06908     0.00000     0.00000     0.11239
+          32     0.08492     0.00000    -0.02665     0.00000     0.00000     0.00970
+          33     0.00000     0.03650     0.00000     0.11420    -0.08500     0.00000
+          34    -0.01733     0.00000    -0.10143     0.00000     0.00000     0.12214
+          35     0.08851     0.00000     0.00233     0.00000     0.00000     0.00096
+          36     0.00000    -0.05406     0.00000     0.12790    -0.10016     0.00000
+          37    -0.01430     0.00000    -0.07707     0.00000     0.00000     0.11480
+          38     0.08058     0.00000    -0.06161     0.00000     0.00000     0.02024
+          39     0.00000     0.13513     0.00000     0.11372    -0.11602     0.00000
+          40    -0.02157     0.00000    -0.13564     0.00000     0.00000     0.13246
+          41     0.08723     0.00000    -0.00805     0.00000     0.00000     0.00409
+          42     0.00000    -0.03197     0.00000     0.13862    -0.14277     0.00000
+          43    -0.01665     0.00000    -0.09601     0.00000     0.00000     0.12051
+          44     0.09289     0.00000     0.03763     0.00000     0.00000    -0.00968
+          45     0.00000    -0.15428     0.00000     0.12929    -0.07159     0.00000
+          46     0.01015     0.00000     0.12005     0.00000     0.00000     0.05537
+          47     0.08919     0.00000     0.00777     0.00000     0.00000    -0.00068
+          48     0.00000    -0.01973     0.00000     0.05282     0.13571     0.00000
+          49     0.01416     0.00000     0.15240     0.00000     0.00000     0.04561
+          50     0.08559     0.00000    -0.02120     0.00000     0.00000     0.00806
+          51     0.00000     0.07083     0.00000     0.03913     0.15088     0.00000
+          52     0.01114     0.00000     0.12804     0.00000     0.00000     0.05296
+          53     0.09352     0.00000     0.04273     0.00000     0.00000    -0.01122
+          54     0.00000    -0.11835     0.00000     0.05331     0.16674     0.00000
+          55     0.01841     0.00000     0.18661     0.00000     0.00000     0.03530
+          56     0.08688     0.00000    -0.01083     0.00000     0.00000     0.00493
+          57     0.00000     0.04874     0.00000     0.02841     0.19349     0.00000
+          58     0.01349     0.00000     0.14698     0.00000     0.00000     0.04725
+          59     0.08121     0.00000    -0.05651     0.00000     0.00000     0.01870
+          60     0.00000     0.17105     0.00000     0.03774     0.12231     0.00000
+
+                    7           8           9          10          11          12
+ 
+ P.Frequency       37.56       57.57      154.88      197.50      292.26      330.30
+ 
+           1     0.00000     0.00000     0.00000    -0.05727    -0.06701     0.00000
+           2     0.00000     0.00000     0.00000     0.01044    -0.02413     0.00000
+           3    -0.04178    -0.04920    -0.02768     0.00000     0.00000    -0.12147
+           4     0.00000     0.00000     0.00000    -0.06229    -0.03575     0.00000
+           5     0.00000     0.00000     0.00000     0.01362    -0.05529     0.00000
+           6    -0.04961     0.02964    -0.06339     0.00000     0.00000    -0.07622
+           7     0.00000     0.00000     0.00000    -0.06114     0.04458     0.00000
+           8     0.00000     0.00000     0.00000     0.00630    -0.03773     0.00000
+           9    -0.04687     0.08101    -0.06874     0.00000     0.00000     0.06638
+          10     0.00000     0.00000     0.00000    -0.05726     0.06701     0.00000
+          11     0.00000     0.00000     0.00000     0.01044     0.02413     0.00000
+          12    -0.04178     0.04920    -0.02768     0.00000     0.00000     0.12147
+          13     0.00000     0.00000     0.00000    -0.06229     0.03576     0.00000
+          14     0.00000     0.00000     0.00000     0.01362     0.05529     0.00000
+          15    -0.04961    -0.02963    -0.06339     0.00000     0.00000     0.07622
+          16     0.00000     0.00000     0.00000    -0.06115    -0.04458     0.00000
+          17     0.00000     0.00000     0.00000     0.00630     0.03773     0.00000
+          18    -0.04688    -0.08100    -0.06874     0.00000     0.00000    -0.06638
+          19     0.00000     0.00000     0.00000    -0.06266    -0.05350     0.00000
+          20     0.00000     0.00000     0.00000     0.01443    -0.10327     0.00000
+          21    -0.05456     0.05624    -0.05128     0.00000     0.00000    -0.11626
+          22     0.00000     0.00000     0.00000    -0.05927     0.08119     0.00000
+          23     0.00000     0.00000     0.00000     0.00141    -0.08060     0.00000
+          24    -0.05256     0.15241    -0.05921     0.00000     0.00000     0.09173
+          25     0.00000     0.00000     0.00000    -0.06266     0.05350     0.00000
+          26     0.00000     0.00000     0.00000     0.01443     0.10327     0.00000
+          27    -0.05457    -0.05623    -0.05129     0.00000     0.00000     0.11627
+          28     0.00000     0.00000     0.00000    -0.05927    -0.08119     0.00000
+          29     0.00000     0.00000     0.00000     0.00141     0.08060     0.00000
+          30    -0.05258    -0.15240    -0.05921     0.00000     0.00000    -0.09173
+          31     0.00000     0.00000     0.00000     0.03149     0.03033     0.00000
+          32     0.00000     0.00000     0.00000     0.02842     0.02480     0.00000
+          33    -0.02631     0.08852     0.12199     0.00000     0.00000    -0.02986
+          34     0.00000     0.00000     0.00000     0.12650    -0.06624     0.00000
+          35     0.00000     0.00000     0.00000    -0.05484     0.11245     0.00000
+          36     0.14915    -0.09178     0.02173     0.00000     0.00000    -0.02506
+          37     0.00000     0.00000     0.00000     0.05185     0.01357     0.00000
+          38     0.00000     0.00000     0.00000     0.11779    -0.04694     0.00000
+          39    -0.16291     0.26685     0.34792     0.00000     0.00000    -0.25254
+          40     0.00000     0.00000     0.00000     0.23041    -0.18362     0.00000
+          41     0.00000     0.00000     0.00000    -0.02347     0.07754     0.00000
+          42     0.15091    -0.05254     0.16659     0.00000     0.00000    -0.23871
+          43     0.00000     0.00000     0.00000     0.11006    -0.04713     0.00000
+          44     0.00000     0.00000     0.00000    -0.15697     0.22686     0.00000
+          45     0.30274    -0.29124    -0.21245     0.00000     0.00000     0.19501
+          46     0.00000     0.00000     0.00000     0.03149    -0.03033     0.00000
+          47     0.00000     0.00000     0.00000     0.02842    -0.02480     0.00000
+          48    -0.02632    -0.08851     0.12199     0.00000     0.00000     0.02986
+          49     0.00000     0.00000     0.00000     0.12650     0.06623     0.00000
+          50     0.00000     0.00000     0.00000    -0.05484    -0.11245     0.00000
+          51     0.14916     0.09176     0.02173     0.00000     0.00000     0.02506
+          52     0.00000     0.00000     0.00000     0.05185    -0.01357     0.00000
+          53     0.00000     0.00000     0.00000     0.11779     0.04693     0.00000
+          54    -0.16295    -0.26682     0.34792     0.00000     0.00000     0.25254
+          55     0.00000     0.00000     0.00000     0.23041     0.18362     0.00000
+          56     0.00000     0.00000     0.00000    -0.02347    -0.07754     0.00000
+          57     0.15093     0.05251     0.16659     0.00000     0.00000     0.23871
+          58     0.00000     0.00000     0.00000     0.11007     0.04713     0.00000
+          59     0.00000     0.00000     0.00000    -0.15698    -0.22685     0.00000
+          60     0.30278     0.29119    -0.21244     0.00000     0.00000    -0.19501
+
+                   13          14          15          16          17          18
+ 
+ P.Frequency      444.36      477.06      525.72      528.45      629.25      738.22
+ 
+           1     0.06276     0.00000     0.00000     0.02051     0.03836    -0.03983
+           2    -0.05989     0.00000     0.00000     0.03341     0.06920     0.00070
+           3     0.00000     0.01129    -0.13079     0.00000     0.00000     0.00000
+           4     0.00354     0.00000     0.00000     0.04170     0.07879    -0.08847
+           5     0.02480     0.00000     0.00000     0.05029     0.03724     0.09868
+           6     0.00000     0.11960     0.06326     0.00000     0.00000     0.00000
+           7    -0.07025     0.00000     0.00000     0.04430    -0.01414     0.06277
+           8     0.02981     0.00000     0.00000     0.05464     0.01275     0.12241
+           9     0.00000    -0.12520     0.04108     0.00000     0.00000     0.00000
+          10    -0.06276     0.00000     0.00000     0.02051    -0.03836     0.03983
+          11     0.05989     0.00000     0.00000     0.03341    -0.06920    -0.00070
+          12     0.00000     0.01129    -0.13079     0.00000     0.00000     0.00000
+          13    -0.00354     0.00000     0.00000     0.04170    -0.07879     0.08847
+          14    -0.02480     0.00000     0.00000     0.05029    -0.03724    -0.09868
+          15     0.00000     0.11959     0.06326     0.00000     0.00000     0.00000
+          16     0.07025     0.00000     0.00000     0.04430     0.01414    -0.06277
+          17    -0.02981     0.00000     0.00000     0.05464    -0.01275    -0.12241
+          18     0.00000    -0.12520     0.04108     0.00000     0.00000     0.00000
+          19     0.03871     0.00000     0.00000     0.04528     0.08459    -0.10472
+          20     0.11542     0.00000     0.00000     0.05454     0.05018     0.05722
+          21     0.00000     0.23583     0.22478     0.00000     0.00000     0.00000
+          22    -0.07376     0.00000     0.00000     0.04535    -0.09269     0.08529
+          23     0.03511     0.00000     0.00000     0.05288     0.11109     0.09499
+          24     0.00000    -0.28418     0.18516     0.00000     0.00000     0.00000
+          25    -0.03871     0.00000     0.00000     0.04528    -0.08459     0.10472
+          26    -0.11542     0.00000     0.00000     0.05454    -0.05018    -0.05722
+          27     0.00000     0.23583     0.22478     0.00000     0.00000     0.00000
+          28     0.07376     0.00000     0.00000     0.04535     0.09269    -0.08529
+          29    -0.03511     0.00000     0.00000     0.05288    -0.11109    -0.09499
+          30     0.00000    -0.28418     0.18516     0.00000     0.00000     0.00000
+          31     0.00283     0.00000     0.00000    -0.09768     0.10250     0.02102
+          32     0.11041     0.00000     0.00000    -0.01438    -0.05606    -0.00414
+          33     0.00000    -0.00004    -0.04669     0.00000     0.00000     0.00000
+          34     0.03953     0.00000     0.00000    -0.01668     0.01227     0.01487
+          35     0.09029     0.00000     0.00000    -0.10291     0.03373     0.00831
+          36     0.00000    -0.00049     0.01921     0.00000     0.00000     0.00000
+          37     0.01263     0.00000     0.00000    -0.09898     0.10831     0.02214
+          38     0.16300     0.00000     0.00000    -0.02812    -0.03099     0.00098
+          39     0.00000    -0.01154     0.13496     0.00000     0.00000     0.00000
+          40     0.06901     0.00000     0.00000     0.14699    -0.19558    -0.01572
+          41     0.10055     0.00000     0.00000    -0.05532    -0.02817    -0.00066
+          42     0.00000    -0.02458     0.25674     0.00000     0.00000     0.00000
+          43     0.03670     0.00000     0.00000    -0.04521     0.04688     0.02069
+          44     0.06581     0.00000     0.00000    -0.27460     0.25385     0.04656
+          45     0.00000     0.02314    -0.15944     0.00000     0.00000     0.00000
+          46    -0.00283     0.00000     0.00000    -0.09768    -0.10250    -0.02102
+          47    -0.11041     0.00000     0.00000    -0.01438     0.05606     0.00414
+          48     0.00000    -0.00004    -0.04669     0.00000     0.00000     0.00000
+          49    -0.03953     0.00000     0.00000    -0.01668    -0.01227    -0.01487
+          50    -0.09029     0.00000     0.00000    -0.10291    -0.03373    -0.00831
+          51     0.00000    -0.00049     0.01921     0.00000     0.00000     0.00000
+          52    -0.01263     0.00000     0.00000    -0.09898    -0.10831    -0.02214
+          53    -0.16300     0.00000     0.00000    -0.02812     0.03099    -0.00098
+          54     0.00000    -0.01154     0.13496     0.00000     0.00000     0.00000
+          55    -0.06901     0.00000     0.00000     0.14699     0.19558     0.01572
+          56    -0.10055     0.00000     0.00000    -0.05532     0.02817     0.00066
+          57     0.00000    -0.02458     0.25673     0.00000     0.00000     0.00000
+          58    -0.03670     0.00000     0.00000    -0.04521    -0.04688    -0.02069
+          59    -0.06581     0.00000     0.00000    -0.27460    -0.25385    -0.04656
+          60     0.00000     0.02314    -0.15944     0.00000     0.00000     0.00000
+
+                   19          20          21          22          23          24
+ 
+ P.Frequency      740.01      795.11      797.73      918.47      945.83     1020.90
+ 
+           1     0.00000     0.00000     0.00308     0.00000    -0.00793     0.00000
+           2     0.00000     0.00000    -0.00759     0.00000     0.04085     0.00000
+           3    -0.02336     0.07154     0.00000     0.14182     0.00000     0.09529
+           4     0.00000     0.00000    -0.03876     0.00000     0.11540     0.00000
+           5     0.00000     0.00000     0.07241     0.00000    -0.00155     0.00000
+           6     0.08040     0.01225     0.00000    -0.05592     0.00000    -0.05688
+           7     0.00000     0.00000    -0.01463     0.00000     0.11653     0.00000
+           8     0.00000     0.00000     0.07546     0.00000     0.03272     0.00000
+           9    -0.07734     0.01556     0.00000     0.05474     0.00000    -0.06186
+          10     0.00000     0.00000     0.00308     0.00000     0.00793     0.00000
+          11     0.00000     0.00000    -0.00759     0.00000    -0.04085     0.00000
+          12     0.02336     0.07154     0.00000    -0.14182     0.00000     0.09529
+          13     0.00000     0.00000    -0.03876     0.00000    -0.11540     0.00000
+          14     0.00000     0.00000     0.07241     0.00000     0.00155     0.00000
+          15    -0.08040     0.01224     0.00000     0.05592     0.00000    -0.05688
+          16     0.00000     0.00000    -0.01463     0.00000    -0.11653     0.00000
+          17     0.00000     0.00000     0.07546     0.00000    -0.03272     0.00000
+          18     0.07734     0.01556     0.00000    -0.05474     0.00000    -0.06187
+          19     0.00000     0.00000    -0.02034     0.00000     0.08652     0.00000
+          20     0.00000     0.00000     0.12139     0.00000    -0.10016     0.00000
+          21     0.12467    -0.25783     0.00000    -0.17909     0.00000     0.35215
+          22     0.00000     0.00000    -0.04603     0.00000     0.07209     0.00000
+          23     0.00000     0.00000     0.11184     0.00000     0.10026     0.00000
+          24    -0.14097    -0.25368     0.00000     0.17863     0.00000     0.35835
+          25     0.00000     0.00000    -0.02034     0.00000    -0.08652     0.00000
+          26     0.00000     0.00000     0.12139     0.00000     0.10016     0.00000
+          27    -0.12467    -0.25783     0.00000     0.17909     0.00000     0.35220
+          28     0.00000     0.00000    -0.04603     0.00000    -0.07209     0.00000
+          29     0.00000     0.00000     0.11184     0.00000    -0.10026     0.00000
+          30     0.14097    -0.25368     0.00000    -0.17863     0.00000     0.35840
+          31     0.00000     0.00000     0.07190     0.00000    -0.03659     0.00000
+          32     0.00000     0.00000    -0.10274     0.00000     0.05177     0.00000
+          33     0.09850    -0.09541     0.00000     0.06505     0.00000    -0.04582
+          34     0.00000     0.00000    -0.00672     0.00000     0.00091     0.00000
+          35     0.00000     0.00000    -0.05090     0.00000     0.03623     0.00000
+          36    -0.01640     0.01410     0.00000    -0.00571     0.00000     0.00058
+          37     0.00000     0.00000     0.07554     0.00000    -0.03977     0.00000
+          38     0.00000     0.00000    -0.10824     0.00000     0.05562     0.00000
+          39    -0.12715     0.14285     0.00000    -0.07954     0.00000     0.01666
+          40     0.00000     0.00000    -0.20864     0.00000     0.15451     0.00000
+          41     0.00000     0.00000    -0.11382     0.00000     0.08404     0.00000
+          42    -0.35937     0.35689     0.00000    -0.22407     0.00000     0.15043
+          43     0.00000     0.00000     0.02241     0.00000    -0.01988     0.00000
+          44     0.00000     0.00000     0.14785     0.00000    -0.10101     0.00000
+          45     0.20490    -0.20285     0.00000     0.11152     0.00000    -0.05959
+          46     0.00000     0.00000     0.07190     0.00000     0.03659     0.00000
+          47     0.00000     0.00000    -0.10274     0.00000    -0.05177     0.00000
+          48    -0.09850    -0.09541     0.00000    -0.06505     0.00000    -0.04582
+          49     0.00000     0.00000    -0.00672     0.00000    -0.00091     0.00000
+          50     0.00000     0.00000    -0.05090     0.00000    -0.03623     0.00000
+          51     0.01640     0.01410     0.00000     0.00571     0.00000     0.00058
+          52     0.00000     0.00000     0.07554     0.00000     0.03977     0.00000
+          53     0.00000     0.00000    -0.10824     0.00000    -0.05562     0.00000
+          54     0.12715     0.14285     0.00000     0.07954     0.00000     0.01666
+          55     0.00000     0.00000    -0.20864     0.00000    -0.15451     0.00000
+          56     0.00000     0.00000    -0.11382     0.00000    -0.08404     0.00000
+          57     0.35938     0.35689     0.00000     0.22407     0.00000     0.15042
+          58     0.00000     0.00000     0.02241     0.00000     0.01988     0.00000
+          59     0.00000     0.00000     0.14785     0.00000     0.10101     0.00000
+          60    -0.20490    -0.20285     0.00000    -0.11152     0.00000    -0.05958
+
+                   25          26          27          28          29          30
+ 
+ P.Frequency     1022.73     1145.66     1145.69     1154.73     1162.74     1179.52
+ 
+           1     0.00000     0.00000     0.00000     0.10359     0.00000     0.01252
+           2     0.00000     0.00000     0.00000     0.00246     0.00000     0.03414
+           3     0.00148    -0.00332    -0.00553     0.00000    -0.02527     0.00000
+           4     0.00000     0.00000     0.00000    -0.05480     0.00000     0.11460
+           5     0.00000     0.00000     0.00000    -0.07055     0.00000    -0.01877
+           6     0.06431    -0.00254    -0.00162     0.00000     0.07166     0.00000
+           7     0.00000     0.00000     0.00000    -0.05489     0.00000    -0.12265
+           8     0.00000     0.00000     0.00000     0.07255     0.00000    -0.02036
+           9     0.06970     0.00352     0.00558     0.00000    -0.07017     0.00000
+          10     0.00000     0.00000     0.00000     0.10359     0.00000     0.01252
+          11     0.00000     0.00000     0.00000     0.00246     0.00000     0.03414
+          12    -0.00149     0.00327    -0.00556     0.00000     0.02527     0.00000
+          13     0.00000     0.00000     0.00000    -0.05480     0.00000     0.11460
+          14     0.00000     0.00000     0.00000    -0.07055     0.00000    -0.01877
+          15    -0.06430     0.00253    -0.00165     0.00000    -0.07166     0.00000
+          16     0.00000     0.00000     0.00000    -0.05489     0.00000    -0.12265
+          17     0.00000     0.00000     0.00000     0.07255     0.00000    -0.02036
+          18    -0.06970    -0.00346     0.00561     0.00000     0.07017     0.00000
+          19     0.00000     0.00000     0.00000    -0.03928     0.00000     0.18137
+          20     0.00000     0.00000     0.00000    -0.02394     0.00000     0.14426
+          21    -0.43571     0.01888     0.01172     0.00000    -0.43520     0.00000
+          22     0.00000     0.00000     0.00000    -0.02808     0.00000    -0.24524
+          23     0.00000     0.00000     0.00000     0.03601     0.00000     0.12498
+          24    -0.44606    -0.02962    -0.02711     0.00000     0.41701     0.00000
+          25     0.00000     0.00000     0.00000    -0.03928     0.00000     0.18137
+          26     0.00000     0.00000     0.00000    -0.02394     0.00000     0.14426
+          27     0.43567    -0.01877     0.01190     0.00000     0.43520     0.00000
+          28     0.00000     0.00000     0.00000    -0.02808     0.00000    -0.24523
+          29     0.00000     0.00000     0.00000     0.03601     0.00000     0.12498
+          30     0.44602     0.02935    -0.02739     0.00000    -0.41701     0.00000
+          31     0.00000     0.00000     0.00000     0.02381     0.00000     0.00056
+          32     0.00000     0.00000     0.00000    -0.01392     0.00000    -0.00227
+          33     0.00004    -0.03153     0.03283     0.00000    -0.01047     0.00000
+          34     0.00000     0.00000     0.00000    -0.02289     0.00000     0.00331
+          35     0.00000     0.00000     0.00000     0.03412     0.00000    -0.01392
+          36    -0.00177     0.10198    -0.10305     0.00000     0.00522     0.00000
+          37     0.00000     0.00000     0.00000    -0.01919     0.00000    -0.00109
+          38     0.00000     0.00000     0.00000    -0.20991     0.00000    -0.01487
+          39     0.00413    -0.02216     0.02395     0.00000    -0.03029     0.00000
+          40     0.00000     0.00000     0.00000     0.20667     0.00000    -0.04344
+          41     0.00000     0.00000     0.00000     0.10408     0.00000    -0.02917
+          42     0.01295    -0.39760     0.39833     0.00000     0.02115     0.00000
+          43     0.00000     0.00000     0.00000    -0.05828     0.00000     0.00898
+          44     0.00000     0.00000     0.00000    -0.19993     0.00000     0.02700
+          45    -0.00358    -0.44204     0.44818     0.00000    -0.04957     0.00000
+          46     0.00000     0.00000     0.00000     0.02381     0.00000     0.00056
+          47     0.00000     0.00000     0.00000    -0.01392     0.00000    -0.00227
+          48    -0.00004     0.03186     0.03252     0.00000     0.01047     0.00000
+          49     0.00000     0.00000     0.00000    -0.02290     0.00000     0.00331
+          50     0.00000     0.00000     0.00000     0.03413     0.00000    -0.01392
+          51     0.00177    -0.10299    -0.10203     0.00000    -0.00522     0.00000
+          52     0.00000     0.00000     0.00000    -0.01919     0.00000    -0.00109
+          53     0.00000     0.00000     0.00000    -0.20991     0.00000    -0.01487
+          54    -0.00413     0.02240     0.02372     0.00000     0.03028     0.00000
+          55     0.00000     0.00000     0.00000     0.20668     0.00000    -0.04344
+          56     0.00000     0.00000     0.00000     0.10408     0.00000    -0.02917
+          57    -0.01297     0.40153     0.39436     0.00000    -0.02114     0.00000
+          58     0.00000     0.00000     0.00000    -0.05828     0.00000     0.00898
+          59     0.00000     0.00000     0.00000    -0.19993     0.00000     0.02700
+          60     0.00359     0.44647     0.44377     0.00000     0.04958     0.00000
+
+                   31          32          33          34          35          36
+ 
+ P.Frequency     1187.57     1213.18     1234.91     1246.48     1246.72     1333.40
+ 
+           1     0.00000     0.01671    -0.03108     0.00000     0.00000    -0.06760
+           2     0.00000    -0.04870    -0.03579     0.00000     0.00000    -0.06314
+           3     0.00066     0.00000     0.00000     0.00226    -0.00126     0.00000
+           4     0.00000     0.02018     0.00509     0.00000     0.00000     0.03843
+           5     0.00000    -0.02797     0.09156     0.00000     0.00000    -0.00320
+           6    -0.07615     0.00000     0.00000    -0.00294     0.00341     0.00000
+           7     0.00000     0.03926    -0.00028     0.00000     0.00000     0.03999
+           8     0.00000     0.01769    -0.07157     0.00000     0.00000     0.03715
+           9     0.07479     0.00000     0.00000     0.00046    -0.00077     0.00000
+          10     0.00000    -0.01671    -0.03108     0.00000     0.00000    -0.06760
+          11     0.00000     0.04870    -0.03579     0.00000     0.00000    -0.06314
+          12     0.00067     0.00000     0.00000     0.00226     0.00126     0.00000
+          13     0.00000    -0.02018     0.00509     0.00000     0.00000     0.03843
+          14     0.00000     0.02797     0.09156     0.00000     0.00000    -0.00320
+          15    -0.07615     0.00000     0.00000    -0.00293    -0.00341     0.00000
+          16     0.00000    -0.03926    -0.00028     0.00000     0.00000     0.03999
+          17     0.00000    -0.01769    -0.07157     0.00000     0.00000     0.03715
+          18     0.07479     0.00000     0.00000     0.00046     0.00077     0.00000
+          19     0.00000     0.01006     0.06648     0.00000     0.00000    -0.04887
+          20     0.00000    -0.06748     0.26654     0.00000     0.00000    -0.26464
+          21     0.43126     0.00000     0.00000     0.00765    -0.02829     0.00000
+          22     0.00000     0.07827    -0.00099     0.00000     0.00000    -0.24662
+          23     0.00000    -0.02081    -0.08141     0.00000     0.00000     0.40670
+          24    -0.41643     0.00000     0.00000     0.01297     0.02679     0.00000
+          25     0.00000    -0.01006     0.06648     0.00000     0.00000    -0.04887
+          26     0.00000     0.06748     0.26654     0.00000     0.00000    -0.26464
+          27     0.43125     0.00000     0.00000     0.00764     0.02829     0.00000
+          28     0.00000    -0.07827    -0.00099     0.00000     0.00000    -0.24662
+          29     0.00000     0.02081    -0.08141     0.00000     0.00000     0.40670
+          30    -0.41643     0.00000     0.00000     0.01298    -0.02678     0.00000
+          31     0.00000    -0.04603     0.03972     0.00000     0.00000     0.01201
+          32     0.00000     0.02618    -0.02528     0.00000     0.00000    -0.01212
+          33    -0.00170     0.00000     0.00000    -0.06285    -0.06311     0.00000
+          34     0.00000     0.03592    -0.03209     0.00000     0.00000    -0.00816
+          35     0.00000    -0.07056     0.04934     0.00000     0.00000     0.02962
+          36     0.00443     0.00000     0.00000     0.01252     0.01259     0.00000
+          37     0.00000     0.01088     0.00178     0.00000     0.00000     0.00834
+          38     0.00000     0.27914    -0.19717     0.00000     0.00000    -0.01964
+          39     0.00031     0.00000     0.00000     0.54875     0.54805     0.00000
+          40     0.00000    -0.32757     0.22662     0.00000     0.00000     0.13364
+          41     0.00000    -0.18321     0.12917     0.00000     0.00000     0.07471
+          42    -0.01513     0.00000     0.00000    -0.25307    -0.25266     0.00000
+          43     0.00000     0.08907    -0.07198     0.00000     0.00000    -0.02123
+          44     0.00000     0.28679    -0.21543     0.00000     0.00000    -0.05788
+          45    -0.02423     0.00000     0.00000     0.28543     0.28478     0.00000
+          46     0.00000     0.04603     0.03972     0.00000     0.00000     0.01201
+          47     0.00000    -0.02618    -0.02528     0.00000     0.00000    -0.01212
+          48    -0.00170     0.00000     0.00000    -0.06288     0.06309     0.00000
+          49     0.00000    -0.03592    -0.03209     0.00000     0.00000    -0.00816
+          50     0.00000     0.07056     0.04934     0.00000     0.00000     0.02962
+          51     0.00443     0.00000     0.00000     0.01253    -0.01258     0.00000
+          52     0.00000    -0.01088     0.00178     0.00000     0.00000     0.00834
+          53     0.00000    -0.27913    -0.19717     0.00000     0.00000    -0.01965
+          54     0.00031     0.00000     0.00000     0.54895    -0.54785     0.00000
+          55     0.00000     0.32757     0.22663     0.00000     0.00000     0.13364
+          56     0.00000     0.18320     0.12917     0.00000     0.00000     0.07471
+          57    -0.01513     0.00000     0.00000    -0.25316     0.25257     0.00000
+          58     0.00000    -0.08907    -0.07199     0.00000     0.00000    -0.02123
+          59     0.00000    -0.28679    -0.21544     0.00000     0.00000    -0.05788
+          60    -0.02423     0.00000     0.00000     0.28553    -0.28468     0.00000
+
+                   37          38          39          40          41          42
+ 
+ P.Frequency     1386.60     1418.31     1428.80     1534.05     1552.45     1565.66
+ 
+           1    -0.00313    -0.00060     0.04149    -0.07029     0.00521     0.05290
+           2     0.04863     0.13361    -0.11893     0.01310    -0.01368     0.00373
+           3     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           4    -0.03327    -0.04270    -0.02975    -0.00646    -0.01134     0.01105
+           5    -0.02657     0.05671    -0.01373    -0.00972     0.01363     0.02071
+           6     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           7    -0.03286    -0.00348     0.01276     0.01038     0.00678    -0.01422
+           8     0.01380    -0.07165     0.02618    -0.03290    -0.01302     0.01755
+           9     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          10     0.00313     0.00060     0.04149     0.07029     0.00521    -0.05290
+          11    -0.04863    -0.13361    -0.11893    -0.01310    -0.01368    -0.00373
+          12     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          13     0.03327     0.04270    -0.02975     0.00646    -0.01134    -0.01105
+          14     0.02657    -0.05671    -0.01374     0.00972     0.01363    -0.02071
+          15     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          16     0.03286     0.00348     0.01276    -0.01038     0.00678     0.01422
+          17    -0.01380     0.07165     0.02618     0.03290    -0.01302    -0.01755
+          18     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          19    -0.19010    -0.05484     0.11988     0.10848    -0.01491    -0.09315
+          20    -0.44112     0.06404     0.38343     0.30102     0.00936    -0.25949
+          21     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          22    -0.28330     0.08355    -0.06458    -0.21420    -0.04083     0.17254
+          23     0.32447    -0.19720     0.12018     0.24306     0.04469    -0.21392
+          24     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          25     0.19009     0.05484     0.11988    -0.10848    -0.01491     0.09315
+          26     0.44112    -0.06405     0.38344    -0.30102     0.00936     0.25948
+          27     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          28     0.28330    -0.08354    -0.06458     0.21420    -0.04083    -0.17255
+          29    -0.32447     0.19719     0.12018    -0.24306     0.04469     0.21392
+          30     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          31    -0.01828    -0.04556    -0.04596    -0.05612    -0.06437    -0.03805
+          32     0.01394     0.03022     0.02929     0.02954     0.02140     0.00271
+          33     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          34     0.00528     0.01594     0.01379     0.04948     0.07166     0.05416
+          35     0.00191     0.01541     0.00634    -0.00671     0.00524     0.01317
+          36     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          37    -0.00642    -0.00724    -0.00719    -0.13028    -0.19036    -0.14106
+          38     0.08020     0.24131     0.23747    -0.26398    -0.48931    -0.41934
+          39     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          40     0.01765     0.01006     0.01386    -0.00824     0.02658     0.03759
+          41     0.00665     0.01802     0.00964    -0.02012    -0.00011     0.01560
+          42     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          43     0.01076     0.03119     0.02935     0.08768     0.12493     0.09247
+          44     0.03555     0.09053     0.09281     0.19932     0.27395     0.19539
+          45     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          46     0.01828     0.04556    -0.04596     0.05612    -0.06437     0.03805
+          47    -0.01394    -0.03022     0.02929    -0.02954     0.02140    -0.00271
+          48     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          49    -0.00528    -0.01594     0.01379    -0.04948     0.07166    -0.05416
+          50    -0.00191    -0.01541     0.00634     0.00671     0.00524    -0.01317
+          51     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          52     0.00642     0.00724    -0.00719     0.13028    -0.19036     0.14107
+          53    -0.08020    -0.24132     0.23747     0.26398    -0.48930     0.41935
+          54     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          55    -0.01765    -0.01006     0.01386     0.00824     0.02658    -0.03760
+          56    -0.00665    -0.01802     0.00964     0.02012    -0.00011    -0.01560
+          57     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          58    -0.01076    -0.03119     0.02935    -0.08768     0.12493    -0.09247
+          59    -0.03555    -0.09053     0.09281    -0.19932     0.27395    -0.19539
+          60     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+
+                   43          44          45          46          47          48
+ 
+ P.Frequency     1666.82     1716.32     1724.92     1819.24     1888.97     1948.39
+ 
+           1     0.09685     0.01358    -0.04321     0.02673    -0.13606    -0.01873
+           2     0.00576    -0.02498    -0.01766    -0.10344    -0.01793     0.08143
+           3     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           4    -0.04859    -0.00726     0.00302     0.05089     0.07522    -0.01155
+           5     0.06639    -0.02504    -0.03870     0.07455     0.06057    -0.12194
+           6     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           7     0.00306     0.00937     0.02054    -0.07435    -0.08780    -0.05431
+           8    -0.08982     0.00844     0.02730     0.04320     0.02279     0.11265
+           9     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          10     0.09685    -0.01358    -0.04321     0.02673     0.13606     0.01873
+          11     0.00576     0.02498    -0.01766    -0.10344     0.01793    -0.08143
+          12     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          13    -0.04859     0.00726     0.00302     0.05089    -0.07522     0.01155
+          14     0.06639     0.02504    -0.03870     0.07455    -0.06057     0.12194
+          15     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          16     0.00306    -0.00937     0.02054    -0.07435     0.08780     0.05431
+          17    -0.08982    -0.00844     0.02730     0.04320    -0.02279    -0.11265
+          18     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          19    -0.13751     0.01825     0.06887    -0.06867     0.01707     0.08681
+          20    -0.12667     0.04116     0.12341    -0.27393    -0.13287     0.12063
+          21     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          22    -0.24117     0.00957     0.02994     0.12933     0.02002     0.11895
+          23     0.19358     0.01470     0.02654    -0.23061    -0.13476    -0.09424
+          24     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          25    -0.13751    -0.01825     0.06887    -0.06867    -0.01707    -0.08681
+          26    -0.12667    -0.04116     0.12341    -0.27393     0.13287    -0.12062
+          27     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          28    -0.24117    -0.00957     0.02994     0.12933    -0.02002    -0.11895
+          29     0.19358    -0.01470     0.02654    -0.23061     0.13476     0.09425
+          30     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          31     0.00079    -0.02097     0.02552    -0.01665    -0.00183    -0.00729
+          32     0.04416    -0.07787     0.06178     0.01672     0.01641     0.00896
+          33     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          34    -0.00463    -0.02369     0.02562     0.01674    -0.01611     0.00603
+          35    -0.01930    -0.00538     0.01297     0.01574    -0.02365     0.00494
+          36     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          37     0.00260     0.03247    -0.03247    -0.02092     0.01101    -0.01168
+          38     0.04161     0.16785    -0.20419     0.02364     0.06203     0.00389
+          39     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          40    -0.16247     0.43827    -0.40018    -0.08635     0.05592    -0.02095
+          41    -0.07398     0.14456    -0.12408    -0.01341    -0.00523    -0.00230
+          42     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          43    -0.02671     0.04599    -0.04133     0.00660    -0.00240     0.00433
+          44    -0.12020     0.38128    -0.36570    -0.06254     0.07863    -0.01081
+          45     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          46     0.00079     0.02097     0.02552    -0.01665     0.00183     0.00729
+          47     0.04416     0.07787     0.06178     0.01672    -0.01641    -0.00896
+          48     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          49    -0.00463     0.02369     0.02562     0.01674     0.01611    -0.00603
+          50    -0.01930     0.00538     0.01297     0.01574     0.02365    -0.00494
+          51     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          52     0.00260    -0.03247    -0.03247    -0.02092    -0.01101     0.01168
+          53     0.04161    -0.16785    -0.20419     0.02364    -0.06203    -0.00389
+          54     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          55    -0.16247    -0.43827    -0.40019    -0.08635    -0.05592     0.02095
+          56    -0.07398    -0.14456    -0.12409    -0.01341     0.00523     0.00230
+          57     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          58    -0.02671    -0.04599    -0.04133     0.00660     0.00240    -0.00433
+          59    -0.12020    -0.38128    -0.36570    -0.06254    -0.07863     0.01081
+          60     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+
+                   49          50          51          52          53          54
+ 
+ P.Frequency     2038.83     2040.51     3658.61     3659.68     3711.79     3711.88
+ 
+           1    -0.02608     0.01085     0.00015     0.00012     0.00052     0.00053
+           2    -0.02487     0.02952     0.00031     0.00041    -0.00169    -0.00166
+           3     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           4     0.01230    -0.00590     0.00144     0.00003     0.00050    -0.00093
+           5     0.00183     0.00284    -0.00028    -0.00001    -0.00004     0.00036
+           6     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           7    -0.01251     0.00321    -0.00256     0.00195    -0.00074     0.00106
+           8     0.00387    -0.01138    -0.00192     0.00140    -0.00080     0.00098
+           9     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          10     0.02608     0.01085     0.00015    -0.00012     0.00052    -0.00053
+          11     0.02487     0.02952     0.00031    -0.00041    -0.00169     0.00166
+          12     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          13    -0.01230    -0.00590     0.00144    -0.00003     0.00050     0.00093
+          14    -0.00183     0.00284    -0.00028     0.00001    -0.00004    -0.00036
+          15     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          16     0.01251     0.00321    -0.00256    -0.00195    -0.00074    -0.00106
+          17    -0.00387    -0.01138    -0.00192    -0.00140    -0.00080    -0.00098
+          18     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          19     0.01007    -0.00948    -0.01676     0.00062    -0.00476     0.01117
+          20    -0.01397     0.00189     0.00602    -0.00010     0.00198    -0.00390
+          21     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          22    -0.01050    -0.02631     0.02721    -0.01886     0.00832    -0.01090
+          23    -0.00322     0.02203     0.02005    -0.01352     0.00644    -0.00808
+          24     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          25    -0.01007    -0.00948    -0.01676    -0.00062    -0.00476    -0.01116
+          26     0.01397     0.00189     0.00602     0.00010     0.00198     0.00390
+          27     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          28     0.01050    -0.02631     0.02721     0.01886     0.00832     0.01090
+          29     0.00322     0.02203     0.02005     0.01352     0.00644     0.00807
+          30     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          31    -0.07346    -0.07256     0.01263    -0.01241    -0.05808     0.05817
+          32    -0.11599    -0.11794    -0.00910     0.00910     0.00827    -0.00834
+          33     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          34     0.07763     0.07777     0.02930    -0.02933     0.01482    -0.01469
+          35     0.09341     0.09405     0.03692    -0.03707     0.01316    -0.01295
+          36     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          37    -0.03649    -0.03621    -0.19887     0.19556     0.62471    -0.62579
+          38     0.13469     0.12943     0.04434    -0.04377    -0.14131     0.14160
+          39     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          40    -0.14941    -0.14876     0.14153    -0.14203     0.03681    -0.03603
+          41     0.04985     0.05079    -0.45173     0.45294    -0.11949     0.11711
+          42     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          43     0.06155     0.06143    -0.44077     0.44194    -0.15317     0.15104
+          44    -0.16788    -0.16944     0.07258    -0.07277     0.02737    -0.02703
+          45     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          46     0.07346    -0.07255     0.01263     0.01241    -0.05810    -0.05815
+          47     0.11599    -0.11794    -0.00910    -0.00910     0.00828     0.00834
+          48     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          49    -0.07763     0.07777     0.02930     0.02933     0.01482     0.01469
+          50    -0.09342     0.09405     0.03692     0.03706     0.01317     0.01295
+          51     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          52     0.03649    -0.03621    -0.19887    -0.19556     0.62495     0.62555
+          53    -0.13469     0.12943     0.04434     0.04377    -0.14136    -0.14154
+          54     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          55     0.14941    -0.14876     0.14153     0.14203     0.03682     0.03602
+          56    -0.04985     0.05079    -0.45175    -0.45293    -0.11954    -0.11707
+          57     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          58    -0.06155     0.06143    -0.44078    -0.44193    -0.15323    -0.15097
+          59     0.16789    -0.16944     0.07258     0.07277     0.02738     0.02702
+          60     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+
+                   55          56          57          58          59          60
+ 
+ P.Frequency     3716.38     3723.48     3742.09     3745.37     3816.86     3816.89
+ 
+           1    -0.00092     0.00341    -0.00429    -0.00175    -0.00008    -0.00011
+           2    -0.00249     0.00159    -0.00009     0.00198    -0.00028    -0.00030
+           3     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           4     0.05015    -0.05180     0.02628    -0.02358    -0.00013     0.00026
+           5    -0.01695     0.01801    -0.01289     0.01170     0.00014    -0.00020
+           6     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+           7    -0.02263     0.02010     0.04132    -0.04287    -0.00131     0.00149
+           8    -0.01414     0.01237     0.03480    -0.03570    -0.00103     0.00121
+           9     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          10    -0.00092    -0.00341    -0.00429     0.00175    -0.00008     0.00011
+          11    -0.00249    -0.00159    -0.00009    -0.00198    -0.00028     0.00030
+          12     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          13     0.05015     0.05180     0.02629     0.02358    -0.00013    -0.00026
+          14    -0.01695    -0.01800    -0.01289    -0.01170     0.00014     0.00020
+          15     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          16    -0.02263    -0.02010     0.04132     0.04287    -0.00131    -0.00149
+          17    -0.01414    -0.01237     0.03480     0.03570    -0.00103    -0.00121
+          18     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          19    -0.55991     0.57572    -0.28972     0.25636     0.00184    -0.00224
+          20     0.20673    -0.21297     0.10882    -0.09609    -0.00064     0.00084
+          21     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          22     0.24408    -0.21650    -0.46481     0.47822     0.01559    -0.01771
+          23     0.19273    -0.17135    -0.37166     0.38208     0.01306    -0.01482
+          24     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          25    -0.55991    -0.57572    -0.28973    -0.25635     0.00184     0.00224
+          26     0.20673     0.21296     0.10882     0.09608    -0.00064    -0.00084
+          27     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          28     0.24408     0.21650    -0.46481    -0.47822     0.01561     0.01769
+          29     0.19273     0.17135    -0.37166    -0.38208     0.01308     0.01480
+          30     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          31     0.00003    -0.00113     0.00008     0.00009    -0.00208     0.00209
+          32     0.00033     0.00018    -0.00008     0.00012     0.00051    -0.00051
+          33     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          34    -0.00084     0.00010    -0.00060     0.00080    -0.05106     0.05111
+          35    -0.00237     0.00141     0.00262    -0.00275     0.04321    -0.04325
+          36     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          37    -0.00007     0.01262     0.00102    -0.00207     0.02700    -0.02709
+          38     0.00050    -0.00303    -0.00098     0.00141    -0.00405     0.00407
+          39     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          40    -0.00854     0.00452     0.00880    -0.00909     0.13340    -0.13353
+          41     0.02782    -0.01419    -0.02826     0.03004    -0.44049     0.44092
+          42     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          43     0.01741    -0.00541    -0.00294     0.00029     0.47288    -0.47344
+          44    -0.00374     0.00155     0.00189    -0.00153    -0.07451     0.07460
+          45     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          46     0.00003     0.00113     0.00008    -0.00009    -0.00208    -0.00208
+          47     0.00033    -0.00018    -0.00008    -0.00012     0.00051     0.00051
+          48     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          49    -0.00084    -0.00010    -0.00060    -0.00080    -0.05112    -0.05105
+          50    -0.00237    -0.00141     0.00262     0.00275     0.04326     0.04320
+          51     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          52    -0.00006    -0.01262     0.00102     0.00207     0.02704     0.02706
+          53     0.00050     0.00303    -0.00098    -0.00141    -0.00405    -0.00406
+          54     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          55    -0.00854    -0.00453     0.00880     0.00909     0.13356     0.13336
+          56     0.02782     0.01419    -0.02826    -0.03004    -0.44102    -0.44038
+          57     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          58     0.01741     0.00541    -0.00294    -0.00029     0.47346     0.47286
+          59    -0.00374    -0.00155     0.00189     0.00153    -0.07460    -0.07451
+          60     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+
+
+
+ ----------------------------------------------------------------------------
+ Normal Eigenvalue ||    Projected Derivative Dipole Moments (debye/angs)
+  Mode   [cm**-1]  ||      [d/dqX]             [d/dqY]           [d/dqZ]
+ ------ ---------- || ------------------ ------------------ -----------------
+    1        0.000 ||       0.000               0.000             0.000
+    2        0.000 ||       0.000               0.000             0.000
+    3        0.000 ||       0.000               0.000             0.000
+    4        0.000 ||       0.000               0.000             0.000
+    5        0.000 ||       0.000               0.000             0.000
+    6        0.000 ||       0.000               0.000             0.000
+    7       37.565 ||       0.000               0.000             0.006
+    8       57.575 ||       0.000               0.000             0.000
+    9      154.880 ||       0.000               0.000             0.079
+   10      197.502 ||       0.024               0.069             0.000
+   11      292.257 ||       0.000               0.000             0.000
+   12      330.296 ||       0.000               0.000             0.000
+   13      444.361 ||       0.000               0.000             0.000
+   14      477.063 ||       0.000               0.000            -0.041
+   15      525.722 ||       0.000               0.000             0.274
+   16      528.446 ||       0.030               0.232             0.000
+   17      629.250 ||       0.000               0.000             0.000
+   18      738.215 ||       0.000               0.000             0.000
+   19      740.011 ||       0.000               0.000             0.000
+   20      795.109 ||       0.000               0.000            -0.073
+   21      797.729 ||       0.000              -0.364             0.000
+   22      918.470 ||       0.000               0.000             0.000
+   23      945.829 ||       0.000               0.000             0.000
+   24     1020.897 ||       0.000               0.000             0.657
+   25     1022.728 ||       0.000               0.000             0.000
+   26     1145.656 ||       0.000               0.000             0.004
+   27     1145.693 ||       0.000               0.000             0.854
+   28     1154.734 ||      -0.022              -0.103             0.000
+   29     1162.741 ||       0.000               0.000             0.000
+   30     1179.521 ||       0.022               0.051             0.000
+   31     1187.569 ||       0.000               0.000            -0.032
+   32     1213.182 ||       0.000               0.000             0.000
+   33     1234.906 ||      -0.013              -0.487             0.000
+   34     1246.480 ||       0.000               0.000             0.423
+   35     1246.724 ||       0.000               0.000             0.000
+   36     1333.402 ||      -0.008              -0.337             0.000
+   37     1386.605 ||       0.000               0.000             0.000
+   38     1418.308 ||       0.000               0.000             0.000
+   39     1428.796 ||      -0.011               0.028             0.000
+   40     1534.055 ||       0.000               0.000             0.000
+   41     1552.453 ||       0.055               0.629             0.000
+   42     1565.664 ||       0.000               0.000             0.000
+   43     1666.817 ||      -0.638               0.183             0.000
+   44     1716.317 ||       0.000               0.000             0.000
+   45     1724.923 ||       0.008               0.187             0.000
+   46     1819.245 ||      -0.053              -0.663             0.000
+   47     1888.971 ||       0.000               0.000             0.000
+   48     1948.387 ||       0.000               0.000             0.000
+   49     2038.825 ||       0.000               0.000             0.000
+   50     2040.513 ||      -0.120              -0.035             0.000
+   51     3658.607 ||      -0.586              -1.698             0.000
+   52     3659.682 ||       0.000               0.000             0.000
+   53     3711.794 ||       0.102               0.471             0.000
+   54     3711.881 ||       0.000               0.000             0.000
+   55     3716.376 ||      -0.165              -0.059             0.000
+   56     3723.485 ||       0.000               0.000             0.000
+   57     3742.085 ||      -0.404              -0.113             0.000
+   58     3745.374 ||       0.000               0.000             0.000
+   59     3816.865 ||       0.069               0.044             0.000
+   60     3816.890 ||       0.000               0.000             0.000
+ ----------------------------------------------------------------------------
+
+
+
+  
+  
+ ----------------------------------------------------------------------------
+ Normal Eigenvalue ||           Projected Infra Red Intensities
+  Mode   [cm**-1]  || [atomic units] [(debye/angs)**2] [(KM/mol)] [arbitrary]
+ ------ ---------- || -------------- ----------------- ---------- -----------
+    1        0.000 ||    0.000000           0.000         0.000       0.000
+    2        0.000 ||    0.000000           0.000         0.000       0.000
+    3        0.000 ||    0.000000           0.000         0.000       0.000
+    4        0.000 ||    0.000000           0.000         0.000       0.000
+    5        0.000 ||    0.000000           0.000         0.000       0.000
+    6        0.000 ||    0.000000           0.000         0.000       0.000
+    7       37.565 ||    0.000001           0.000         0.001       0.003
+    8       57.575 ||    0.000000           0.000         0.000       0.000
+    9      154.880 ||    0.000270           0.006         0.264       0.535
+   10      197.502 ||    0.000232           0.005         0.227       0.460
+   11      292.257 ||    0.000000           0.000         0.000       0.000
+   12      330.296 ||    0.000000           0.000         0.000       0.000
+   13      444.361 ||    0.000000           0.000         0.000       0.000
+   14      477.063 ||    0.000072           0.002         0.070       0.143
+   15      525.722 ||    0.003243           0.075         3.161       6.418
+   16      528.446 ||    0.002372           0.055         2.312       4.694
+   17      629.250 ||    0.000000           0.000         0.000       0.000
+   18      738.215 ||    0.000000           0.000         0.000       0.000
+   19      740.011 ||    0.000000           0.000         0.000       0.000
+   20      795.109 ||    0.000230           0.005         0.225       0.456
+   21      797.729 ||    0.005739           0.132         5.594      11.357
+   22      918.470 ||    0.000000           0.000         0.000       0.000
+   23      945.829 ||    0.000000           0.000         0.000       0.000
+   24     1020.897 ||    0.018736           0.432        18.265      37.082
+   25     1022.728 ||    0.000000           0.000         0.000       0.000
+   26     1145.656 ||    0.000001           0.000         0.001       0.002
+   27     1145.693 ||    0.031624           0.730        30.828      62.588
+   28     1154.734 ||    0.000481           0.011         0.469       0.953
+   29     1162.741 ||    0.000000           0.000         0.000       0.000
+   30     1179.521 ||    0.000132           0.003         0.129       0.262
+   31     1187.569 ||    0.000045           0.001         0.044       0.089
+   32     1213.182 ||    0.000000           0.000         0.000       0.000
+   33     1234.906 ||    0.010294           0.238        10.036      20.374
+   34     1246.480 ||    0.007749           0.179         7.555      15.337
+   35     1246.724 ||    0.000000           0.000         0.000       0.000
+   36     1333.402 ||    0.004937           0.114         4.813       9.771
+   37     1386.605 ||    0.000000           0.000         0.000       0.000
+   38     1418.308 ||    0.000000           0.000         0.000       0.000
+   39     1428.796 ||    0.000039           0.001         0.038       0.077
+   40     1534.055 ||    0.000000           0.000         0.000       0.000
+   41     1552.453 ||    0.017294           0.399        16.859      34.227
+   42     1565.664 ||    0.000000           0.000         0.000       0.000
+   43     1666.817 ||    0.019068           0.440        18.589      37.739
+   44     1716.317 ||    0.000000           0.000         0.000       0.000
+   45     1724.923 ||    0.001525           0.035         1.486       3.018
+   46     1819.245 ||    0.019151           0.442        18.670      37.903
+   47     1888.971 ||    0.000000           0.000         0.000       0.000
+   48     1948.387 ||    0.000000           0.000         0.000       0.000
+   49     2038.825 ||    0.000000           0.000         0.000       0.000
+   50     2040.513 ||    0.000676           0.016         0.659       1.337
+   51     3658.607 ||    0.139934           3.228       136.415     276.952
+   52     3659.682 ||    0.000000           0.000         0.000       0.000
+   53     3711.794 ||    0.010077           0.232         9.823      19.943
+   54     3711.881 ||    0.000000           0.000         0.000       0.000
+   55     3716.376 ||    0.001330           0.031         1.296       2.631
+   56     3723.485 ||    0.000000           0.000         0.000       0.000
+   57     3742.085 ||    0.007617           0.176         7.425      15.075
+   58     3745.374 ||    0.000000           0.000         0.000       0.000
+   59     3816.865 ||    0.000289           0.007         0.282       0.572
+   60     3816.890 ||    0.000000           0.000         0.000       0.000
+ ----------------------------------------------------------------------------
+
+
+
+ vib:animation  F
+
+ Task  times  cpu:       29.3s     wall:       29.5s
+ Summary of allocated global arrays
+-----------------------------------
+  No active global arrays
+
+
+
+                         GA Statistics for process    0
+                         ------------------------------
+
+       create   destroy   get      put      acc     scatter   gather  read&inc
+calls: 1.20e+04 1.20e+04 2.86e+05 2.49e+05 2.67e+04 1261        0        0     
+number of processes/call 1.00e+00 1.00e+00 1.00e+00 1.00e+00 0.00e+00
+bytes total:             4.52e+08 1.97e+08 3.41e+08 3.11e+07 0.00e+00 0.00e+00
+bytes remote:            0.00e+00 0.00e+00 0.00e+00 0.00e+00 0.00e+00 0.00e+00
+Max memory consumed for GA by this process: 17251200 bytes
+MA_summarize_allocated_blocks: starting scan ...
+MA_summarize_allocated_blocks: scan completed: 0 heap blocks, 0 stack blocks
+MA usage statistics:
+
+	allocation statistics:
+					      heap	     stack
+					      ----	     -----
+	current number of blocks	         0	         0
+	maximum number of blocks	        25	        36
+	current total bytes		         0	         0
+	maximum total bytes		     80096	  67010384
+	maximum total K-bytes		        81	     67011
+	maximum total M-bytes		         1	        68
+
+
+                                NWChem Input Module
+                                -------------------
+
+
+
+
+
+                                     CITATION
+                                     --------
+                Please cite the following reference when publishing
+                           results obtained with NWChem:
+
+                 M. Valiev, E.J. Bylaska, N. Govind, K. Kowalski,
+              T.P. Straatsma, H.J.J. van Dam, D. Wang, J. Nieplocha,
+                        E. Apra, T.L. Windus, W.A. de Jong
+                 "NWChem: a comprehensive and scalable open-source
+                  solution for large scale molecular simulations"
+                      Comput. Phys. Commun. 181, 1477 (2010)
+                           doi:10.1016/j.cpc.2010.04.018
+
+                              AUTHORS & CONTRIBUTORS
+                              ----------------------
+      E. J. Bylaska, W. A. de Jong, N. Govind, K. Kowalski, T. P. Straatsma,
+     M. Valiev, H. J. J. van Dam, D. Wang, E. Apra, T. L. Windus, J. Hammond,
+     J. Autschbach, P. Nichols, S. Hirata, M. T. Hackler, Y. Zhao, P.-D. Fan,
+      R. J. Harrison, M. Dupuis, D. M. A. Smith, K. Glaesemann, J. Nieplocha,
+      V. Tipparaju, M. Krishnan, A. Vazquez-Mayagoitia, L. Jensen, M. Swart,
+      Q. Wu, T. Van Voorhis, A. A. Auer, M. Nooijen, L. D. Crosby, E. Brown,
+             G. Cisneros, G. I. Fann, H. Fruchtl, J. Garza, K. Hirao,
+        R. Kendall, J. A. Nichols, K. Tsemekhman, K. Wolinski, J. Anchell,
+       D. Bernholdt, P. Borowski, T. Clark, D. Clerc, H. Dachsel, M. Deegan,
+        K. Dyall, D. Elwood, E. Glendening, M. Gutowski, A. Hess, J. Jaffe,
+        B. Johnson, J. Ju, R. Kobayashi, R. Kutteh, Z. Lin, R. Littlefield,
+    X. Long, B. Meng, T. Nakajima, S. Niu, L. Pollack, M. Rosing, G. Sandrone,
+       M. Stave, H. Taylor, G. Thomas, J. H. van Lenthe, A. Wong, Z. Zhang.
+
+ Total times  cpu:       29.3s     wall:       29.8s

--- a/regressionfiles.yaml
+++ b/regressionfiles.yaml
@@ -599,6 +599,7 @@ regressions:
   tests:
   - GenericPolarTest
 - loc_entry: NWChem/NWChem6.0/dvb_gopt_hf_unconverged.out
+- loc_entry: NWChem/NWChem6.0/dvb_ir_hf.out
 - loc_entry: NWChem/NWChem6.0/dvb_sp_hf_moments_only_octupole.out
 - loc_entry: NWChem/NWChem6.0/dvb_sp_hf_moments_only_quadrupole.out
 - loc_entry: NWChem/NWChem6.0/dvb_sp_ks_warnings.out


### PR DESCRIPTION
https://github.com/cclib/cclib/pull/1499 needs to be merged first.

Before a fix, https://github.com/cclib/cclib/commit/110292d71d4a88b3e1c2ec37c5fc95d4abf5b4b7 gives

    $ ccget --list NWChem/NWChem6.0/dvb_ir_hf.out
    Attempting to read NWChem/NWChem6.0/dvb_ir_hf.out
    [NWChem NWChem/NWChem6.0/dvb_ir_hf.out ERROR] Encountered error when parsing.
    [NWChem NWChem/NWChem6.0/dvb_ir_hf.out ERROR] Last line read:     3   3.97190D-14-2.57643D-15 1.69348D+01

    Traceback (most recent call last):
      File "/usr/bin/ccget", line 8, in <module>
        sys.exit(ccget())
                 ^^^^^^^
      File "/usr/lib/python3.12/site-packages/cclib/scripts/ccget.py", line 182, in ccget
        data = ccread(filename, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.12/site-packages/cclib/io/ccio.py", line 185, in ccread
        return log.parse()
               ^^^^^^^^^^^
      File "/usr/lib/python3.12/site-packages/cclib/parser/logfileparser.py", line 156, in parse
        self.extract(self.inputfile, line)
      File "/usr/lib/python3.12/site-packages/cclib/parser/nwchemparser.py", line 1158, in extract
        vals = [utils.float(x) for x in tokens[1:]]
                ^^^^^^^^^^^^^^
      File "/usr/lib/python3.12/site-packages/cclib/parser/utils.py", line 76, in float
        return _BUILTIN_FLOAT(number.replace("D", "E"))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ValueError: could not convert string to float: '3.97190E-14-2.57643E-15'