### PR TITLE
ORCA: change test classes used for pre-5 regressions

### DIFF
--- a/regressionfiles.yaml
+++ b/regressionfiles.yaml
@@ -771,13 +771,13 @@ regressions:
   - loc_entry: ORCA/ORCA4.1/dvb_sp.out
     tests:
       - GenericBasisTest
-      - OrcaSPTest
+      - OrcaSPTest_nohirshfeld
   - loc_entry: ORCA/ORCA4.1/dvb_sp_un.out
     tests:
       - GenericSPunTest
   - loc_entry: ORCA/ORCA4.1/dvb_td.out
     tests:
-      - OrcaTDDFTTest
+      - OrcaTDDFTTest_pre5
   - loc_entry: ORCA/ORCA4.1/orca_from_issue_736.out
   - loc_entry: ORCA/ORCA4.1/porphine.out
   - loc_entry: ORCA/ORCA4.1/raw_failed_run_from_issue_426.out
@@ -835,7 +835,7 @@ regressions:
       - GenericSPunTest
   - loc_entry: ORCA/ORCA4.2/dvb_td.out
     tests:
-      - OrcaTDDFTTest
+      - OrcaTDDFTTest_pre5
   - loc_entry: ORCA/ORCA4.2/ligando-30-SRM1-S_ZINDO.out
   - loc_entry: ORCA/ORCA4.2/long-input.out
   - loc_entry: ORCA/ORCA4.2/longer-input.out


### PR DESCRIPTION
Follow-up to https://github.com/cclib/cclib-data/pull/204