### PR TITLE
ORCA: add CASSCF relaxed scan

### DIFF
--- a/ORCA/.gitignore
+++ b/ORCA/.gitignore
@@ -1,0 +1,7 @@
+*.property.txt
+*.gbw
+*.densities
+*.densitiesinfo
+*.prop
+*_property.txt
+*.bibtex

--- a/ORCA/ORCA3.0/casscf_beryllium_atom_nosym.in
+++ b/ORCA/ORCA3.0/casscf_beryllium_atom_nosym.in
@@ -1,0 +1,10 @@
+! def2-qzvpp verytightscf noautostart nousesym
+
+%casscf
+ nel 2
+ norb 4
+ end
+
+* xyz 0 1
+Be 0 0 0
+*

--- a/ORCA/ORCA3.0/casscf_beryllium_atom_nosym.out
+++ b/ORCA/ORCA3.0/casscf_beryllium_atom_nosym.out
@@ -1,0 +1,939 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #  Department of molecular theory and spectroscopy    #
+                  #              Directorship: Frank Neese              #
+                  # Max Planck Institute for Chemical Energy Conversion #
+                  #                  D-45470 Muelheim/Ruhr              #
+                  #                       Germany                       #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 3.0.3 - RELEASE   -
+
+
+ With contributions from (in alphabetic order):
+   Ute Becker             : Parallelization
+   Dmytro Bykov           : SCF Hessian
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Dimitrios Liakos       : Extrapolation schemes; parallel MDCI
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA and ECA modules, normal mode analysis, Resonance Raman, ABS, FL, XAS/XES, NRVS
+   Christoph Reimann      : Effective Core Potentials
+   Michael Roemelt        : Restricted open shell CIS
+   Christoph Riplinger    : Improved optimizer, TS searches, QM/MM, DLPNO-CCSD
+   Barbara Sandhoefer     : DKH picture change effects
+   Igor Schapiro          : Molecular dynamics
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, T. Risthaus : VdW corrections, initial TS optimization,
+                                                   DFT functionals, gCP
+   Ed Valeev                                     : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, R. Olivares           : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+Your calculation utilizes the basis: Ahlrichs-QZV
+Cite in your paper:
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+Now building the actual basis set
+
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = casscf_beryllium_atom_nosym.in
+|  1> ! def2-qzvpp verytightscf noautostart nousesym
+|  2> 
+|  3> %casscf
+|  4>  nel 2
+|  5>  norb 4
+|  6>  end
+|  7> 
+|  8> * xyz 0 1
+|  9> Be 0 0 0
+| 10> *
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  Be     0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG    MASS        X           Y           Z
+   0 Be    4.0000    0     9.012          0.000000000000000          0.000000000000000          0.000000000000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ Be     0   0   0   0.000000     0.000     0.000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ Be     0   0   0   0.000000     0.000     0.000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type Be  : 15s7p2d1f contracted to 7s4p2d1f pattern {8211111/4111/11/1}
+
+Atom   0Be   basis set group =>   1
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...   25
+ # of primitive gaussian functions       ...   53
+ # of contracted shell                   ...   14
+ # of contracted basis functions         ...   36
+ Highest angular momentum                ...    3
+ Maximum contraction depth               ...    8
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  1.000e-12
+ Primitive cut-off              TCut     ...  1.000e-14
+
+
+                              INTEGRAL EVALUATION
+
+ One electron integrals                  ... done
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.000 sec)
+
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... casscf_beryllium_atom_nosym
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   36
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 6.741e-03
+Time for diagonalization                   ...    0.092 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Total time needed                          ...    0.093 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-12
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   1678 (   0.0 sec)
+# of grid points (after weights+screening)   ...   1678 (   0.0 sec)
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     1678
+Total number of batches                      ...       27
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1678
+Average number of shells per batch           ...    11.54 (82.40%)
+Average number of basis functions per batch  ...    31.75 (88.19%)
+Average number of large shells per batch     ...    11.18 (96.90%)
+Average number of large basis fcns per batch ...    31.39 (98.88%)
+Maximum spatial batch extension              ...  21.83, 39.91, 39.91 au
+Average spatial batch extension              ...  10.49, 12.28, 14.05 au
+
+Time for grid setup =    0.055 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Setting up the integral package                    ... done
+Initializing the effective Hamiltonian             ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.1 sec)
+                      ------------------
+
+
+ ... the calculation is a CASSCF calculation -I'm leaving here GOOD LUCK!!!
+
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+
+Setting up the integral package       ... done
+Building the CAS space              ... done (10 configurations for Mult=1)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    2
+Number of active orbitals           ...    4
+Total number of electrons           ...    4
+Total number of orbitals            ...   36
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   35 (  31 orbitals)
+Number of rotation parameters      ...    159
+
+CI-STEP:
+Number of multiplicity blocks       ...    1
+BLOCK  1 WEIGHT=   1.0000
+  Multiplicity                      ...    1
+  #(Configurations)                 ...   10
+  #(CSFs)                           ...   10
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+CI step strategy                    ... DIRECT (CSF)
+  N(GuessMat)                       ...      2064
+  Max(Iter-CI)                      ...        35
+  MaxDim(CI)                        ...         3
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  1.00e-09
+  Residual Tolerance CI             ...  1.00e-09
+  Shift(CI)                         ...  1.00e-13
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI
+  Default Parametrization           ... CAYLEY
+  Options for diverging steps       ... let the program figure out whats best
+  Act-Act rotations                 ... depends on algorithm used
+  FreezeIE                          ... 95.00% of ||g||
+  Until reaching FreezeIE rotations with active orbitals are damped. 
+
+  MaxRot                            ... 2.00e-01 
+  TolU                              ... 5.00e-01 
+  MaxDampIter                       ... 3 
+  Approx. Fock at                   ... 1.000000e-02 density convergence
+  Level shift                       ... energy gap dependent
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... DIIS    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  1.00e-12
+  Primitive cutoff TCut             ...  1.00e-14
+  Energy convergence tolerance      ...  1.00e-08
+  Orbital gradient convergence      ...  1.00e-05
+  Max. number of iterations         ...        75  
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Inactive Energy E0 = -13.60390391 Eh
+CI-ITERATION   0: 
+   -14.604424771   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  1 MULT= 1 NROOTS= 1 
+ROOT   0:  E=     -14.6044247712 Eh
+      0.90756 [     0]: 2000
+      0.03081 [     7]: 0020
+      0.03081 [     9]: 0002
+      0.03081 [     4]: 0200
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -14.604424771 Eh DE=     0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.095   Act-Int = 4.462
+   N(occ)=  1.81512 0.06163 0.06163 0.06163
+   ||g|| =      0.512945368 Max(G)=    -0.341954278 Rot=30,0
+   --- Orbital Update [   SuperCI]
+   SUPERCI-ITER   0: DE=    -0.014000753 <r|r>=      0.001192695
+   SUPERCI-ITER   1: DE=    -0.001471610 <r|r>=      0.000056340
+   SUPERCI-ITER   2: DE=    -0.000199420 <r|r>=      0.000033448
+   SUPERCI-ITER   3: DE=    -0.000004392 <r|r>=      0.000000006
+   SUPERCI-ITER   4: DE=    -0.000000001 <r|r>=      0.000000000
+   <Psi(SX)|Psi(SX)>=      1.000000000 DE(SX)=-0.015676176
+   Largest coefficient in the normalized |SX> wavefunction= 0.134399833
+   --- Forming Natural Orbitals
+   --- Density off from convergence (1.315e+00). Exact active Fock build
+
+MACRO-ITERATION   2: 
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Inactive Energy E0 = -13.60938958 Eh
+CI-ITERATION   0: 
+   -14.613485224   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.613485224 Eh DE=    -0.009060452
+   --- Energy gap subspaces: Ext-Act = 0.043   Act-Int = 4.454
+   N(occ)=  1.79941 0.06686 0.06686 0.06686
+   ||g|| =      0.242920111 Max(G)=    -0.165949257 Rot=30,0
+   --- Orbital Update [   SuperCI]
+   SUPERCI-ITER   0: DE=    -0.003832536 <r|r>=      0.000003679
+   SUPERCI-ITER   1: DE=    -0.000004789 <r|r>=      0.000000167
+   SUPERCI-ITER   2: DE=    -0.000000204 <r|r>=      0.000000001
+   <Psi(SX)|Psi(SX)>=      1.000000000 DE(SX)=-0.003837529
+   Largest coefficient in the normalized |SX> wavefunction= 0.073377755
+   --- Forming Natural Orbitals
+   --- Density off from convergence (1.574e-02). Exact active Fock build
+
+MACRO-ITERATION   3: 
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Inactive Energy E0 = -13.61083875 Eh
+CI-ITERATION   0: 
+   -14.615742927   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.615742927 Eh DE=    -0.002257703
+   --- Energy gap subspaces: Ext-Act = 0.029   Act-Int = 4.447
+   N(occ)=  1.80069 0.06644 0.06644 0.06644
+   ||g|| =      0.114179852 Max(G)=    -0.076409293 Rot=30,0
+   --- Orbital Update [   SuperCI]
+   SUPERCI-ITER   0: DE=    -0.000660142 <r|r>=      0.000000192
+   SUPERCI-ITER   1: DE=    -0.000000235 <r|r>=      0.000000047
+   SUPERCI-ITER   2: DE=    -0.000000020 <r|r>=      0.000000000
+   <Psi(SX)|Psi(SX)>=      1.000000000 DE(SX)=-0.000660397
+   Largest coefficient in the normalized |SX> wavefunction= 0.029890632
+   --- Forming Natural Orbitals
+   --- Density close to convergence (1.271e-03). Approximate active Fock build
+
+MACRO-ITERATION   4: 
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Inactive Energy E0 = -13.61106919 Eh
+CI-ITERATION   0: 
+   -14.616247197   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616247197 Eh DE=    -0.000504270
+   --- Energy gap subspaces: Ext-Act = 0.023   Act-Int = 4.442
+   N(occ)=  1.80255 0.06582 0.06582 0.06582
+   ||g|| =      0.054797991 Max(G)=     0.034868559 Rot=30,0
+   --- Orbital Update [   SuperCI]
+   SUPERCI-ITER   0: DE=    -0.000139722 <r|r>=      0.000000006
+   SUPERCI-ITER   1: DE=    -0.000000006 <r|r>=      0.000000005
+   SUPERCI-ITER   2: DE=    -0.000000001 
+   <Psi(SX)|Psi(SX)>=      1.000000000 DE(SX)=-0.000139729
+   Largest coefficient in the normalized |SX> wavefunction= 0.007743042
+   --- Forming Natural Orbitals
+   --- Density close to convergence (1.872e-03). Approximate active Fock build
+
+MACRO-ITERATION   5: 
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Inactive Energy E0 = -13.61095110 Eh
+CI-ITERATION   0: 
+   -14.616393839   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616393839 Eh DE=    -0.000146642
+   --- Energy gap subspaces: Ext-Act = 0.020   Act-Int = 4.439
+   N(occ)=  1.80310 0.06563 0.06563 0.06563
+   ||g|| =      0.027552183 Max(G)=     0.015894555 Rot=30,0
+   ===>>> Convergence to 3.0e-02 achieved - switching to Step=DIIS
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (5.592e-04). Approximate active Fock build
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -13.61002771 Eh
+CI-ITERATION   0: 
+   -14.616478156   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616478156 Eh DE=    -0.000084317
+   --- Energy gap subspaces: Ext-Act = 0.018   Act-Int = 4.435
+   N(occ)=  1.80360 0.06547 0.06547 0.06547
+   ||g|| =      0.018317894 Max(G)=     0.011874325 Rot=30,0
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (5.130e-04). Approximate active Fock build
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -13.61012151 Eh
+CI-ITERATION   0: 
+   -14.616490640   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616490640 Eh DE=    -0.000012484
+   --- Energy gap subspaces: Ext-Act = 0.017   Act-Int = 4.435
+   N(occ)=  1.80354 0.06549 0.06549 0.06549
+   ||g|| =      0.014359670 Max(G)=    -0.007928281 Rot=30,0
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (5.969e-05). Approximate active Fock build
+
+MACRO-ITERATION   8: 
+   --- Inactive Energy E0 = -13.61012484 Eh
+CI-ITERATION   0: 
+   -14.616495111   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616495111 Eh DE=    -0.000004471
+   --- Energy gap subspaces: Ext-Act = 0.016   Act-Int = 4.435
+   N(occ)=  1.80359 0.06547 0.06547 0.06547
+   ||g|| =      0.004141539 Max(G)=    -0.002976060 Rot=35,0
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (4.830e-05). Approximate active Fock build
+
+MACRO-ITERATION   9: 
+   --- Inactive Energy E0 = -13.61010476 Eh
+CI-ITERATION   0: 
+   -14.616496559   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496559 Eh DE=    -0.000001448
+   --- Energy gap subspaces: Ext-Act = 0.016   Act-Int = 4.434
+   N(occ)=  1.80365 0.06545 0.06545 0.06545
+   ||g|| =      0.002623648 Max(G)=     0.001963395 Rot=35,0
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (6.649e-05). Approximate active Fock build
+
+MACRO-ITERATION  10: 
+   --- Inactive Energy E0 = -13.61009451 Eh
+CI-ITERATION   0: 
+   -14.616496948   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496948 Eh DE=    -0.000000389
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80370 0.06543 0.06543 0.06543
+   ||g|| =      0.000920309 Max(G)=     0.000676763 Rot=35,0
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (4.684e-05). Approximate active Fock build
+
+MACRO-ITERATION  11: 
+   --- Inactive Energy E0 = -13.61009534 Eh
+CI-ITERATION   0: 
+   -14.616497000   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497000 Eh DE=    -0.000000052
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80373 0.06542 0.06542 0.06542
+   ||g|| =      0.000456574 Max(G)=    -0.000309782 Rot=34,0
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (2.951e-05). Approximate active Fock build
+
+MACRO-ITERATION  12: 
+   --- Inactive Energy E0 = -13.61009547 Eh
+CI-ITERATION   0: 
+   -14.616497007   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497007 Eh DE=    -0.000000007
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80374 0.06542 0.06542 0.06542
+   ||g|| =      0.000184163 Max(G)=     0.000129216 Rot=34,0
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Forming Natural Orbitals
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION  13: 
+   --- Inactive Energy E0 = -13.61009547 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -14.616497007   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497007 Eh DE=    -0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80374 0.06542 0.06542 0.06542
+   ||g|| =      0.000183955 Max(G)=    -0.000129130 Rot=34,0
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -14.616497007 Eh    -397.7351 eV
+
+Orbital   Occ.   Energy(Eh)   Energy(eV):
+    0:  2.000000       -4.711840   -128.2157 
+    1:  1.803744       -0.277795     -7.5592 
+    2:  0.065419        0.112646      3.0653 
+    3:  0.065419        0.112646      3.0653 
+    4:  0.065419        0.112646      3.0653 
+    5:  0.000000        0.127743      3.4761 
+    6:  0.000000        0.150934      4.1071 
+    7:  0.000000        0.150934      4.1071 
+    8:  0.000000        0.150934      4.1071 
+    9:  0.000000        0.274858      7.4793 
+   10:  0.000000        0.274858      7.4793 
+   11:  0.000000        0.274858      7.4793 
+   12:  0.000000        0.274858      7.4793 
+   13:  0.000000        0.274858      7.4793 
+   14:  0.000000        0.681115     18.5341 
+   15:  0.000000        0.767033     20.8720 
+   16:  0.000000        0.767033     20.8720 
+   17:  0.000000        0.767033     20.8720 
+   18:  0.000000        1.118726     30.4421 
+   19:  0.000000        1.118726     30.4421 
+   20:  0.000000        1.118726     30.4421 
+   21:  0.000000        1.118726     30.4421 
+   22:  0.000000        1.118726     30.4421 
+   23:  0.000000        1.176081     32.0028 
+   24:  0.000000        1.176081     32.0028 
+   25:  0.000000        1.176081     32.0028 
+   26:  0.000000        1.176081     32.0028 
+   27:  0.000000        1.176081     32.0028 
+   28:  0.000000        1.176081     32.0028 
+   29:  0.000000        1.176081     32.0028 
+   30:  0.000000        3.007599     81.8409 
+   31:  0.000000       10.933791    297.5236 
+   32:  0.000000       10.933791    297.5236 
+   33:  0.000000       10.933791    297.5236 
+   34:  0.000000       11.951757    325.2239 
+   35:  0.000000       65.244454   1775.3919 
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  1 MULT= 1 NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -14.6164970070 Eh
+      0.90187 [     0]: 2000
+      0.03271 [     7]: 0020
+      0.03271 [     4]: 0200
+      0.03271 [     9]: 0002
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                   0          1          2          3    
+      0       1.803744   0.000000  -0.000000   0.000000
+      1       0.000000   0.065419   0.000000  -0.000000
+      2      -0.000000   0.000000   0.065419  -0.000000
+      3       0.000000  -0.000000  -0.000000   0.065419
+Trace of the electron density:  2.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -19.082324970 Eh        -519.2565 eV
+Two electron energy          :      4.465827964 Eh         121.5214 eV
+Nuclear repuslion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -14.616497007
+
+Kinetic energy               :     14.616237387 Eh         397.7280 eV
+Potential energy             :    -29.232734394 Eh        -795.4631 eV
+Virial ratio                 :     -2.000017762 
+                               ----------------
+                                  -14.616497007
+
+Core energy                  :    -13.610095475 Eh     -370.3495 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71184  -0.27779   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80374   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0      36.8      19.7      43.5       0.0
+ 0 Be px              0.0       0.0       1.2      60.1      38.7       0.0
+ 0 Be py              0.0       0.0      62.0      20.3      17.8       0.0
+
+                      6         7         8         9        10        11   
+                   0.15093   0.15093   0.15093   0.27486   0.27486   0.27486
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be pz              0.3       0.1      99.6       0.0       0.0       0.0
+ 0 Be px             98.0       1.7       0.3       0.0       0.0       0.0
+ 0 Be py              1.7      98.2       0.1       0.0       0.0       0.0
+ 0 Be dz2             0.0       0.0       0.0      14.1      85.9       0.0
+ 0 Be dxz             0.0       0.0       0.0       0.0       0.0      96.5
+ 0 Be dyz             0.0       0.0       0.0       0.0       0.0       2.7
+ 0 Be dx2y2           0.0       0.0       0.0      85.9      14.1       0.0
+ 0 Be dxy             0.0       0.0       0.0       0.0       0.0       0.7
+
+                     12        13        14        15        16        17   
+                   0.27486   0.27486   0.68112   0.76703   0.76703   0.76703
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s               0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be pz              0.0       0.0       0.0       0.0       0.4      99.6
+ 0 Be px              0.0       0.0       0.0      17.5      82.3       0.2
+ 0 Be py              0.0       0.0       0.0      82.5      17.4       0.2
+ 0 Be dxz             3.4       0.1       0.0       0.0       0.0       0.0
+ 0 Be dyz            86.4      10.9       0.0       0.0       0.0       0.0
+ 0 Be dxy            10.2      89.0       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.11873   1.11873   1.11873   1.11873   1.11873   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be dz2            61.2      38.8       0.0       0.0       0.0       0.0
+ 0 Be dxz             0.0       0.0      63.1       1.5      35.5       0.0
+ 0 Be dyz             0.0       0.0       0.1      94.0       5.9       0.0
+ 0 Be dx2y2          38.8      61.2       0.0       0.0       0.0       0.0
+ 0 Be dxy             0.0       0.0      36.8       4.6      58.6       0.0
+ 0 Be f0              0.0       0.0       0.0       0.0       0.0       6.1
+ 0 Be f+1             0.0       0.0       0.0       0.0       0.0      16.5
+ 0 Be f-1             0.0       0.0       0.0       0.0       0.0      18.6
+ 0 Be f+3             0.0       0.0       0.0       0.0       0.0      27.8
+ 0 Be f-3             0.0       0.0       0.0       0.0       0.0      31.1
+
+                     24        25        26        27        28        29   
+                   1.17608   1.17608   1.17608   1.17608   1.17608   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be f0             79.2      14.7       0.0       0.0       0.0       0.0
+ 0 Be f+1             7.3      13.6       2.5      59.7       0.5       0.0
+ 0 Be f-1             0.4      18.5      37.5       0.7      24.3       0.0
+ 0 Be f+2             0.0       0.0      36.1       3.8      60.1       0.0
+ 0 Be f-2             0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be f+3            12.4      22.5       1.6      35.5       0.3       0.0
+ 0 Be f-3             0.7      30.7      22.3       0.4      14.8       0.0
+
+                     30        31        32        33        34        35   
+                   3.00760  10.93379  10.93379  10.93379  11.95176  65.24445
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0       0.0       0.0       0.0     100.0     100.0
+ 0 Be pz              0.0       0.1       0.4      99.5       0.0       0.0
+ 0 Be px              0.0      68.1      31.4       0.4       0.0       0.0
+ 0 Be py              0.0      31.7      68.2       0.1       0.0       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... casscf_beryllium_atom_nosym.scfp.tmp
+BaseName (.gbw .S,...)              ... casscf_beryllium_atom_nosym
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 Be:   -0.000000
+Sum of atomic charges:   -0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Bes       :     3.803744  s :     3.803744
+      pz      :     0.065419  p :     0.196256
+      px      :     0.065419
+      py      :     0.065419
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 Be:   -0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Bes       :     3.803744  s :     3.803744
+      pz      :     0.065419  p :     0.196256
+      px      :     0.065419
+      py      :     0.065419
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 Be     4.0000     4.0000    -0.0000     0.7337     0.0000     0.7337
+
+
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.093193135 (    -0.010237452,     -0.073358796,      0.056556538)
+ MO   3:      0.093193135 (     0.072217563,     -0.041953879,     -0.041345568)
+ MO   4:      0.093193135 (     0.058006711,      0.039285105,      0.061456182)
+MO   1:
+ MO   2:      1.461436957 (     0.160541767,      1.150398640,     -0.886908838)
+ MO   3:      1.461436957 (    -1.132502042,      0.657912722,      0.648373312)
+ MO   4:      1.461436957 (    -0.909650176,     -0.616061520,     -0.963744125)
+MO   2:
+MO   3:
+MO   4:
+  newgto Be
+  0 15
+    1      29646.704407000001         0.000038108121
+    2       4428.761435400000         0.000297339519
+    3       1005.470133200000         0.001564012189
+    4        284.153395780000         0.006560695178
+    5         92.504356461000         0.023217277748
+    6         33.311016058000         0.069760234287
+    7         12.911553314000         0.170882796272
+    8          5.266549736100         0.318203370984
+    9         22.995386380000        -0.000026816811
+   10          6.623635417600        -0.000262295694
+   11          2.228959500300         0.379039345639
+   12          0.953024334500         0.186073662085
+   13          0.246516024400         0.006077980713
+   14          0.101538953100        -0.011158776982
+   15          0.041551374600        -0.001939287633
+  0 15
+    1      29646.704407000001         0.000006656479
+    2       4428.761435400000         0.000051937333
+    3       1005.470133200000         0.000273191476
+    4        284.153395780000         0.001145979558
+    5         92.504356461000         0.004055443055
+    6         33.311016058000         0.012185263955
+    7         12.911553314000         0.029848695310
+    8          5.266549736100         0.055581695023
+    9         22.995386380000         0.001089174539
+   10          6.623635417600         0.010653234928
+   11          2.228959500300         0.118820253833
+   12          0.953024334500         0.107296709006
+   13          0.246516024400        -0.284116196701
+   14          0.101538953100        -0.627982487568
+   15          0.041551374600        -0.214445193944
+  1 7
+    1         14.099789445000         0.004692860169
+    2          3.180318848200         0.029433152129
+    3          0.904892205000         0.119338052458
+    4          0.304115855100         0.359138995818
+    5          0.113026066600         0.606337401509
+    6          0.042831733700         0.037936248001
+    7          6.400000000000        -0.004718510828
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.000189 sec
+-------------------------------------------------------------
+
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+-------------------
+ABSORPTION SPECTRUM
+-------------------
+
+Center of mass           = (  0.0000,  0.0000,  0.0000)
+Nuclear contribution to the dipole moment =     0.000000,    0.000000,    0.000000 au
+
+Calculating the dipole integrals          ... done
+
+Ground state mult:    1
+Ground state block:   0
+Ground state root:    0
+
+
+------------------------------------------------------------------------------
+                                 DIPOLE MOMENTS
+------------------------------------------------------------------------------
+  Root  Block           TX        TY        TZ           |T|
+                      (Debye)   (Debye)   (Debye)      (Debye)
+------------------------------------------------------------------------------
+    0    0           -0.00000   0.00000  -0.00000      0.00000
+
+-------
+TIMINGS
+-------
+
+Total time                       ...        8.5 sec
+Sum of individual times          ...        0.4 sec (  4.8%)
+
+Calculation of AO operators
+   F(Core) operator              ...        0.1 sec (  1.5%)
+   G(Act) operator               ...        0.1 sec (  0.7%)
+   J(AO) operators               ...        0.2 sec (  2.0%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.0 sec (  0.0%)
+   (pq|rs) integrals             ...        0.0 sec (  0.0%)
+   AO->MO one electron integrals ...        0.0 sec (  0.0%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  0.1%)
+   CI-solution phase             ...        0.0 sec (  0.4%)
+   Generation of densities       ...        0.0 sec (  0.0%)
+Orbital improvement steps
+   Orbital gradient              ...        0.0 sec (  0.0%)
+   O(1) converger                ...        0.0 sec (  0.1%)
+Properties                       ...        0.0 sec (  0.0%)
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -14.616497006964
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... casscf_beryllium_atom_nosym.gbw
+Electron density file                           ... casscf_beryllium_atom_nosym.scfp.tmp
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:     -0.00000       0.00000      -0.00000
+Nuclear contribution   :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :     -0.00000       0.00000      -0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+Timings for individual modules:
+
+Sum of individual times         ...       33.196 sec (=   0.553 min)
+GTO integral calculation        ...        8.129 sec (=   0.135 min)  24.5 %
+SCF iterations                  ...        8.274 sec (=   0.138 min)  24.9 %
+CASSCF iterations               ...       16.793 sec (=   0.280 min)  50.6 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 41 seconds 207 msec

--- a/ORCA/ORCA3.0/casscf_beryllium_atom_sym.in
+++ b/ORCA/ORCA3.0/casscf_beryllium_atom_sym.in
@@ -1,0 +1,10 @@
+! def2-qzvpp verytightscf noautostart usesym
+
+%casscf
+ nel 2
+ norb 4
+ end
+
+* xyz 0 1
+Be 0 0 0
+*

--- a/ORCA/ORCA3.0/casscf_beryllium_atom_sym.out
+++ b/ORCA/ORCA3.0/casscf_beryllium_atom_sym.out
@@ -1,0 +1,1041 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #  Department of molecular theory and spectroscopy    #
+                  #              Directorship: Frank Neese              #
+                  # Max Planck Institute for Chemical Energy Conversion #
+                  #                  D-45470 Muelheim/Ruhr              #
+                  #                       Germany                       #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 3.0.3 - RELEASE   -
+
+
+ With contributions from (in alphabetic order):
+   Ute Becker             : Parallelization
+   Dmytro Bykov           : SCF Hessian
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Dimitrios Liakos       : Extrapolation schemes; parallel MDCI
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA and ECA modules, normal mode analysis, Resonance Raman, ABS, FL, XAS/XES, NRVS
+   Christoph Reimann      : Effective Core Potentials
+   Michael Roemelt        : Restricted open shell CIS
+   Christoph Riplinger    : Improved optimizer, TS searches, QM/MM, DLPNO-CCSD
+   Barbara Sandhoefer     : DKH picture change effects
+   Igor Schapiro          : Molecular dynamics
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, T. Risthaus : VdW corrections, initial TS optimization,
+                                                   DFT functionals, gCP
+   Ed Valeev                                     : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, R. Olivares           : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+Your calculation utilizes the basis: Ahlrichs-QZV
+Cite in your paper:
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+Now building the actual basis set
+
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = casscf_beryllium_atom_sym.in
+|  1> ! def2-qzvpp verytightscf noautostart usesym
+|  2> 
+|  3> %casscf
+|  4>  nel 2
+|  5>  norb 4
+|  6>  end
+|  7> 
+|  8> * xyz 0 1
+|  9> Be 0 0 0
+| 10> *
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+
+------------------------------------------------------------------------------
+                            SYMMETRY HANDLING SETUP
+------------------------------------------------------------------------------
+
+------------------
+SYMMETRY DETECTION
+------------------
+Preparing Data                    ... done
+Detection Threshold:    SymThresh ... 1.0000e-04
+
+Point Group will now be determined:
+Moving molecule to center of mass ... done
+
+POINT GROUP                       ... Kh
+
+The coordinates will now be cleaned:
+Structure cleanup requested       ... yes
+Selected point group              ... Kh
+Cleaning Tolerance      SymThresh ... 1.0000e-04
+
+Cleaning coordinates              ... done
+
+-----------------------------------------------
+SYMMETRY-PERFECTED CARTESIAN COORDINATES (A.U.)
+-----------------------------------------------
+Warning (ORCA_SYM): Coordinates were not cleaned so far!
+
+------------------
+SYMMETRY REDUCTION
+------------------
+ORCA supports only abelian point groups.
+It is now checked, if the determined point group is supported:
+Point Group ( Kh    ) is          ... NOT supported
+Reducing to abelian subgroup      ... D2h
+
+(Re)building abelian point group:
+Creating Character Table          ... done
+Making direct product table       ... done
+Constructing symmetry operations  ... done
+Creating atom transfer table      ... done
+Creating asymmetric unit          ... done
+
+----------------------
+ASYMMETRIC UNIT IN D2h
+----------------------
+  #  AT     MASS              COORDS (A.U.)             BAS
+   0 Be   9.0120   0.00000000   0.00000000   0.00000000   0
+
+----------------------
+SYMMETRY ADAPTED BASIS
+----------------------
+The coefficients for the symmetry adapted linear combinations (SALCS)
+of basis functions will now be computed:
+Number of basis functions         ...    36
+Preparing memory                  ... done
+Constructing Gamma(red)           ... done
+Reducing Gamma(red)               ... done
+Constructing SALCs                ... done
+Checking SALC integrity           ... nothing suspicious
+Normalizing SALCs                 ... done
+
+Storing the symmetry object:
+Symmetry file                     ... casscf_beryllium_atom_sym.sym.tmp
+Writing symmetry information      ... done
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  Be     0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG    MASS        X           Y           Z
+   0 Be    4.0000    0     9.012          0.000000000000000          0.000000000000000          0.000000000000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ Be     0   0   0   0.000000     0.000     0.000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ Be     0   0   0   0.000000     0.000     0.000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type Be  : 15s7p2d1f contracted to 7s4p2d1f pattern {8211111/4111/11/1}
+
+Atom   0Be   basis set group =>   1
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...   25
+ # of primitive gaussian functions       ...   53
+ # of contracted shell                   ...   14
+ # of contracted basis functions         ...   36
+ Highest angular momentum                ...    3
+ Maximum contraction depth               ...    8
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  1.000e-12
+ Primitive cut-off              TCut     ...  1.000e-14
+
+
+                              INTEGRAL EVALUATION
+
+ One electron integrals                  ... done
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.000 sec)
+
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... casscf_beryllium_atom_sym
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   36
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+ Symmetry handling      UseSym         .... ON
+ Point group                           .... D2h
+ Used point group                      .... D2h
+ Number of irreps                      .... 8
+   Irrep   Ag has   11 symmetry adapted basis functions (ofs=   0)
+   Irrep  B1g has    2 symmetry adapted basis functions (ofs=  11)
+   Irrep  B2g has    2 symmetry adapted basis functions (ofs=  13)
+   Irrep  B3g has    2 symmetry adapted basis functions (ofs=  15)
+   Irrep   Au has    1 symmetry adapted basis functions (ofs=  17)
+   Irrep  B1u has    6 symmetry adapted basis functions (ofs=  18)
+   Irrep  B2u has    6 symmetry adapted basis functions (ofs=  24)
+   Irrep  B3u has    6 symmetry adapted basis functions (ofs=  30)
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 6.741e-03
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Producing symmetrization matrix            ... done (   0.000 sec)
+Total time needed                          ...    0.001 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-12
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   1678 (   0.0 sec)
+# of grid points (after weights+screening)   ...   1678 (   0.0 sec)
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     1678
+Total number of batches                      ...       27
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1678
+Average number of shells per batch           ...    11.54 (82.40%)
+Average number of basis functions per batch  ...    31.75 (88.19%)
+Average number of large shells per batch     ...    11.18 (96.90%)
+Average number of large basis fcns per batch ...    31.39 (98.88%)
+Maximum spatial batch extension              ...  21.83, 39.91, 39.91 au
+Average spatial batch extension              ...  10.49, 12.28, 14.05 au
+
+Time for grid setup =    0.004 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Setting up the integral package                    ... done
+Initializing the effective Hamiltonian             ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+The symmetry of the initial guess is 1-Ag
+Irrep occupations for operator 0
+    Ag -    2
+   B1g -    0
+   B2g -    0
+   B3g -    0
+    Au -    0
+   B1u -    1
+   B2u -    1
+   B3u -    1
+                      ------------------
+                      INITIAL GUESS DONE (   0.1 sec)
+                      ------------------
+
+
+ ... the calculation is a CASSCF calculation -I'm leaving here GOOD LUCK!!!
+
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+
+Symmetry handling      UseSym     ... ON
+Point group                       ... D2h
+Used point group                  ... D2h
+Number of irreps                  ... 8
+   Irrep   Ag has   11 SALCs (ofs=   0) #(closed)=   1 #(active)=   1
+   Irrep  B1g has    2 SALCs (ofs=  11) #(closed)=   0 #(active)=   0
+   Irrep  B2g has    2 SALCs (ofs=  13) #(closed)=   0 #(active)=   0
+   Irrep  B3g has    2 SALCs (ofs=  15) #(closed)=   0 #(active)=   0
+   Irrep   Au has    1 SALCs (ofs=  17) #(closed)=   0 #(active)=   0
+   Irrep  B1u has    6 SALCs (ofs=  18) #(closed)=   0 #(active)=   1
+   Irrep  B2u has    6 SALCs (ofs=  24) #(closed)=   0 #(active)=   1
+   Irrep  B3u has    6 SALCs (ofs=  30) #(closed)=   0 #(active)=   1
+ Symmetries of active orbitals:
+   MO =    1  IRREP= 0 (Ag)
+   MO =    2  IRREP= 6 (B2u)
+   MO =    3  IRREP= 7 (B3u)
+   MO =    4  IRREP= 5 (B1u)
+
+Setting up the integral package       ... done
+Building the CAS space              ... done (4 configurations for Mult=1 Irrep=0)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    2
+Number of active orbitals           ...    4
+Total number of electrons           ...    4
+Total number of orbitals            ...   36
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   35 (  31 orbitals)
+Number of rotation parameters      ...     34
+
+CI-STEP:
+Number of symmetry/multplity blocks ...    1
+BLOCK  1 WEIGHT=   1.0000
+  Multiplicity                      ...    1
+  Irrep                             ...    0 (Ag)
+  #(Configurations)                 ...    4
+  #(CSFs)                           ...    4
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+CI step strategy                    ... DIRECT (CSF)
+  N(GuessMat)                       ...      2064
+  Max(Iter-CI)                      ...        35
+  MaxDim(CI)                        ...         3
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  1.00e-09
+  Residual Tolerance CI             ...  1.00e-09
+  Shift(CI)                         ...  1.00e-13
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI
+  Default Parametrization           ... CAYLEY
+  Options for diverging steps       ... let the program figure out whats best
+  Act-Act rotations                 ... depends on algorithm used
+  FreezeIE                          ... 95.00% of ||g||
+  Until reaching FreezeIE rotations with active orbitals are damped. 
+
+  MaxRot                            ... 2.00e-01 
+  TolU                              ... 5.00e-01 
+  MaxDampIter                       ... 3 
+  Approx. Fock at                   ... 1.000000e-02 density convergence
+  Level shift                       ... energy gap dependent
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... DIIS    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  1.00e-12
+  Primitive cutoff TCut             ...  1.00e-14
+  Energy convergence tolerance      ...  1.00e-08
+  Orbital gradient convergence      ...  1.00e-05
+  Max. number of iterations         ...        75  
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Inactive Energy E0 = -13.60390391 Eh
+CI-ITERATION   0: 
+   -14.604424771   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  1 MULT= 1 NROOTS= 1  IRREP=Ag 
+ROOT   0:  E=     -14.6044247712 Eh
+      0.90756 [     0]: 2000
+      0.03081 [     3]: 0002
+      0.03081 [     1]: 0200
+      0.03081 [     2]: 0020
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -14.604424771 Eh DE=     0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.095   Act-Int = 4.462
+   N(occ)=  1.81512 0.06163 0.06163 0.06163
+   ||g|| =      0.512945368 Max(G)=    -0.341954278 Rot=30,0
+   --- Orbital Update [   SuperCI]
+   SUPERCI-ITER   0: DE=    -0.014000753 <r|r>=      0.001192695
+   SUPERCI-ITER   1: DE=    -0.001471610 <r|r>=      0.000056340
+   SUPERCI-ITER   2: DE=    -0.000199420 <r|r>=      0.000033448
+   SUPERCI-ITER   3: DE=    -0.000004392 <r|r>=      0.000000006
+   SUPERCI-ITER   4: DE=    -0.000000001 <r|r>=      0.000000000
+   <Psi(SX)|Psi(SX)>=      1.000000000 DE(SX)=-0.015676176
+   Largest coefficient in the normalized |SX> wavefunction= 0.134477135
+   --- Forming Natural Orbitals
+   --- Density off from convergence (1.315e+00). Exact active Fock build
+
+MACRO-ITERATION   2: 
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Inactive Energy E0 = -13.60938958 Eh
+CI-ITERATION   0: 
+   -14.613485224   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.613485224 Eh DE=    -0.009060452
+   --- Energy gap subspaces: Ext-Act = 0.043   Act-Int = 4.454
+   N(occ)=  1.79941 0.06686 0.06686 0.06686
+   ||g|| =      0.242920111 Max(G)=    -0.165949257 Rot=30,0
+   --- Orbital Update [   SuperCI]
+   SUPERCI-ITER   0: DE=    -0.003832536 <r|r>=      0.000003679
+   SUPERCI-ITER   1: DE=    -0.000004789 <r|r>=      0.000000167
+   SUPERCI-ITER   2: DE=    -0.000000204 <r|r>=      0.000000001
+   <Psi(SX)|Psi(SX)>=      1.000000000 DE(SX)=-0.003837529
+   Largest coefficient in the normalized |SX> wavefunction= 0.076290821
+   --- Forming Natural Orbitals
+   --- Density off from convergence (1.574e-02). Exact active Fock build
+
+MACRO-ITERATION   3: 
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Inactive Energy E0 = -13.61083875 Eh
+CI-ITERATION   0: 
+   -14.615742927   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.615742927 Eh DE=    -0.002257703
+   --- Energy gap subspaces: Ext-Act = 0.029   Act-Int = 4.447
+   N(occ)=  1.80069 0.06644 0.06644 0.06644
+   ||g|| =      0.114179852 Max(G)=     0.076409293 Rot=30,0
+   --- Orbital Update [   SuperCI]
+   SUPERCI-ITER   0: DE=    -0.000660142 <r|r>=      0.000000192
+   SUPERCI-ITER   1: DE=    -0.000000235 <r|r>=      0.000000047
+   SUPERCI-ITER   2: DE=    -0.000000020 <r|r>=      0.000000000
+   <Psi(SX)|Psi(SX)>=      1.000000000 DE(SX)=-0.000660397
+   Largest coefficient in the normalized |SX> wavefunction= 0.030476638
+   --- Forming Natural Orbitals
+   --- Density close to convergence (1.271e-03). Approximate active Fock build
+
+MACRO-ITERATION   4: 
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Inactive Energy E0 = -13.61106919 Eh
+CI-ITERATION   0: 
+   -14.616247197   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616247197 Eh DE=    -0.000504270
+   --- Energy gap subspaces: Ext-Act = 0.023   Act-Int = 4.442
+   N(occ)=  1.80255 0.06582 0.06582 0.06582
+   ||g|| =      0.054797991 Max(G)=    -0.034868559 Rot=30,0
+   --- Orbital Update [   SuperCI]
+   SUPERCI-ITER   0: DE=    -0.000139722 <r|r>=      0.000000006
+   SUPERCI-ITER   1: DE=    -0.000000006 <r|r>=      0.000000005
+   SUPERCI-ITER   2: DE=    -0.000000001 
+   <Psi(SX)|Psi(SX)>=      1.000000000 DE(SX)=-0.000139729
+   Largest coefficient in the normalized |SX> wavefunction= 0.009294810
+   --- Forming Natural Orbitals
+   --- Density close to convergence (1.872e-03). Approximate active Fock build
+
+MACRO-ITERATION   5: 
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Inactive Energy E0 = -13.61095110 Eh
+CI-ITERATION   0: 
+   -14.616393839   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616393839 Eh DE=    -0.000146642
+   --- Energy gap subspaces: Ext-Act = 0.020   Act-Int = 4.439
+   N(occ)=  1.80310 0.06563 0.06563 0.06563
+   ||g|| =      0.027552183 Max(G)=    -0.015894555 Rot=30,0
+   ===>>> Convergence to 3.0e-02 achieved - switching to Step=DIIS
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (5.592e-04). Approximate active Fock build
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -13.61002771 Eh
+CI-ITERATION   0: 
+   -14.616478156   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616478156 Eh DE=    -0.000084317
+   --- Energy gap subspaces: Ext-Act = 0.018   Act-Int = 4.435
+   N(occ)=  1.80360 0.06547 0.06547 0.06547
+   ||g|| =      0.018317894 Max(G)=    -0.011874325 Rot=30,0
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (5.130e-04). Approximate active Fock build
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -13.61012151 Eh
+CI-ITERATION   0: 
+   -14.616490640   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616490640 Eh DE=    -0.000012484
+   --- Energy gap subspaces: Ext-Act = 0.017   Act-Int = 4.435
+   N(occ)=  1.80354 0.06549 0.06549 0.06549
+   ||g|| =      0.014359670 Max(G)=    -0.007928281 Rot=30,0
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (5.969e-05). Approximate active Fock build
+
+MACRO-ITERATION   8: 
+   --- Inactive Energy E0 = -13.61012484 Eh
+CI-ITERATION   0: 
+   -14.616495111   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616495111 Eh DE=    -0.000004471
+   --- Energy gap subspaces: Ext-Act = 0.016   Act-Int = 4.435
+   N(occ)=  1.80359 0.06547 0.06547 0.06547
+   ||g|| =      0.004141539 Max(G)=     0.002976060 Rot=35,0
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (4.830e-05). Approximate active Fock build
+
+MACRO-ITERATION   9: 
+   --- Inactive Energy E0 = -13.61010476 Eh
+CI-ITERATION   0: 
+   -14.616496559   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496559 Eh DE=    -0.000001448
+   --- Energy gap subspaces: Ext-Act = 0.016   Act-Int = 4.434
+   N(occ)=  1.80365 0.06545 0.06545 0.06545
+   ||g|| =      0.002623648 Max(G)=    -0.001963395 Rot=35,0
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (6.649e-05). Approximate active Fock build
+
+MACRO-ITERATION  10: 
+   --- Inactive Energy E0 = -13.61009451 Eh
+CI-ITERATION   0: 
+   -14.616496948   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496948 Eh DE=    -0.000000389
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80370 0.06543 0.06543 0.06543
+   ||g|| =      0.000920309 Max(G)=     0.000676763 Rot=35,0
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (4.684e-05). Approximate active Fock build
+
+MACRO-ITERATION  11: 
+   --- Inactive Energy E0 = -13.61009534 Eh
+CI-ITERATION   0: 
+   -14.616497000   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497000 Eh DE=    -0.000000052
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80373 0.06542 0.06542 0.06542
+   ||g|| =      0.000456574 Max(G)=    -0.000309782 Rot=34,0
+   --- Orbital Update [      DIIS]
+   --- S-Fitting active orbitals
+   --- Density close to convergence (2.951e-05). Approximate active Fock build
+
+MACRO-ITERATION  12: 
+   --- Inactive Energy E0 = -13.61009547 Eh
+CI-ITERATION   0: 
+   -14.616497007   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497007 Eh DE=    -0.000000007
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80374 0.06542 0.06542 0.06542
+   ||g|| =      0.000184163 Max(G)=     0.000129216 Rot=34,0
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Forming Natural Orbitals
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION  13: 
+   --- Inactive Energy E0 = -13.61009547 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -14.616497007   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497007 Eh DE=     0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80374 0.06542 0.06542 0.06542
+   ||g|| =      0.000183955 Max(G)=    -0.000129130 Rot=34,0
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -14.616497007 Eh    -397.7351 eV
+
+Orbital   Occ.   Energy(Eh)   Energy(eV): Sym
+    0:  2.000000       -4.711840   -128.2157   1-Ag
+    1:  1.803744       -0.277795     -7.5592   2-Ag
+    2:  0.065419        0.112646      3.0653   1-B2u
+    3:  0.065419        0.112646      3.0653   1-B3u
+    4:  0.065419        0.112646      3.0653   1-B1u
+    5:  0.000000        0.127743      3.4761   3-Ag
+    6:  0.000000        0.150934      4.1071   2-B3u
+    7:  0.000000        0.150934      4.1071   2-B1u
+    8:  0.000000        0.150934      4.1071   2-B2u
+    9:  0.000000        0.274858      7.4793   1-B2g
+   10:  0.000000        0.274858      7.4793   1-B1g
+   11:  0.000000        0.274858      7.4793   1-B3g
+   12:  0.000000        0.274858      7.4793   4-Ag
+   13:  0.000000        0.274858      7.4793   5-Ag
+   14:  0.000000        0.681115     18.5341   6-Ag
+   15:  0.000000        0.767033     20.8720   3-B2u
+   16:  0.000000        0.767033     20.8720   3-B3u
+   17:  0.000000        0.767033     20.8720   3-B1u
+   18:  0.000000        1.118726     30.4421   2-B2g
+   19:  0.000000        1.118726     30.4421   2-B1g
+   20:  0.000000        1.118726     30.4421   2-B3g
+   21:  0.000000        1.118726     30.4421   7-Ag
+   22:  0.000000        1.118726     30.4421   8-Ag
+   23:  0.000000        1.176081     32.0028   4-B3u
+   24:  0.000000        1.176081     32.0028   4-B2u
+   25:  0.000000        1.176081     32.0028   4-B1u
+   26:  0.000000        1.176081     32.0028   5-B1u
+   27:  0.000000        1.176081     32.0028   5-B3u
+   28:  0.000000        1.176081     32.0028   5-B2u
+   29:  0.000000        1.176081     32.0028   1-Au
+   30:  0.000000        3.007599     81.8409   9-Ag
+   31:  0.000000       10.933791    297.5236   6-B2u
+   32:  0.000000       10.933791    297.5236   6-B3u
+   33:  0.000000       10.933791    297.5236   6-B1u
+   34:  0.000000       11.951757    325.2239  10-Ag
+   35:  0.000000       65.244454   1775.3919  11-Ag
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  1 MULT= 1 IRREP= Ag NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -14.6164970070 Eh
+      0.90187 [     0]: 2000
+      0.03271 [     2]: 0020
+      0.03271 [     3]: 0002
+      0.03271 [     1]: 0200
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                   0          1          2          3    
+      0       1.803744   0.000000   0.000000   0.000000
+      1       0.000000   0.065419   0.000000   0.000000
+      2       0.000000   0.000000   0.065419   0.000000
+      3       0.000000   0.000000   0.000000   0.065419
+Trace of the electron density:  2.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -19.082324970 Eh        -519.2565 eV
+Two electron energy          :      4.465827964 Eh         121.5214 eV
+Nuclear repuslion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -14.616497007
+
+Kinetic energy               :     14.616237387 Eh         397.7280 eV
+Potential energy             :    -29.232734394 Eh        -795.4631 eV
+Virial ratio                 :     -2.000017762 
+                               ----------------
+                                  -14.616497007
+
+Core energy                  :    -13.610095475 Eh     -370.3495 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71184  -0.27779   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80374   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be px              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be py              0.0       0.0     100.0       0.0       0.0       0.0
+
+                      6         7         8         9        10        11   
+                   0.15093   0.15093   0.15093   0.27486   0.27486   0.27486
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be pz              0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be px            100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be py              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be dxz             0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be dyz             0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be dxy             0.0       0.0       0.0       0.0     100.0       0.0
+
+                     12        13        14        15        16        17   
+                   0.27486   0.27486   0.68112   0.76703   0.76703   0.76703
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s               0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be pz              0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be px              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be dz2             0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be dx2y2         100.0       0.0       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.11873   1.11873   1.11873   1.11873   1.11873   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be dz2             0.0       0.0       0.0       8.6      91.4       0.0
+ 0 Be dxz           100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be dyz             0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be dx2y2           0.0       0.0       0.0      91.4       8.6       0.0
+ 0 Be dxy             0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be f+1             0.0       0.0       0.0       0.0       0.0      37.3
+ 0 Be f+3             0.0       0.0       0.0       0.0       0.0      62.7
+
+                     24        25        26        27        28        29   
+                   1.17608   1.17608   1.17608   1.17608   1.17608   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be f0              0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be f+1             0.0       0.0       0.0      62.7       0.0       0.0
+ 0 Be f-1            37.5       0.0       0.0       0.0      62.5       0.0
+ 0 Be f+2             0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be f-2             0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be f+3             0.0       0.0       0.0      37.3       0.0       0.0
+ 0 Be f-3            62.5       0.0       0.0       0.0      37.5       0.0
+
+                     30        31        32        33        34        35   
+                   3.00760  10.93379  10.93379  10.93379  11.95176  65.24445
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0       0.0       0.0       0.0     100.0     100.0
+ 0 Be pz              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py              0.0     100.0       0.0       0.0       0.0       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... casscf_beryllium_atom_sym.scfp.tmp
+BaseName (.gbw .S,...)              ... casscf_beryllium_atom_sym
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 Be:    0.000000
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Bes       :     3.803744  s :     3.803744
+      pz      :     0.065419  p :     0.196256
+      px      :     0.065419
+      py      :     0.065419
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 Be:    0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Bes       :     3.803744  s :     3.803744
+      pz      :     0.065419  p :     0.196256
+      px      :     0.065419
+      py      :     0.065419
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 Be     4.0000     4.0000     0.0000     0.7337     0.0000     0.7337
+
+
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.093193135 (    -0.000000000,      0.093193135,     -0.000000000)
+ MO   3:      0.093193135 (     0.093193135,     -0.000000000,     -0.000000000)
+ MO   4:      0.093193135 (     0.000000000,      0.000000000,     -0.093193135)
+MO   1:
+ MO   2:      1.461436957 (    -0.000000000,      1.461436957,     -0.000000000)
+ MO   3:      1.461436957 (     1.461436957,     -0.000000000,     -0.000000000)
+ MO   4:      1.461436957 (     0.000000000,      0.000000000,     -1.461436957)
+MO   2:
+MO   3:
+MO   4:
+  newgto Be
+  0 15
+    1      29646.704407000001         0.000038108121
+    2       4428.761435400000         0.000297339519
+    3       1005.470133200000         0.001564012189
+    4        284.153395780000         0.006560695178
+    5         92.504356461000         0.023217277748
+    6         33.311016058000         0.069760234287
+    7         12.911553314000         0.170882796272
+    8          5.266549736100         0.318203370984
+    9         22.995386380000        -0.000026816811
+   10          6.623635417600        -0.000262295694
+   11          2.228959500300         0.379039345639
+   12          0.953024334500         0.186073662085
+   13          0.246516024400         0.006077980713
+   14          0.101538953100        -0.011158776982
+   15          0.041551374600        -0.001939287633
+  0 15
+    1      29646.704407000001         0.000006656479
+    2       4428.761435400000         0.000051937333
+    3       1005.470133200000         0.000273191476
+    4        284.153395780000         0.001145979558
+    5         92.504356461000         0.004055443055
+    6         33.311016058000         0.012185263955
+    7         12.911553314000         0.029848695310
+    8          5.266549736100         0.055581695023
+    9         22.995386380000         0.001089174539
+   10          6.623635417600         0.010653234928
+   11          2.228959500300         0.118820253833
+   12          0.953024334500         0.107296709006
+   13          0.246516024400        -0.284116196701
+   14          0.101538953100        -0.627982487568
+   15          0.041551374600        -0.214445193944
+  1 7
+    1         14.099789445000         0.004692860169
+    2          3.180318848200         0.029433152129
+    3          0.904892205000         0.119338052458
+    4          0.304115855100         0.359138995817
+    5          0.113026066600         0.606337401509
+    6          0.042831733700         0.037936248001
+    7          6.400000000000        -0.004718510828
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.000138 sec
+-------------------------------------------------------------
+
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+-------------------
+ABSORPTION SPECTRUM
+-------------------
+
+Center of mass           = (  0.0000,  0.0000,  0.0000)
+Nuclear contribution to the dipole moment =     0.000000,    0.000000,    0.000000 au
+
+Calculating the dipole integrals          ... done
+
+Ground state mult:    1
+Ground state block:   0
+Ground state root:    0
+
+
+------------------------------------------------------------------------------
+                                 DIPOLE MOMENTS
+------------------------------------------------------------------------------
+  Root  Block           TX        TY        TZ           |T|
+                      (Debye)   (Debye)   (Debye)      (Debye)
+------------------------------------------------------------------------------
+    0    0           -0.00000   0.00000   0.00000      0.00000
+
+-------
+TIMINGS
+-------
+
+Total time                       ...        0.5 sec
+Sum of individual times          ...        0.4 sec ( 71.2%)
+
+Calculation of AO operators
+   F(Core) operator              ...        0.1 sec ( 25.6%)
+   G(Act) operator               ...        0.0 sec (  9.7%)
+   J(AO) operators               ...        0.2 sec ( 30.9%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.0 sec (  0.2%)
+   (pq|rs) integrals             ...        0.0 sec (  0.1%)
+   AO->MO one electron integrals ...        0.0 sec (  0.1%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  0.0%)
+   CI-solution phase             ...        0.0 sec (  2.5%)
+   Generation of densities       ...        0.0 sec (  0.1%)
+Orbital improvement steps
+   Orbital gradient              ...        0.0 sec (  0.2%)
+   O(1) converger                ...        0.0 sec (  1.5%)
+Properties                       ...        0.0 sec (  0.2%)
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -14.616497006964
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... casscf_beryllium_atom_sym.gbw
+Electron density file                           ... casscf_beryllium_atom_sym.scfp.tmp
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:     -0.00000       0.00000       0.00000
+Nuclear contribution   :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :     -0.00000       0.00000       0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+Timings for individual modules:
+
+Sum of individual times         ...        0.851 sec (=   0.014 min)
+GTO integral calculation        ...        0.174 sec (=   0.003 min)  20.5 %
+SCF iterations                  ...        0.080 sec (=   0.001 min)   9.4 %
+CASSCF iterations               ...        0.597 sec (=   0.010 min)  70.1 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 0 seconds 997 msec

--- a/ORCA/ORCA4.0/casscf_beryllium_atom_nosym.in
+++ b/ORCA/ORCA4.0/casscf_beryllium_atom_nosym.in
@@ -1,0 +1,10 @@
+! def2-qzvpp verytightscf noautostart nousesym
+
+%casscf
+ nel 2
+ norb 4
+ end
+
+* xyz 0 1
+Be 0 0 0
+*

--- a/ORCA/ORCA4.0/casscf_beryllium_atom_nosym.out
+++ b/ORCA/ORCA4.0/casscf_beryllium_atom_nosym.out
@@ -1,0 +1,858 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #  Department of molecular theory and spectroscopy    #
+                  #              Directorship: Frank Neese              #
+                  # Max Planck Institute for Chemical Energy Conversion #
+                  #                  D-45470 Muelheim/Ruhr              #
+                  #                       Germany                       #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.0.1.2 - RELEASE -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Properties
+   Michael Atanasov       : Ab Initio Ligand Field Theory
+   Ute Becker             : Parallelization
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Dagmar Lenk            : GEPOL surface
+   Dimitrios Liakos       : Extrapolation schemes; parallel MDCI
+   Dimitrios Manganas     : ROCIS; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Restricted open shell CIS
+   Masaaki Saitow         : Open-shell DLPNO
+   Barbara Sandhoefer     : DKH picture change effects
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Georgi Stoychev        : AutoAux
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev                                     : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+Your calculation utilizes the basis: def2-QZVPP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+Warning: TCutStore was < 0. Adjusted to Thresh (uncritical)
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = casscf_beryllium_atom_nosym.in
+|  1> ! def2-qzvpp verytightscf noautostart nousesym
+|  2> 
+|  3> %casscf
+|  4>  nel 2
+|  5>  norb 4
+|  6>  end
+|  7> 
+|  8> * xyz 0 1
+|  9> Be 0 0 0
+| 10> *
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  Be     0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 Be    4.0000    0     9.012    0.000000    0.000000    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type Be  : 15s7p2d1f contracted to 7s4p2d1f pattern {8211111/4111/11/1}
+
+Atom   0Be   basis set group =>   1
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...   25
+ # of primitive gaussian functions       ...   53
+ # of contracted shells                  ...   14
+ # of contracted basis functions         ...   36
+ Highest angular momentum                ...    3
+ Maximum contraction depth               ...    8
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  1.000e-12
+ Primitive cut-off              TCut     ...  1.000e-14
+
+
+------------------------------ INTEGRAL EVALUATION ----------------------------
+
+
+ * One electron integrals 
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.000 sec)
+
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... casscf_beryllium_atom_nosym
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   36
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 6.741e-03
+Time for diagonalization                   ...    0.070 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.005 sec
+Total time needed                          ...    0.075 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-12
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   1678 (   0.0 sec)
+# of grid points (after weights+screening)   ...   1678 (   0.0 sec)
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     1678
+Total number of batches                      ...       27
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1678
+Average number of shells per batch           ...    11.54 (82.40%)
+Average number of basis functions per batch  ...    31.75 (88.19%)
+Average number of large shells per batch     ...    11.21 (97.21%)
+Average number of large basis fcns per batch ...    31.43 (98.99%)
+Maximum spatial batch extension              ...  21.83, 39.91, 39.91 au
+Average spatial batch extension              ...  10.55, 12.37, 14.01 au
+
+Time for grid setup =    0.024 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Setting up the integral package                    ... done
+Initializing the effective Hamiltonian             ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.1 sec)
+                      ------------------
+
+
+ ... the calculation is a CASSCF calculation -I'm leaving here GOOD LUCK!!!
+
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Setting up the integral package       ... done
+Building the CAS space                ... done (10 configurations for Mult=1)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    2
+Number of active orbitals           ...    4
+Total number of electrons           ...    4
+Total number of orbitals            ...   36
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   35 (  31 orbitals)
+Number of rotation parameters      ...    159
+
+CI-STEP:
+CI strategy                         ... General CI
+Number of multiplicity blocks       ...    1
+BLOCK  1 WEIGHT=   1.0000
+  Multiplicity                      ...    1
+  #(Configurations)                 ...   10
+  #(CSFs)                           ...   10
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+  N(GuessMat)                       ...       512
+  MaxDim(CI)                        ...        10
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  1.00e-09
+  Residual Tolerance CI             ...  1.00e-09
+  Shift(CI)                         ...  1.00e-04
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI(PT)
+  Default Parametrization           ... CAYLEY
+  Act-Act rotations                 ... depends on algorithm used
+
+  Note: SuperCI(PT) will ignore level shift, gradscaling, FreezeIE, FreezeAct and FreezeGrad
+
+  MaxRot                            ... 2.00e-01 
+  Max. no of vectors (DIIS)         ... 15
+  DThresh (cut-off) metric          ... 1.00e-06
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... SuperCI(PT)    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  1.00e-12
+  Primitive cutoff TCut             ...  1.00e-14
+  Energy convergence tolerance      ...  1.00e-08
+  Orbital gradient convergence      ...  1.00e-05
+  Max. number of iterations         ...        75  
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Inactive Energy E0 = -13.60390391 Eh
+CI-ITERATION   0: 
+   -14.604424771   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  1 MULT= 1 NROOTS= 1 
+ROOT   0:  E=     -14.6044247712 Eh
+      0.90756 [     0]: 2000
+      0.03081 [     9]: 0002
+      0.03081 [     4]: 0200
+      0.03081 [     7]: 0020
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -14.604424771 Eh DE=     0.000000000
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Energy gap subspaces: Ext-Act = 0.062   Act-Int = 4.462
+   N(occ)=  1.81512 0.06163 0.06163 0.06163
+   ||g|| =      0.512945368 Max(G)=     0.351846827 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.342427500 Max(X)(6,3) =     -0.188516161 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   2: 
+   --- Inactive Energy E0 = -13.61070861 Eh
+CI-ITERATION   0: 
+   -14.615891588   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.615891588 Eh DE=    -0.011466817
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Energy gap subspaces: Ext-Act = 0.032   Act-Int = 4.444
+   N(occ)=  1.80034 0.06655 0.06655 0.06655
+   ||g|| =      0.046434164 Max(G)=     0.025296620 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.077240157 Max(X)(6,3) =     -0.039342594 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   3: 
+   --- Inactive Energy E0 = -13.61017255 Eh
+CI-ITERATION   0: 
+   -14.616467015   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616467015 Eh DE=    -0.000575427
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.437
+   N(occ)=  1.80346 0.06551 0.06551 0.06551
+   ||g|| =      0.010141554 Max(G)=    -0.006282867 Rot=5,1
+   --- Orbital Update [SuperCI(PT)]
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.011058651 Max(X)(7,4) =     -0.005531063 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   4: 
+   --- Inactive Energy E0 = -13.61008825 Eh
+CI-ITERATION   0: 
+   -14.616496888   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496888 Eh DE=    -0.000029873
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80382 0.06539 0.06539 0.06539
+   ||g|| =      0.000764647 Max(G)=    -0.000409109 Rot=34,0
+   --- Orbital Update [SuperCI(PT)]
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.001059019 Max(X)(6,3) =      0.000448168 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   5: 
+   --- Inactive Energy E0 = -13.61009983 Eh
+CI-ITERATION   0: 
+   -14.616497002   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497002 Eh DE=    -0.000000114
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80373 0.06542 0.06542 0.06542
+   ||g|| =      0.000248514 Max(G)=     0.000174817 Rot=34,0
+   --- Orbital Update [SuperCI(PT)]
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.000276300 Max(X)(6,2) =     -0.000144795 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=    -0.000000007
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =      0.000016063 Max(G)=    -0.000011575 Rot=14,1
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Forming Natural Orbitals
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=    -0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =      0.000016063 Max(G)=    -0.000011575 Rot=14,1
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -14.616497008 Eh    -397.7351 eV
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000      -4.711845      -128.2158 
+   1   1.8038      -0.277797        -7.5592 
+   2   0.0654       0.112653         3.0655 
+   3   0.0654       0.112653         3.0655 
+   4   0.0654       0.112653         3.0655 
+   5   0.0000       0.127743         3.4761 
+   6   0.0000       0.150920         4.1067 
+   7   0.0000       0.150920         4.1067 
+   8   0.0000       0.150920         4.1067 
+   9   0.0000       0.274858         7.4793 
+  10   0.0000       0.274858         7.4793 
+  11   0.0000       0.274858         7.4793 
+  12   0.0000       0.274858         7.4793 
+  13   0.0000       0.274858         7.4793 
+  14   0.0000       0.681115        18.5341 
+  15   0.0000       0.767036        20.8721 
+  16   0.0000       0.767036        20.8721 
+  17   0.0000       0.767036        20.8721 
+  18   0.0000       1.118724        30.4420 
+  19   0.0000       1.118724        30.4420 
+  20   0.0000       1.118724        30.4420 
+  21   0.0000       1.118724        30.4420 
+  22   0.0000       1.118724        30.4420 
+  23   0.0000       1.176080        32.0028 
+  24   0.0000       1.176080        32.0028 
+  25   0.0000       1.176080        32.0028 
+  26   0.0000       1.176080        32.0028 
+  27   0.0000       1.176080        32.0028 
+  28   0.0000       1.176080        32.0028 
+  29   0.0000       1.176080        32.0028 
+  30   0.0000       3.007595        81.8408 
+  31   0.0000      10.933785       297.5234 
+  32   0.0000      10.933785       297.5234 
+  33   0.0000      10.933785       297.5234 
+  34   0.0000      11.951752       325.2237 
+  35   0.0000      65.244448      1775.3917 
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  1 MULT= 1 NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -14.6164970082 Eh
+      0.90188 [     0]: 2000
+      0.03271 [     9]: 0002
+      0.03271 [     7]: 0020
+      0.03271 [     4]: 0200
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                   0          1          2          3    
+      0       1.803752  -0.000000   0.000000   0.000000
+      1      -0.000000   0.065416  -0.000000   0.000000
+      2       0.000000  -0.000000   0.065416  -0.000000
+      3       0.000000   0.000000  -0.000000   0.065416
+Trace of the electron density:  2.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -19.082312356 Eh        -519.2561 eV
+Two electron energy          :      4.465815348 Eh         121.5210 eV
+Nuclear repuslion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -14.616497008
+
+Kinetic energy               :     14.616237926 Eh         397.7281 eV
+Potential energy             :    -29.232734934 Eh        -795.4632 eV
+Virial ratio                 :     -2.000017726 
+                               ----------------
+                                  -14.616497008
+
+Core energy                  :    -13.610095236 Eh     -370.3495 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.1      99.9       0.0       0.0
+ 0 Be px              0.0       0.0      99.9       0.1       0.0       0.0
+ 0 Be py              0.0       0.0       0.0       0.0     100.0       0.0
+
+                      6         7         8         9        10        11   
+                   0.15092   0.15092   0.15092   0.27486   0.27486   0.27486
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be pz              0.3      65.8      33.9       0.0       0.0       0.0
+ 0 Be px              0.5      34.2      65.3       0.0       0.0       0.0
+ 0 Be py             99.2       0.0       0.8       0.0       0.0       0.0
+ 0 Be dxz             0.0       0.0       0.0       4.1      86.3       9.6
+ 0 Be dyz             0.0       0.0       0.0      95.6       3.1       1.3
+ 0 Be dxy             0.0       0.0       0.0       0.2      10.6      89.2
+
+                     12        13        14        15        16        17   
+                   0.27486   0.27486   0.68111   0.76704   0.76704   0.76704
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s               0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be pz              0.0       0.0       0.0      77.6       2.1      20.3
+ 0 Be px              0.0       0.0       0.0       0.9      97.4       1.7
+ 0 Be py              0.0       0.0       0.0      21.5       0.5      78.0
+ 0 Be dz2            87.4      12.6       0.0       0.0       0.0       0.0
+ 0 Be dx2y2          12.6      87.4       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.11872   1.11872   1.11872   1.11872   1.11872   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be dz2             0.0       0.0       0.0      25.1      74.9       0.0
+ 0 Be dxz             0.7      39.9      59.4       0.0       0.0       0.0
+ 0 Be dyz            24.2      41.8      33.9       0.0       0.0       0.0
+ 0 Be dx2y2           0.0       0.0       0.0      74.9      25.1       0.0
+ 0 Be dxy            75.1      18.3       6.6       0.0       0.0       0.0
+ 0 Be f-2             0.0       0.0       0.0       0.0       0.0     100.0
+
+                     24        25        26        27        28        29   
+                   1.17608   1.17608   1.17608   1.17608   1.17608   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be f0              0.0       0.0       0.0       0.0       0.0      99.9
+ 0 Be f+1             4.6      45.2      13.6      23.8      12.7       0.0
+ 0 Be f-1            36.8       0.7      25.4      13.0      24.0       0.0
+ 0 Be f+2            33.9      28.1      37.9       0.0       0.0       0.0
+ 0 Be f+3             3.0      25.6       7.9      40.4      23.1       0.0
+ 0 Be f-3            21.6       0.3      15.1      22.7      40.2       0.0
+
+                     30        31        32        33        34        35   
+                   3.00760  10.93379  10.93379  10.93379  11.95175  65.24445
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0       0.0       0.0       0.0     100.0     100.0
+ 0 Be pz              0.0       4.1       2.7      93.3       0.0       0.0
+ 0 Be px              0.0      63.3      36.3       0.4       0.0       0.0
+ 0 Be py              0.0      32.7      61.1       6.3       0.0       0.0
+
+
+----------------------------
+LOEWDIN REDUCED ACTIVE MOs  
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.1      99.9       0.0       0.0
+ 0 Be px              0.0       0.0      99.9       0.1       0.0       0.0
+ 0 Be py              0.0       0.0       0.0       0.0     100.0       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... casscf_beryllium_atom_nosym.scfp.tmp
+BaseName (.gbw .S,...)              ... casscf_beryllium_atom_nosym
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 Be:    0.000000
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 Be:    0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 Be     4.0000     4.0000     0.0000     0.7336     0.0000     0.7336
+
+
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.093188947 (     0.093134333,      0.001336522,     -0.002896466)
+ MO   3:      0.093188947 (     0.002886277,      0.000725351,      0.093141414)
+ MO   4:      0.093188947 (     0.001358386,     -0.093176539,      0.000683530)
+MO   1:
+ MO   2:      1.461408146 (    -1.460551682,     -0.020959618,      0.045422979)
+ MO   3:      1.461408146 (    -0.045263194,     -0.011375097,     -1.460662733)
+ MO   4:      1.461408146 (    -0.021302484,      1.461213561,     -0.010719263)
+MO   2:
+MO   3:
+MO   4:
+  newgto Be
+  0 15
+    1      29646.704407000001         0.000038108224
+    2       4428.761435400000         0.000297340321
+    3       1005.470133200000         0.001564016408
+    4        284.153395780000         0.006560712877
+    5         92.504356461000         0.023217340382
+    6         33.311016058000         0.069760422481
+    7         12.911553314000         0.170883257267
+    8          5.266549736100         0.318204229410
+    9         22.995386380000        -0.000026605257
+   10          6.623635417600        -0.000260226477
+   11          2.228959500300         0.379026890551
+   12          0.953024334500         0.186086635305
+   13          0.246516024400         0.006073816978
+   14          0.101538953100        -0.011158857101
+   15          0.041551374600        -0.001939619455
+  0 15
+    1      29646.704407000001         0.000006656465
+    2       4428.761435400000         0.000051937223
+    3       1005.470133200000         0.000273190897
+    4        284.153395780000         0.001145977130
+    5         92.504356461000         0.004055434462
+    6         33.311016058000         0.012185238136
+    7         12.911553314000         0.029848632063
+    8          5.266549736100         0.055581577250
+    9         22.995386380000         0.001088706138
+   10          6.623635417600         0.010648653488
+   11          2.228959500300         0.118828786568
+   12          0.953024334500         0.107283329848
+   13          0.246516024400        -0.284089779427
+   14          0.101538953100        -0.628004193293
+   15          0.041551374600        -0.214441958613
+  1 7
+    1         14.099789445000         0.004692441536
+    2          3.180318848200         0.029430526501
+    3          0.904892205000         0.119327406732
+    4          0.304115855100         0.359106958296
+    5          0.113026066600         0.606477568469
+    6          0.042831733700         0.037784957343
+    7          6.400000000000        -0.004717453605
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.000700 sec
+-------------------------------------------------------------
+
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+-------------------
+ABSORPTION SPECTRUM
+-------------------
+
+Center of mass           = (  0.0000,  0.0000,  0.0000)
+Nuclear contribution to the dipole moment =     0.000000,    0.000000,    0.000000 au
+
+Calculating the dipole integrals          ... done
+
+Ground state mult:    1
+Ground state block:   0
+Ground state root:    0
+
+
+------------------------------------------------------------------------------
+                                 DIPOLE MOMENTS
+------------------------------------------------------------------------------
+  Root  Block           TX        TY        TZ           |T|
+                      (Debye)   (Debye)   (Debye)      (Debye)
+------------------------------------------------------------------------------
+    0    0            0.00000  -0.00000   0.00000      0.00000
+
+-------
+TIMINGS
+-------
+
+Total time                       ...        0.5 sec
+Sum of individual times          ...        0.3 sec ( 57.5%)
+
+Calculation of AO operators
+   F(Core) operator              ...        0.0 sec (  6.3%)
+   G(Act) operator               ...        0.1 sec ( 14.3%)
+   J(AO) operators               ...        0.1 sec ( 16.3%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.0 sec (  0.0%)
+   (pq|rs) integrals             ...        0.0 sec (  0.1%)
+   AO->MO one electron integrals ...        0.0 sec (  4.9%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  2.0%)
+   CI-solution phase             ...        0.1 sec ( 13.1%)
+   Generation of densities       ...        0.0 sec (  0.1%)
+Orbital improvement steps
+   Orbital gradient              ...        0.0 sec (  0.1%)
+   O(1) converger                ...        0.0 sec (  0.1%)
+Properties                       ...        0.0 sec (  0.3%)
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -14.616497008249
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... casscf_beryllium_atom_nosym.gbw
+Electron density file                           ... casscf_beryllium_atom_nosym.scfp.tmp
+The origin for moment calculation is the CENTER OF MASS  = ( 0.000000,  0.000000  0.000000)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:      0.00000      -0.00000       0.00000
+Nuclear contribution   :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :      0.00000      -0.00000       0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+Timings for individual modules:
+
+Sum of individual times         ...        1.655 sec (=   0.028 min)
+GTO integral calculation        ...        0.280 sec (=   0.005 min)  16.9 %
+SCF iterations                  ...        0.244 sec (=   0.004 min)  14.7 %
+CASSCF iterations               ...        1.131 sec (=   0.019 min)  68.3 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 1 seconds 990 msec

--- a/ORCA/ORCA4.0/casscf_beryllium_atom_sym.in
+++ b/ORCA/ORCA4.0/casscf_beryllium_atom_sym.in
@@ -1,0 +1,10 @@
+! def2-qzvpp verytightscf noautostart usesym
+
+%casscf
+ nel 2
+ norb 4
+ end
+
+* xyz 0 1
+Be 0 0 0
+*

--- a/ORCA/ORCA4.0/casscf_beryllium_atom_sym.out
+++ b/ORCA/ORCA4.0/casscf_beryllium_atom_sym.out
@@ -1,0 +1,968 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #  Department of molecular theory and spectroscopy    #
+                  #              Directorship: Frank Neese              #
+                  # Max Planck Institute for Chemical Energy Conversion #
+                  #                  D-45470 Muelheim/Ruhr              #
+                  #                       Germany                       #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.0.1.2 - RELEASE -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Properties
+   Michael Atanasov       : Ab Initio Ligand Field Theory
+   Ute Becker             : Parallelization
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Dagmar Lenk            : GEPOL surface
+   Dimitrios Liakos       : Extrapolation schemes; parallel MDCI
+   Dimitrios Manganas     : ROCIS; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Restricted open shell CIS
+   Masaaki Saitow         : Open-shell DLPNO
+   Barbara Sandhoefer     : DKH picture change effects
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Georgi Stoychev        : AutoAux
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev                                     : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+Your calculation utilizes the basis: def2-QZVPP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+Warning: TCutStore was < 0. Adjusted to Thresh (uncritical)
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = casscf_beryllium_atom_sym.in
+|  1> ! def2-qzvpp verytightscf noautostart usesym
+|  2> 
+|  3> %casscf
+|  4>  nel 2
+|  5>  norb 4
+|  6>  end
+|  7> 
+|  8> * xyz 0 1
+|  9> Be 0 0 0
+| 10> *
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+
+------------------------------------------------------------------------------
+                            SYMMETRY HANDLING SETUP
+------------------------------------------------------------------------------
+
+------------------
+SYMMETRY DETECTION
+------------------
+Preparing Data                    ... done
+Detection Threshold:    SymThresh ... 1.0000e-04
+
+Point Group will now be determined:
+Moving molecule to center of mass ... done
+
+POINT GROUP                       ... Kh
+
+The coordinates will now be cleaned:
+Structure cleanup requested       ... yes
+Selected point group              ... Kh
+Cleaning Tolerance      SymThresh ... 1.0000e-04
+
+Cleaning coordinates              ... done
+
+-----------------------------------------------
+SYMMETRY-PERFECTED CARTESIAN COORDINATES (A.U.)
+-----------------------------------------------
+Warning (ORCA_SYM): Coordinates were not cleaned so far!
+
+------------------
+SYMMETRY REDUCTION
+------------------
+ORCA supports only abelian point groups.
+It is now checked, if the determined point group is supported:
+Point Group ( Kh    ) is          ... NOT supported
+Reducing to abelian subgroup      ... D2h
+
+(Re)building abelian point group:
+Creating Character Table          ... done
+Making direct product table       ... done
+Constructing symmetry operations  ... done
+Creating atom transfer table      ... done
+Creating asymmetric unit          ... done
+
+----------------------
+ASYMMETRIC UNIT IN D2h
+----------------------
+  #  AT     MASS              COORDS (A.U.)             BAS
+   0 Be   9.0120   0.00000000   0.00000000   0.00000000   0
+
+----------------------
+SYMMETRY ADAPTED BASIS
+----------------------
+The coefficients for the symmetry adapted linear combinations (SALCS)
+of basis functions will now be computed:
+Number of basis functions         ...    36
+Preparing memory                  ... done
+Constructing Gamma(red)           ... done
+Reducing Gamma(red)               ... done
+Constructing SALCs                ... done
+Checking SALC integrity           ... nothing suspicious
+Normalizing SALCs                 ... done
+
+Storing the symmetry object:
+Symmetry file                     ... casscf_beryllium_atom_sym.sym.tmp
+Writing symmetry information      ... done
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  Be     0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 Be    4.0000    0     9.012    0.000000    0.000000    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type Be  : 15s7p2d1f contracted to 7s4p2d1f pattern {8211111/4111/11/1}
+
+Atom   0Be   basis set group =>   1
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...   25
+ # of primitive gaussian functions       ...   53
+ # of contracted shells                  ...   14
+ # of contracted basis functions         ...   36
+ Highest angular momentum                ...    3
+ Maximum contraction depth               ...    8
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  1.000e-12
+ Primitive cut-off              TCut     ...  1.000e-14
+
+
+------------------------------ INTEGRAL EVALUATION ----------------------------
+
+
+ * One electron integrals 
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.000 sec)
+
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... casscf_beryllium_atom_sym
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   36
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+ Symmetry handling      UseSym         .... ON
+ Point group                           .... D2h
+ Used point group                      .... D2h
+ Number of irreps                      .... 8
+   Irrep   Ag has   11 symmetry adapted basis functions (ofs=   0)
+   Irrep  B1g has    2 symmetry adapted basis functions (ofs=  11)
+   Irrep  B2g has    2 symmetry adapted basis functions (ofs=  13)
+   Irrep  B3g has    2 symmetry adapted basis functions (ofs=  15)
+   Irrep   Au has    1 symmetry adapted basis functions (ofs=  17)
+   Irrep  B1u has    6 symmetry adapted basis functions (ofs=  18)
+   Irrep  B2u has    6 symmetry adapted basis functions (ofs=  24)
+   Irrep  B3u has    6 symmetry adapted basis functions (ofs=  30)
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 6.741e-03
+Time for diagonalization                   ...    0.001 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Producing symmetrization matrix            ... done (   0.000 sec)
+Total time needed                          ...    0.001 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-12
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   1678 (   0.0 sec)
+# of grid points (after weights+screening)   ...   1678 (   0.0 sec)
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     1678
+Total number of batches                      ...       27
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1678
+Average number of shells per batch           ...    11.54 (82.40%)
+Average number of basis functions per batch  ...    31.75 (88.19%)
+Average number of large shells per batch     ...    11.21 (97.21%)
+Average number of large basis fcns per batch ...    31.43 (98.99%)
+Maximum spatial batch extension              ...  21.83, 39.91, 39.91 au
+Average spatial batch extension              ...  10.55, 12.37, 14.01 au
+
+Time for grid setup =    0.003 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Setting up the integral package                    ... done
+Initializing the effective Hamiltonian             ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+The symmetry of the initial guess is 1-Ag
+Irrep occupations for operator 0
+    Ag -    2
+   B1g -    0
+   B2g -    0
+   B3g -    0
+    Au -    0
+   B1u -    1
+   B2u -    1
+   B3u -    1
+                      ------------------
+                      INITIAL GUESS DONE (   0.1 sec)
+                      ------------------
+
+
+ ... the calculation is a CASSCF calculation -I'm leaving here GOOD LUCK!!!
+
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Symmetry handling      UseSym     ... ON
+Point group                       ... D2h
+Used point group                  ... D2h
+Number of irreps                  ... 8
+   Irrep   Ag has   11 SALCs (ofs=   0) #(closed)=   1 #(active)=   1
+   Irrep  B1g has    2 SALCs (ofs=  11) #(closed)=   0 #(active)=   0
+   Irrep  B2g has    2 SALCs (ofs=  13) #(closed)=   0 #(active)=   0
+   Irrep  B3g has    2 SALCs (ofs=  15) #(closed)=   0 #(active)=   0
+   Irrep   Au has    1 SALCs (ofs=  17) #(closed)=   0 #(active)=   0
+   Irrep  B1u has    6 SALCs (ofs=  18) #(closed)=   0 #(active)=   1
+   Irrep  B2u has    6 SALCs (ofs=  24) #(closed)=   0 #(active)=   1
+   Irrep  B3u has    6 SALCs (ofs=  30) #(closed)=   0 #(active)=   1
+ Symmetries of active orbitals:
+   MO =    1  IRREP= 0 (Ag)
+   MO =    2  IRREP= 7 (B3u)
+   MO =    3  IRREP= 6 (B2u)
+   MO =    4  IRREP= 5 (B1u)
+
+Setting up the integral package       ... done
+Building the CAS space                ... done (4 configurations for Mult=1 Irrep=0)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    2
+Number of active orbitals           ...    4
+Total number of electrons           ...    4
+Total number of orbitals            ...   36
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   35 (  31 orbitals)
+Number of rotation parameters      ...     34
+
+CI-STEP:
+CI strategy                         ... General CI
+Number of symmetry/multplity blocks ...    1
+BLOCK  1 WEIGHT=   1.0000
+  Multiplicity                      ...    1
+  Irrep                             ...    0 (Ag)
+  #(Configurations)                 ...    4
+  #(CSFs)                           ...    4
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+  N(GuessMat)                       ...       512
+  MaxDim(CI)                        ...        10
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  1.00e-09
+  Residual Tolerance CI             ...  1.00e-09
+  Shift(CI)                         ...  1.00e-04
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI(PT)
+  Default Parametrization           ... CAYLEY
+  Act-Act rotations                 ... depends on algorithm used
+
+  Note: SuperCI(PT) will ignore level shift, gradscaling, FreezeIE, FreezeAct and FreezeGrad
+
+  MaxRot                            ... 2.00e-01 
+  Max. no of vectors (DIIS)         ... 15
+  DThresh (cut-off) metric          ... 1.00e-06
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... SuperCI(PT)    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  1.00e-12
+  Primitive cutoff TCut             ...  1.00e-14
+  Energy convergence tolerance      ...  1.00e-08
+  Orbital gradient convergence      ...  1.00e-05
+  Max. number of iterations         ...        75  
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Inactive Energy E0 = -13.60390391 Eh
+CI-ITERATION   0: 
+   -14.604424771   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  1 MULT= 1 NROOTS= 1  IRREP=Ag 
+ROOT   0:  E=     -14.6044247712 Eh
+      0.90756 [     0]: 2000
+      0.03081 [     1]: 0200
+      0.03081 [     3]: 0002
+      0.03081 [     2]: 0020
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -14.604424771 Eh DE=     0.000000000
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Energy gap subspaces: Ext-Act = 0.062   Act-Int = 4.462
+   N(occ)=  1.81512 0.06163 0.06163 0.06163
+   ||g|| =      0.512945368 Max(G)=    -0.351846827 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.342427500 Max(X)(6,3) =      0.195627099 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   2: 
+   --- Inactive Energy E0 = -13.61070861 Eh
+CI-ITERATION   0: 
+   -14.615891588   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.615891588 Eh DE=    -0.011466817
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Energy gap subspaces: Ext-Act = 0.032   Act-Int = 4.444
+   N(occ)=  1.80034 0.06655 0.06655 0.06655
+   ||g|| =      0.046434164 Max(G)=    -0.025296620 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.077240157 Max(X)(7,4) =     -0.043853727 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   3: 
+   --- Inactive Energy E0 = -13.61017255 Eh
+CI-ITERATION   0: 
+   -14.616467015   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616467015 Eh DE=    -0.000575427
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.437
+   N(occ)=  1.80346 0.06551 0.06551 0.06551
+   ||g|| =      0.010141554 Max(G)=     0.006282867 Rot=5,1
+   --- Orbital Update [SuperCI(PT)]
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.011058651 Max(X)(6,3) =      0.005760039 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   4: 
+   --- Inactive Energy E0 = -13.61008825 Eh
+CI-ITERATION   0: 
+   -14.616496888   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496888 Eh DE=    -0.000029873
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80382 0.06539 0.06539 0.06539
+   ||g|| =      0.000764647 Max(G)=    -0.000409109 Rot=34,0
+   --- Orbital Update [SuperCI(PT)]
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.001059019 Max(X)(8,2) =     -0.000448218 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   5: 
+   --- Inactive Energy E0 = -13.61009983 Eh
+CI-ITERATION   0: 
+   -14.616497002   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497002 Eh DE=    -0.000000114
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80373 0.06542 0.06542 0.06542
+   ||g|| =      0.000248514 Max(G)=     0.000174817 Rot=34,0
+   --- Orbital Update [SuperCI(PT)]
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.000276300 Max(X)(7,4) =     -0.000144870 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=    -0.000000007
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =      0.000016063 Max(G)=     0.000011575 Rot=14,1
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Forming Natural Orbitals
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=    -0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =      0.000016063 Max(G)=    -0.000011575 Rot=14,1
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -14.616497008 Eh    -397.7351 eV
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV)    Irrep 
+   0   2.0000      -4.711845      -128.2158    1-Ag
+   1   1.8038      -0.277797        -7.5592    2-Ag
+   2   0.0654       0.112653         3.0655    1-B3u
+   3   0.0654       0.112653         3.0655    1-B2u
+   4   0.0654       0.112653         3.0655    1-B1u
+   5   0.0000       0.127743         3.4761    3-Ag
+   6   0.0000       0.150920         4.1067    2-B2u
+   7   0.0000       0.150920         4.1067    2-B1u
+   8   0.0000       0.150920         4.1067    2-B3u
+   9   0.0000       0.274858         7.4793    1-B1g
+  10   0.0000       0.274858         7.4793    1-B3g
+  11   0.0000       0.274858         7.4793    1-B2g
+  12   0.0000       0.274858         7.4793    4-Ag
+  13   0.0000       0.274858         7.4793    5-Ag
+  14   0.0000       0.681115        18.5341    6-Ag
+  15   0.0000       0.767036        20.8721    3-B2u
+  16   0.0000       0.767036        20.8721    3-B3u
+  17   0.0000       0.767036        20.8721    3-B1u
+  18   0.0000       1.118724        30.4420    2-B1g
+  19   0.0000       1.118724        30.4420    2-B3g
+  20   0.0000       1.118724        30.4420    2-B2g
+  21   0.0000       1.118724        30.4420    7-Ag
+  22   0.0000       1.118724        30.4420    8-Ag
+  23   0.0000       1.176080        32.0028    4-B2u
+  24   0.0000       1.176080        32.0028    4-B1u
+  25   0.0000       1.176080        32.0028    4-B3u
+  26   0.0000       1.176080        32.0028    5-B3u
+  27   0.0000       1.176080        32.0028    5-B2u
+  28   0.0000       1.176080        32.0028    5-B1u
+  29   0.0000       1.176080        32.0028    1-Au
+  30   0.0000       3.007595        81.8408    9-Ag
+  31   0.0000      10.933785       297.5234    6-B3u
+  32   0.0000      10.933785       297.5234    6-B2u
+  33   0.0000      10.933785       297.5234    6-B1u
+  34   0.0000      11.951752       325.2237   10-Ag
+  35   0.0000      65.244448      1775.3917   11-Ag
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  1 MULT= 1 IRREP= Ag NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -14.6164970082 Eh
+      0.90188 [     0]: 2000
+      0.03271 [     1]: 0200
+      0.03271 [     2]: 0020
+      0.03271 [     3]: 0002
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                   0          1          2          3    
+      0       1.803752   0.000000   0.000000   0.000000
+      1       0.000000   0.065416   0.000000   0.000000
+      2       0.000000   0.000000   0.065416   0.000000
+      3       0.000000   0.000000   0.000000   0.065416
+Trace of the electron density:  2.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -19.082312356 Eh        -519.2561 eV
+Two electron energy          :      4.465815348 Eh         121.5210 eV
+Nuclear repuslion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -14.616497008
+
+Kinetic energy               :     14.616237926 Eh         397.7281 eV
+Potential energy             :    -29.232734934 Eh        -795.4632 eV
+Virial ratio                 :     -2.000017726 
+                               ----------------
+                                  -14.616497008
+
+Core energy                  :    -13.610095236 Eh     -370.3495 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+
+                      6         7         8         9        10        11   
+                   0.15092   0.15092   0.15092   0.27486   0.27486   0.27486
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be pz              0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py            100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be dxz             0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be dyz             0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be dxy             0.0       0.0       0.0     100.0       0.0       0.0
+
+                     12        13        14        15        16        17   
+                   0.27486   0.27486   0.68111   0.76704   0.76704   0.76704
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s               0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be pz              0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be px              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be dz2             0.1      99.9       0.0       0.0       0.0       0.0
+ 0 Be dx2y2          99.9       0.1       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.11872   1.11872   1.11872   1.11872   1.11872   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be dz2             0.0       0.0       0.0       0.2      99.8       0.0
+ 0 Be dxz             0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be dyz             0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be dx2y2           0.0       0.0       0.0      99.8       0.2       0.0
+ 0 Be dxy           100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be f-1             0.0       0.0       0.0       0.0       0.0      63.5
+ 0 Be f-3             0.0       0.0       0.0       0.0       0.0      36.5
+
+                     24        25        26        27        28        29   
+                   1.17608   1.17608   1.17608   1.17608   1.17608   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be f0              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be f+1             0.0      64.5      35.5       0.0       0.0       0.0
+ 0 Be f-1             0.0       0.0       0.0      36.5       0.0       0.0
+ 0 Be f+2           100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be f-2             0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be f+3             0.0      35.5      64.5       0.0       0.0       0.0
+ 0 Be f-3             0.0       0.0       0.0      63.5       0.0       0.0
+
+                     30        31        32        33        34        35   
+                   3.00760  10.93379  10.93379  10.93379  11.95175  65.24445
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0       0.0       0.0       0.0     100.0     100.0
+ 0 Be pz              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be px              0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be py              0.0       0.0     100.0       0.0       0.0       0.0
+
+
+----------------------------
+LOEWDIN REDUCED ACTIVE MOs  
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... casscf_beryllium_atom_sym.scfp.tmp
+BaseName (.gbw .S,...)              ... casscf_beryllium_atom_sym
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 Be:    0.000000
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 Be:    0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 Be     4.0000     4.0000     0.0000     0.7336     0.0000     0.7336
+
+
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.093188947 (     0.093188947,     -0.000000000,     -0.000000000)
+ MO   3:      0.093188947 (    -0.000000000,      0.093188947,     -0.000000000)
+ MO   4:      0.093188947 (     0.000000000,     -0.000000000,     -0.093188947)
+MO   1:
+ MO   2:      1.461408146 (     1.461408146,     -0.000000000,     -0.000000000)
+ MO   3:      1.461408146 (    -0.000000000,      1.461408146,     -0.000000000)
+ MO   4:      1.461408146 (     0.000000000,      0.000000000,     -1.461408146)
+MO   2:
+MO   3:
+MO   4:
+  newgto Be
+  0 15
+    1      29646.704407000001         0.000038108224
+    2       4428.761435400000         0.000297340321
+    3       1005.470133200000         0.001564016408
+    4        284.153395780000         0.006560712877
+    5         92.504356461000         0.023217340382
+    6         33.311016058000         0.069760422481
+    7         12.911553314000         0.170883257267
+    8          5.266549736100         0.318204229410
+    9         22.995386380000        -0.000026605257
+   10          6.623635417600        -0.000260226477
+   11          2.228959500300         0.379026890551
+   12          0.953024334500         0.186086635305
+   13          0.246516024400         0.006073816978
+   14          0.101538953100        -0.011158857101
+   15          0.041551374600        -0.001939619455
+  0 15
+    1      29646.704407000001         0.000006656465
+    2       4428.761435400000         0.000051937223
+    3       1005.470133200000         0.000273190897
+    4        284.153395780000         0.001145977130
+    5         92.504356461000         0.004055434462
+    6         33.311016058000         0.012185238136
+    7         12.911553314000         0.029848632063
+    8          5.266549736100         0.055581577250
+    9         22.995386380000         0.001088706138
+   10          6.623635417600         0.010648653488
+   11          2.228959500300         0.118828786568
+   12          0.953024334500         0.107283329848
+   13          0.246516024400        -0.284089779427
+   14          0.101538953100        -0.628004193293
+   15          0.041551374600        -0.214441958613
+  1 7
+    1         14.099789445000         0.004692441536
+    2          3.180318848200         0.029430526501
+    3          0.904892205000         0.119327406732
+    4          0.304115855100         0.359106958296
+    5          0.113026066600         0.606477568469
+    6          0.042831733700         0.037784957343
+    7          6.400000000000        -0.004717453605
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.000146 sec
+-------------------------------------------------------------
+
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+-------------------
+ABSORPTION SPECTRUM
+-------------------
+
+Center of mass           = (  0.0000,  0.0000,  0.0000)
+Nuclear contribution to the dipole moment =     0.000000,    0.000000,    0.000000 au
+
+Calculating the dipole integrals          ... done
+
+Ground state mult:    1
+Ground state block:   0
+Ground state root:    0
+
+
+------------------------------------------------------------------------------
+                                 DIPOLE MOMENTS
+------------------------------------------------------------------------------
+  Root  Block           TX        TY        TZ           |T|
+                      (Debye)   (Debye)   (Debye)      (Debye)
+------------------------------------------------------------------------------
+    0    0           -0.00000  -0.00000   0.00000      0.00000
+
+-------
+TIMINGS
+-------
+
+Total time                       ...        0.4 sec
+Sum of individual times          ...        0.2 sec ( 49.9%)
+
+Calculation of AO operators
+   F(Core) operator              ...        0.0 sec (  7.7%)
+   G(Act) operator               ...        0.1 sec ( 17.8%)
+   J(AO) operators               ...        0.1 sec ( 21.9%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.0 sec (  0.0%)
+   (pq|rs) integrals             ...        0.0 sec (  0.1%)
+   AO->MO one electron integrals ...        0.0 sec (  0.4%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  0.1%)
+   CI-solution phase             ...        0.0 sec (  1.3%)
+   Generation of densities       ...        0.0 sec (  0.1%)
+Orbital improvement steps
+   Orbital gradient              ...        0.0 sec (  0.2%)
+   O(1) converger                ...        0.0 sec (  0.1%)
+Properties                       ...        0.0 sec (  0.3%)
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -14.616497008249
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... casscf_beryllium_atom_sym.gbw
+Electron density file                           ... casscf_beryllium_atom_sym.scfp.tmp
+The origin for moment calculation is the CENTER OF MASS  = ( 0.000000,  0.000000  0.000000)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:     -0.00000      -0.00000       0.00000
+Nuclear contribution   :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :     -0.00000      -0.00000       0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+Timings for individual modules:
+
+Sum of individual times         ...        0.813 sec (=   0.014 min)
+GTO integral calculation        ...        0.235 sec (=   0.004 min)  28.9 %
+SCF iterations                  ...        0.105 sec (=   0.002 min)  12.8 %
+CASSCF iterations               ...        0.473 sec (=   0.008 min)  58.2 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 1 seconds 11 msec

--- a/ORCA/ORCA4.1/casscf_beryllium_atom_nosym.in
+++ b/ORCA/ORCA4.1/casscf_beryllium_atom_nosym.in
@@ -1,0 +1,10 @@
+! def2-qzvpp verytightscf noautostart nousesym
+
+%casscf
+ nel 2
+ norb 4
+ end
+
+* xyz 0 1
+Be 0 0 0
+*

--- a/ORCA/ORCA4.1/casscf_beryllium_atom_nosym.out
+++ b/ORCA/ORCA4.1/casscf_beryllium_atom_nosym.out
@@ -1,0 +1,896 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #               Directorship: Frank Neese             #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.1.2  - RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Properties
+   Michael Atanasov       : Ab Initio Ligand Field Theory
+   Alexander A. Auer      : GIAO ZORA
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, Open-shell LED
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM Hessian
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : CASSCF linear response (MC-RPA)
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Lucas Lang             : DCDCAS
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; parallel MDCI
+   Dimitrios Manganas     : ROCIS; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Restricted open shell CIS
+   Masaaki Saitow         : Open-shell DLPNO
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev                                     : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, Multilevel
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-QZVPP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = casscf_beryllium_atom_nosym.in
+|  1> ! def2-qzvpp verytightscf noautostart nousesym
+|  2> 
+|  3> %casscf
+|  4>  nel 2
+|  5>  norb 4
+|  6>  end
+|  7> 
+|  8> * xyz 0 1
+|  9> Be 0 0 0
+| 10> *
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  Be     0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 Be    4.0000    0     9.012    0.000000    0.000000    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type Be  : 15s7p2d1f contracted to 7s4p2d1f pattern {8211111/4111/11/1}
+
+Atom   0Be   basis set group =>   1
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...   25
+ # of primitive gaussian functions       ...   53
+ # of contracted shells                  ...   14
+ # of contracted basis functions         ...   36
+ Highest angular momentum                ...    3
+ Maximum contraction depth               ...    8
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  1.000e-12
+ Primitive cut-off              TCut     ...  1.000e-14
+
+
+------------------------------ INTEGRAL EVALUATION ----------------------------
+
+
+ * One electron integrals 
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.000 sec)
+
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... casscf_beryllium_atom_nosym
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   36
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 6.741e-03
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Total time needed                          ...    0.001 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-12
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   1678 (   0.0 sec)
+# of grid points (after weights+screening)   ...   1678 (   0.0 sec)
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     1678
+Total number of batches                      ...       27
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1678
+Average number of shells per batch           ...    11.54 (82.40%)
+Average number of basis functions per batch  ...    31.75 (88.19%)
+Average number of large shells per batch     ...    11.21 (97.21%)
+Average number of large basis fcns per batch ...    31.43 (98.99%)
+Maximum spatial batch extension              ...  21.83, 39.91, 39.91 au
+Average spatial batch extension              ...  10.55, 12.37, 14.01 au
+
+Time for grid setup =    0.003 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Setting up the integral package                    ... done
+Initializing the effective Hamiltonian             ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.1 sec)
+                      ------------------
+
+
+ ... the calculation is a CASSCF calculation -I'm leaving here GOOD LUCK!!!
+
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Setting up the integral package       ... done
+Building the CAS space                ... done (10 configurations for Mult=1)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    2
+Number of active orbitals           ...    4
+Total number of electrons           ...    4
+Total number of orbitals            ...   36
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   35 (  31 orbitals)
+Number of rotation parameters      ...    159
+
+CI-STEP:
+CI strategy                         ... General CI
+Number of multiplicity blocks       ...    1
+BLOCK  1 WEIGHT=   1.0000
+  Multiplicity                      ...    1
+  #(Configurations)                 ...   10
+  #(CSFs)                           ...   10
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+  N(GuessMat)                       ...       512
+  MaxDim(CI)                        ...        10
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  1.00e-09
+  Residual Tolerance CI             ...  1.00e-09
+  Shift(CI)                         ...  1.00e-04
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI(PT)
+  Default Parametrization           ... CAYLEY
+  Act-Act rotations                 ... depends on algorithm used
+
+  Note: SuperCI(PT) will ignore FreezeIE, FreezeAct and FreezeGrad. In general Default settings are encouraged.
+        In conjunction with ShiftUp, ShiftDn or GradScaling the performance of SuperCI(PT) is less optimal.  
+
+  MaxRot                            ... 2.00e-01 
+  Max. no of vectors (DIIS)         ... 15
+  DThresh (cut-off) metric          ... 1.00e-06
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... SuperCI(PT)    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  1.00e-12
+  Primitive cutoff TCut             ...  1.00e-14
+  Energy convergence tolerance      ...  1.00e-08
+  Orbital gradient convergence      ...  1.00e-05
+  Max. number of iterations         ...        75  
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Inactive Energy E0 = -13.60390391 Eh
+CI-ITERATION   0: 
+   -14.604424771   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  1 MULT= 1 NROOTS= 1 
+ROOT   0:  E=     -14.6044247712 Eh
+      0.90756 [     0]: 2000
+      0.03081 [     9]: 0002
+      0.03081 [     4]: 0200
+      0.03081 [     7]: 0020
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -14.604424771 Eh DE=     0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.065   Act-Int = 4.462
+   N(occ)=  1.81512 0.06163 0.06163 0.06163
+   ||g|| =      0.512945368 Max(G)=     0.348355028 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.342427500 Max(X)(7,4) =      0.181605614 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   2: 
+   --- Inactive Energy E0 = -13.61070861 Eh
+CI-ITERATION   0: 
+   -14.615891588   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.615891588 Eh DE=    -0.011466817
+   --- Energy gap subspaces: Ext-Act = 0.035   Act-Int = 4.444
+   N(occ)=  1.80034 0.06655 0.06655 0.06655
+   ||g|| =      0.046434164 Max(G)=     0.024705010 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.077240157 Max(X)(7,4) =      0.043762639 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   3: 
+   --- Inactive Energy E0 = -13.61017255 Eh
+CI-ITERATION   0: 
+   -14.616467015   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616467015 Eh DE=    -0.000575427
+   --- Energy gap subspaces: Ext-Act = 0.022   Act-Int = 4.437
+   N(occ)=  1.80346 0.06551 0.06551 0.06551
+   ||g|| =      0.010141554 Max(G)=    -0.006481043 Rot=5,1
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.011058651 Max(X)(8,4) =      0.005754296 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   4: 
+   --- Inactive Energy E0 = -13.61008825 Eh
+CI-ITERATION   0: 
+   -14.616496888   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496888 Eh DE=    -0.000029873
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80382 0.06539 0.06539 0.06539
+   ||g|| =      0.000764647 Max(G)=    -0.000412067 Rot=5,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.001059019 Max(X)(6,4) =     -0.000447813 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   5: 
+   --- Inactive Energy E0 = -13.61009983 Eh
+CI-ITERATION   0: 
+   -14.616497002   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497002 Eh DE=    -0.000000114
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80373 0.06542 0.06542 0.06542
+   ||g|| =      0.000248514 Max(G)=    -0.000176206 Rot=34,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.000276300 Max(X)(8,2) =      0.000144845 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=    -0.000000007
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =      0.000016063 Max(G)=     0.000011695 Rot=14,1
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Forming Natural Orbitals
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=    -0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =      0.000016063 Max(G)=     0.000011575 Rot=14,1
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -14.616497008 Eh    -397.7351 eV
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000      -4.711845      -128.2158 
+   1   1.8038      -0.277797        -7.5592 
+   2   0.0654       0.112653         3.0655 
+   3   0.0654       0.112653         3.0655 
+   4   0.0654       0.112653         3.0655 
+   5   0.0000       0.127743         3.4761 
+   6   0.0000       0.150920         4.1067 
+   7   0.0000       0.150920         4.1067 
+   8   0.0000       0.150920         4.1067 
+   9   0.0000       0.274858         7.4793 
+  10   0.0000       0.274858         7.4793 
+  11   0.0000       0.274858         7.4793 
+  12   0.0000       0.274858         7.4793 
+  13   0.0000       0.274858         7.4793 
+  14   0.0000       0.681115        18.5341 
+  15   0.0000       0.767036        20.8721 
+  16   0.0000       0.767036        20.8721 
+  17   0.0000       0.767036        20.8721 
+  18   0.0000       1.118724        30.4420 
+  19   0.0000       1.118724        30.4420 
+  20   0.0000       1.118724        30.4420 
+  21   0.0000       1.118724        30.4420 
+  22   0.0000       1.118724        30.4420 
+  23   0.0000       1.176080        32.0028 
+  24   0.0000       1.176080        32.0028 
+  25   0.0000       1.176080        32.0028 
+  26   0.0000       1.176080        32.0028 
+  27   0.0000       1.176080        32.0028 
+  28   0.0000       1.176080        32.0028 
+  29   0.0000       1.176080        32.0028 
+  30   0.0000       3.007595        81.8408 
+  31   0.0000      10.933785       297.5234 
+  32   0.0000      10.933785       297.5234 
+  33   0.0000      10.933785       297.5234 
+  34   0.0000      11.951752       325.2237 
+  35   0.0000      65.244448      1775.3917 
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  1 MULT= 1 NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -14.6164970082 Eh
+      0.90188 [     0]: 2000
+      0.03271 [     9]: 0002
+      0.03271 [     7]: 0020
+      0.03271 [     4]: 0200
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                   0          1          2          3    
+      0       1.803752   0.000000   0.000000   0.000000
+      1       0.000000   0.065416   0.000000   0.000000
+      2       0.000000   0.000000   0.065416   0.000000
+      3       0.000000   0.000000   0.000000   0.065416
+Trace of the electron density:  2.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -19.082312356 Eh        -519.2561 eV
+Two electron energy          :      4.465815348 Eh         121.5210 eV
+Nuclear repulsion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -14.616497008
+
+Kinetic energy               :     14.616237926 Eh         397.7281 eV
+Potential energy             :    -29.232734934 Eh        -795.4632 eV
+Virial ratio                 :     -2.000017726 
+                               ----------------
+                                  -14.616497008
+
+Core energy                  :    -13.610095236 Eh     -370.3495 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.3       4.8      94.9       0.0
+ 0 Be px              0.0       0.0      99.7       0.0       0.2       0.0
+ 0 Be py              0.0       0.0       0.0      95.2       4.8       0.0
+
+                      6         7         8         9        10        11   
+                   0.15092   0.15092   0.15092   0.27486   0.27486   0.27486
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be pz             97.6       0.2       2.3       0.0       0.0       0.0
+ 0 Be px              2.3       0.0      97.7       0.0       0.0       0.0
+ 0 Be py              0.1      99.8       0.0       0.0       0.0       0.0
+ 0 Be dxz             0.0       0.0       0.0      48.8       5.3      45.9
+ 0 Be dyz             0.0       0.0       0.0      33.5      54.6      11.9
+ 0 Be dxy             0.0       0.0       0.0      17.8      40.1      42.1
+
+                     12        13        14        15        16        17   
+                   0.27486   0.27486   0.68111   0.76704   0.76704   0.76704
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s               0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be pz              0.0       0.0       0.0      74.6      22.8       2.6
+ 0 Be px              0.0       0.0       0.0       7.7       3.3      89.0
+ 0 Be py              0.0       0.0       0.0      17.8      73.9       8.3
+ 0 Be dz2            72.4      27.6       0.0       0.0       0.0       0.0
+ 0 Be dx2y2          27.6      72.4       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.11872   1.11872   1.11872   1.11872   1.11872   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be dz2             0.0       0.0       0.0      71.3      28.7       0.0
+ 0 Be dxz            41.9      49.7       8.4       0.0       0.0       0.0
+ 0 Be dyz            57.9      33.1       9.0       0.0       0.0       0.0
+ 0 Be dx2y2           0.0       0.0       0.0      28.7      71.3       0.0
+ 0 Be dxy             0.2      17.2      82.6       0.0       0.0       0.0
+ 0 Be f+1             0.0       0.0       0.0       0.0       0.0       1.2
+ 0 Be f-1             0.0       0.0       0.0       0.0       0.0       0.1
+ 0 Be f+2             0.0       0.0       0.0       0.0       0.0       0.1
+ 0 Be f-2             0.0       0.0       0.0       0.0       0.0      98.0
+ 0 Be f+3             0.0       0.0       0.0       0.0       0.0       0.5
+
+                     24        25        26        27        28        29   
+                   1.17608   1.17608   1.17608   1.17608   1.17608   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be f0              0.0       1.1       0.0       6.9      51.5      40.5
+ 0 Be f+1             0.1      55.4      11.5      31.3       0.4       0.2
+ 0 Be f-1            20.1       9.8      36.7       0.6      11.3      21.5
+ 0 Be f+2            68.2       6.7      24.7       0.0       0.2       0.0
+ 0 Be f-2             0.0       2.0       0.0       0.0       0.0       0.0
+ 0 Be f+3             0.1      23.7       6.1      60.1       9.2       0.3
+ 0 Be f-3            11.5       1.4      20.9       1.1      27.4      37.5
+
+                     30        31        32        33        34        35   
+                   3.00760  10.93379  10.93379  10.93379  11.95175  65.24445
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0       0.0       0.0       0.0     100.0     100.0
+ 0 Be pz              0.0      99.7       0.0       0.2       0.0       0.0
+ 0 Be px              0.0       0.2      23.9      75.9       0.0       0.0
+ 0 Be py              0.0       0.0      76.1      23.9       0.0       0.0
+
+
+----------------------------
+LOEWDIN REDUCED ACTIVE MOs  
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.3       4.8      94.9       0.0
+ 0 Be px              0.0       0.0      99.7       0.0       0.2       0.0
+ 0 Be py              0.0       0.0       0.0      95.2       4.8       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... casscf_beryllium_atom_nosym.scfp.tmp
+BaseName (.gbw .S,...)              ... casscf_beryllium_atom_nosym
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 Be:    0.000000
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 Be:    0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 Be     4.0000     4.0000     0.0000     0.7336     0.0000     0.7336
+
+
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.093188947 (     0.093071013,      0.000032207,     -0.004686712)
+ MO   3:      0.093188947 (     0.000997301,      0.090916525,      0.020429651)
+ MO   4:      0.093188947 (    -0.004579486,      0.020453954,     -0.090801123)
+MO   1:
+ MO   2:      1.461408146 (    -1.459558687,     -0.000505071,      0.073497971)
+ MO   3:      1.461408146 (    -0.015639871,     -1.425771563,     -0.320381978)
+ MO   4:      1.461408146 (     0.071816442,     -0.320763093,      1.423961799)
+MO   2:
+MO   3:
+MO   4:
+  newgto Be
+  0 15
+    1      29646.704407000001         0.000038108224
+    2       4428.761435400000         0.000297340321
+    3       1005.470133200000         0.001564016408
+    4        284.153395780000         0.006560712877
+    5         92.504356461000         0.023217340382
+    6         33.311016058000         0.069760422481
+    7         12.911553314000         0.170883257267
+    8          5.266549736100         0.318204229410
+    9         22.995386380000        -0.000026605257
+   10          6.623635417600        -0.000260226477
+   11          2.228959500300         0.379026890551
+   12          0.953024334500         0.186086635305
+   13          0.246516024400         0.006073816978
+   14          0.101538953100        -0.011158857101
+   15          0.041551374600        -0.001939619455
+  0 15
+    1      29646.704407000001         0.000006656465
+    2       4428.761435400000         0.000051937223
+    3       1005.470133200000         0.000273190897
+    4        284.153395780000         0.001145977130
+    5         92.504356461000         0.004055434462
+    6         33.311016058000         0.012185238136
+    7         12.911553314000         0.029848632063
+    8          5.266549736100         0.055581577250
+    9         22.995386380000         0.001088706138
+   10          6.623635417600         0.010648653488
+   11          2.228959500300         0.118828786568
+   12          0.953024334500         0.107283329848
+   13          0.246516024400        -0.284089779426
+   14          0.101538953100        -0.628004193294
+   15          0.041551374600        -0.214441958613
+  1 7
+    1         14.099789445000         0.004692441536
+    2          3.180318848200         0.029430526501
+    3          0.904892205000         0.119327406732
+    4          0.304115855100         0.359106958297
+    5          0.113026066600         0.606477568468
+    6          0.042831733700         0.037784957345
+    7          6.400000000000        -0.004717453605
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.000147 sec
+-------------------------------------------------------------
+
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+-------------------
+ABSORPTION SPECTRUM
+-------------------
+
+Center of mass           = (  0.0000,  0.0000,  0.0000)
+Nuclear contribution to the dipole moment =     0.000000,    0.000000,    0.000000 au
+
+Calculating the dipole integrals                  ... done
+Transforming integrals                            ... done
+Calculating the Linear Momentum integrals         ... done
+Transforming integrals                            ... done
+Calculating the Angular Momentum integrals        ... done
+Transforming integrals                            ... done
+
+Ground state mult:    1
+Ground state block:   0
+Ground state root:    0
+
+
+------------------------------------------------------------------------------
+                                 DIPOLE MOMENTS
+------------------------------------------------------------------------------
+  Root  Block           TX        TY        TZ           |T|
+                      (Debye)   (Debye)   (Debye)      (Debye)
+------------------------------------------------------------------------------
+    0    0            0.00000  -0.00000  -0.00000      0.00000
+
+--------------
+CASSCF TIMINGS
+--------------
+
+Total time                       ...        0.5 sec
+Sum of individual times          ...        0.3 sec ( 61.8%)
+
+Calculation of AO operators
+   F(Core) operator              ...        0.0 sec (  6.0%)
+   G(Act) operator               ...        0.1 sec ( 13.4%)
+   J(AO) operators               ...        0.0 sec (  0.0%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.2 sec ( 39.7%)
+   (pq|rs) integrals             ...        0.0 sec (  0.0%)
+   AO->MO one electron integrals ...        0.0 sec (  0.1%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  0.0%)
+   CI-solution phase             ...        0.0 sec (  1.0%)
+   Generation of densities       ...        0.0 sec (  0.0%)
+Orbital improvement steps
+   Orbital gradient              ...        0.0 sec (  0.1%)
+   O(1) converger                ...        0.0 sec (  1.0%)
+Properties                       ...        0.0 sec (  0.4%)
+   SOC integral calculation      ...        0.0 sec (  0.0%)
+   SSC RMEs (incl. integrals)    ...        0.0 sec (  0.0%)
+   SOC RMEs                      ...        0.0 sec (  0.0%)
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -14.616497008249
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... casscf_beryllium_atom_nosym.gbw
+Electron density file                           ... casscf_beryllium_atom_nosym.scfp.tmp
+The origin for moment calculation is the CENTER OF MASS  = ( 0.000000,  0.000000  0.000000)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:      0.00000      -0.00000      -0.00000
+Nuclear contribution   :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :      0.00000      -0.00000      -0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:     0.000000     0.000000     0.000000 
+Rotational constants in MHz :     0.000000     0.000000     0.000000 
+
+ Dipole components along the rotational axes: 
+x,y,z [a.u.] :     0.000000    -0.000000    -0.000000 
+x,y,z [Debye]:     0.000000    -0.000000    -0.000000 
+
+ 
+
+Timings for individual modules:
+
+Sum of individual times         ...        0.980 sec (=   0.016 min)
+GTO integral calculation        ...        0.251 sec (=   0.004 min)  25.6 %
+SCF iterations                  ...        0.121 sec (=   0.002 min)  12.3 %
+CASSCF iterations               ...        0.609 sec (=   0.010 min)  62.1 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 1 seconds 120 msec

--- a/ORCA/ORCA4.1/casscf_beryllium_atom_sym.in
+++ b/ORCA/ORCA4.1/casscf_beryllium_atom_sym.in
@@ -1,0 +1,10 @@
+! def2-qzvpp verytightscf noautostart usesym
+
+%casscf
+ nel 2
+ norb 4
+ end
+
+* xyz 0 1
+Be 0 0 0
+*

--- a/ORCA/ORCA4.1/casscf_beryllium_atom_sym.out
+++ b/ORCA/ORCA4.1/casscf_beryllium_atom_sym.out
@@ -1,0 +1,999 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #               Directorship: Frank Neese             #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.1.2  - RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Properties
+   Michael Atanasov       : Ab Initio Ligand Field Theory
+   Alexander A. Auer      : GIAO ZORA
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, Open-shell LED
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM Hessian
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : CASSCF linear response (MC-RPA)
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Lucas Lang             : DCDCAS
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; parallel MDCI
+   Dimitrios Manganas     : ROCIS; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Restricted open shell CIS
+   Masaaki Saitow         : Open-shell DLPNO
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev                                     : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, Multilevel
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-QZVPP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = casscf_beryllium_atom_sym.in
+|  1> ! def2-qzvpp verytightscf noautostart usesym
+|  2> 
+|  3> %casscf
+|  4>  nel 2
+|  5>  norb 4
+|  6>  end
+|  7> 
+|  8> * xyz 0 1
+|  9> Be 0 0 0
+| 10> *
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+
+------------------------------------------------------------------------------
+                            SYMMETRY HANDLING SETUP
+------------------------------------------------------------------------------
+
+------------------
+SYMMETRY DETECTION
+------------------
+Preparing Data                    ... done
+Detection Threshold:    SymThresh ... 1.0000e-04
+
+Point Group will now be determined:
+Moving molecule to center of mass ... done
+
+POINT GROUP                       ... Kh
+
+The coordinates will now be cleaned:
+Structure cleanup requested       ... yes
+Selected point group              ... Kh
+Cleaning Tolerance      SymThresh ... 1.0000e-04
+
+Cleaning coordinates              ... done
+
+-----------------------------------------------
+SYMMETRY-PERFECTED CARTESIAN COORDINATES (A.U.)
+-----------------------------------------------
+Warning (ORCA_SYM): Coordinates were not cleaned so far!
+
+------------------
+SYMMETRY REDUCTION
+------------------
+ORCA supports only abelian point groups.
+It is now checked, if the determined point group is supported:
+Point Group ( Kh    ) is          ... NOT supported
+Reducing to abelian subgroup      ... D2h
+
+(Re)building abelian point group:
+Creating Character Table          ... done
+Making direct product table       ... done
+Constructing symmetry operations  ... done
+Creating atom transfer table      ... done
+Creating asymmetric unit          ... done
+
+----------------------
+ASYMMETRIC UNIT IN D2h
+----------------------
+  #  AT     MASS              COORDS (A.U.)             BAS
+   0 Be   9.0120   0.00000000   0.00000000   0.00000000   0
+
+----------------------
+SYMMETRY ADAPTED BASIS
+----------------------
+The coefficients for the symmetry adapted linear combinations (SALCS)
+of basis functions will now be computed:
+Number of basis functions         ...    36
+Preparing memory                  ... done
+Constructing Gamma(red)           ... done
+Reducing Gamma(red)               ... done
+Constructing SALCs                ... done
+Checking SALC integrity           ... nothing suspicious
+Normalizing SALCs                 ... done
+
+Storing the symmetry object:
+Symmetry file                     ... casscf_beryllium_atom_sym.sym.tmp
+Writing symmetry information      ... done
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  Be     0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 Be    4.0000    0     9.012    0.000000    0.000000    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type Be  : 15s7p2d1f contracted to 7s4p2d1f pattern {8211111/4111/11/1}
+
+Atom   0Be   basis set group =>   1
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...   25
+ # of primitive gaussian functions       ...   53
+ # of contracted shells                  ...   14
+ # of contracted basis functions         ...   36
+ Highest angular momentum                ...    3
+ Maximum contraction depth               ...    8
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  1.000e-12
+ Primitive cut-off              TCut     ...  1.000e-14
+
+
+------------------------------ INTEGRAL EVALUATION ----------------------------
+
+
+ * One electron integrals 
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.000 sec)
+
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... casscf_beryllium_atom_sym
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   36
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+ Symmetry handling      UseSym         .... ON
+ Point group                           .... D2h
+ Used point group                      .... D2h
+ Number of irreps                      .... 8
+   Irrep   Ag has   11 symmetry adapted basis functions (ofs=   0)
+   Irrep  B1g has    2 symmetry adapted basis functions (ofs=  11)
+   Irrep  B2g has    2 symmetry adapted basis functions (ofs=  13)
+   Irrep  B3g has    2 symmetry adapted basis functions (ofs=  15)
+   Irrep   Au has    1 symmetry adapted basis functions (ofs=  17)
+   Irrep  B1u has    6 symmetry adapted basis functions (ofs=  18)
+   Irrep  B2u has    6 symmetry adapted basis functions (ofs=  24)
+   Irrep  B3u has    6 symmetry adapted basis functions (ofs=  30)
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 6.741e-03
+Time for diagonalization                   ...    0.035 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Producing symmetrization matrix            ... done (   0.000 sec)
+Total time needed                          ...    0.036 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-12
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   1678 (   0.0 sec)
+# of grid points (after weights+screening)   ...   1678 (   0.0 sec)
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     1678
+Total number of batches                      ...       27
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1678
+Average number of shells per batch           ...    11.54 (82.40%)
+Average number of basis functions per batch  ...    31.75 (88.19%)
+Average number of large shells per batch     ...    11.21 (97.21%)
+Average number of large basis fcns per batch ...    31.43 (98.99%)
+Maximum spatial batch extension              ...  21.83, 39.91, 39.91 au
+Average spatial batch extension              ...  10.55, 12.37, 14.01 au
+
+Time for grid setup =    0.025 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Setting up the integral package                    ... done
+Initializing the effective Hamiltonian             ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+The symmetry of the initial guess is 1-Ag
+Irrep occupations for operator 0
+    Ag -    2
+   B1g -    0
+   B2g -    0
+   B3g -    0
+    Au -    0
+   B1u -    1
+   B2u -    1
+   B3u -    1
+                      ------------------
+                      INITIAL GUESS DONE (   0.1 sec)
+                      ------------------
+
+
+ ... the calculation is a CASSCF calculation -I'm leaving here GOOD LUCK!!!
+
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Symmetry handling      UseSym     ... ON
+Point group                       ... D2h
+Used point group                  ... D2h
+Number of irreps                  ... 8
+   Irrep   Ag has   11 SALCs (ofs=   0) #(closed)=   1 #(active)=   1
+   Irrep  B1g has    2 SALCs (ofs=  11) #(closed)=   0 #(active)=   0
+   Irrep  B2g has    2 SALCs (ofs=  13) #(closed)=   0 #(active)=   0
+   Irrep  B3g has    2 SALCs (ofs=  15) #(closed)=   0 #(active)=   0
+   Irrep   Au has    1 SALCs (ofs=  17) #(closed)=   0 #(active)=   0
+   Irrep  B1u has    6 SALCs (ofs=  18) #(closed)=   0 #(active)=   1
+   Irrep  B2u has    6 SALCs (ofs=  24) #(closed)=   0 #(active)=   1
+   Irrep  B3u has    6 SALCs (ofs=  30) #(closed)=   0 #(active)=   1
+ Symmetries of active orbitals:
+   MO =    1  IRREP= 0 (Ag)
+   MO =    2  IRREP= 7 (B3u)
+   MO =    3  IRREP= 6 (B2u)
+   MO =    4  IRREP= 5 (B1u)
+
+Setting up the integral package       ... done
+Building the CAS space                ... done (4 configurations for Mult=1 Irrep=0)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    2
+Number of active orbitals           ...    4
+Total number of electrons           ...    4
+Total number of orbitals            ...   36
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   35 (  31 orbitals)
+Number of rotation parameters      ...     34
+
+CI-STEP:
+CI strategy                         ... General CI
+Number of symmetry/multplity blocks ...    1
+BLOCK  1 WEIGHT=   1.0000
+  Multiplicity                      ...    1
+  Irrep                             ...    0 (Ag)
+  #(Configurations)                 ...    4
+  #(CSFs)                           ...    4
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+  N(GuessMat)                       ...       512
+  MaxDim(CI)                        ...        10
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  1.00e-09
+  Residual Tolerance CI             ...  1.00e-09
+  Shift(CI)                         ...  1.00e-04
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI(PT)
+  Default Parametrization           ... CAYLEY
+  Act-Act rotations                 ... depends on algorithm used
+
+  Note: SuperCI(PT) will ignore FreezeIE, FreezeAct and FreezeGrad. In general Default settings are encouraged.
+        In conjunction with ShiftUp, ShiftDn or GradScaling the performance of SuperCI(PT) is less optimal.  
+
+  MaxRot                            ... 2.00e-01 
+  Max. no of vectors (DIIS)         ... 15
+  DThresh (cut-off) metric          ... 1.00e-06
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... SuperCI(PT)    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  1.00e-12
+  Primitive cutoff TCut             ...  1.00e-14
+  Energy convergence tolerance      ...  1.00e-08
+  Orbital gradient convergence      ...  1.00e-05
+  Max. number of iterations         ...        75  
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Inactive Energy E0 = -13.60390391 Eh
+CI-ITERATION   0: 
+   -14.604424771   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  1 MULT= 1 NROOTS= 1  IRREP=Ag 
+ROOT   0:  E=     -14.6044247712 Eh
+      0.90756 [     0]: 2000
+      0.03081 [     1]: 0200
+      0.03081 [     3]: 0002
+      0.03081 [     2]: 0020
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -14.604424771 Eh DE=     0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.065   Act-Int = 4.462
+   N(occ)=  1.81512 0.06163 0.06163 0.06163
+   ||g|| =      0.512945368 Max(G)=     0.348355028 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.342427500 Max(X)(6,3) =      0.195627099 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   2: 
+   --- Inactive Energy E0 = -13.61070861 Eh
+CI-ITERATION   0: 
+   -14.615891588   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.615891588 Eh DE=    -0.011466817
+   --- Energy gap subspaces: Ext-Act = 0.035   Act-Int = 4.444
+   N(occ)=  1.80034 0.06655 0.06655 0.06655
+   ||g|| =      0.046434164 Max(G)=     0.024705010 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.077240157 Max(X)(8,2) =     -0.043853727 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   3: 
+   --- Inactive Energy E0 = -13.61017255 Eh
+CI-ITERATION   0: 
+   -14.616467015   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616467015 Eh DE=    -0.000575427
+   --- Energy gap subspaces: Ext-Act = 0.022   Act-Int = 4.437
+   N(occ)=  1.80346 0.06551 0.06551 0.06551
+   ||g|| =      0.010141554 Max(G)=     0.006481043 Rot=5,1
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.011058651 Max(X)(7,4) =     -0.005760039 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   4: 
+   --- Inactive Energy E0 = -13.61008825 Eh
+CI-ITERATION   0: 
+   -14.616496888   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496888 Eh DE=    -0.000029873
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80382 0.06539 0.06539 0.06539
+   ||g|| =      0.000764647 Max(G)=     0.000412067 Rot=5,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.001059019 Max(X)(6,3) =      0.000448218 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   5: 
+   --- Inactive Energy E0 = -13.61009983 Eh
+CI-ITERATION   0: 
+   -14.616497002   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497002 Eh DE=    -0.000000114
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80373 0.06542 0.06542 0.06542
+   ||g|| =      0.000248514 Max(G)=     0.000176206 Rot=34,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.000276300 Max(X)(6,3) =     -0.000144870 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=    -0.000000007
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =      0.000016063 Max(G)=     0.000011695 Rot=14,1
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Forming Natural Orbitals
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=    -0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =      0.000016063 Max(G)=    -0.000011575 Rot=14,1
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -14.616497008 Eh    -397.7351 eV
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV)    Irrep 
+   0   2.0000      -4.711845      -128.2158    1-Ag
+   1   1.8038      -0.277797        -7.5592    2-Ag
+   2   0.0654       0.112653         3.0655    1-B3u
+   3   0.0654       0.112653         3.0655    1-B2u
+   4   0.0654       0.112653         3.0655    1-B1u
+   5   0.0000       0.127743         3.4761    3-Ag
+   6   0.0000       0.150920         4.1067    2-B2u
+   7   0.0000       0.150920         4.1067    2-B1u
+   8   0.0000       0.150920         4.1067    2-B3u
+   9   0.0000       0.274858         7.4793    1-B3g
+  10   0.0000       0.274858         7.4793    1-B2g
+  11   0.0000       0.274858         7.4793    1-B1g
+  12   0.0000       0.274858         7.4793    4-Ag
+  13   0.0000       0.274858         7.4793    5-Ag
+  14   0.0000       0.681115        18.5341    6-Ag
+  15   0.0000       0.767036        20.8721    3-B2u
+  16   0.0000       0.767036        20.8721    3-B1u
+  17   0.0000       0.767036        20.8721    3-B3u
+  18   0.0000       1.118724        30.4420    2-B2g
+  19   0.0000       1.118724        30.4420    2-B3g
+  20   0.0000       1.118724        30.4420    2-B1g
+  21   0.0000       1.118724        30.4420    7-Ag
+  22   0.0000       1.118724        30.4420    8-Ag
+  23   0.0000       1.176080        32.0028    4-B1u
+  24   0.0000       1.176080        32.0028    4-B2u
+  25   0.0000       1.176080        32.0028    4-B3u
+  26   0.0000       1.176080        32.0028    5-B3u
+  27   0.0000       1.176080        32.0028    5-B2u
+  28   0.0000       1.176080        32.0028    5-B1u
+  29   0.0000       1.176080        32.0028    1-Au
+  30   0.0000       3.007595        81.8408    9-Ag
+  31   0.0000      10.933785       297.5234    6-B2u
+  32   0.0000      10.933785       297.5234    6-B3u
+  33   0.0000      10.933785       297.5234    6-B1u
+  34   0.0000      11.951752       325.2237   10-Ag
+  35   0.0000      65.244448      1775.3917   11-Ag
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  1 MULT= 1 IRREP= Ag NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -14.6164970082 Eh
+      0.90188 [     0]: 2000
+      0.03271 [     1]: 0200
+      0.03271 [     2]: 0020
+      0.03271 [     3]: 0002
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                   0          1          2          3    
+      0       1.803752   0.000000   0.000000   0.000000
+      1       0.000000   0.065416   0.000000   0.000000
+      2       0.000000   0.000000   0.065416   0.000000
+      3       0.000000   0.000000   0.000000   0.065416
+Trace of the electron density:  2.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -19.082312356 Eh        -519.2561 eV
+Two electron energy          :      4.465815348 Eh         121.5210 eV
+Nuclear repulsion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -14.616497008
+
+Kinetic energy               :     14.616237926 Eh         397.7281 eV
+Potential energy             :    -29.232734934 Eh        -795.4632 eV
+Virial ratio                 :     -2.000017726 
+                               ----------------
+                                  -14.616497008
+
+Core energy                  :    -13.610095236 Eh     -370.3495 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+
+                      6         7         8         9        10        11   
+                   0.15092   0.15092   0.15092   0.27486   0.27486   0.27486
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be pz              0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py            100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be dxz             0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be dyz             0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be dxy             0.0       0.0       0.0       0.0       0.0     100.0
+
+                     12        13        14        15        16        17   
+                   0.27486   0.27486   0.68111   0.76704   0.76704   0.76704
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s               0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be pz              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be px              0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be dz2             2.3      97.7       0.0       0.0       0.0       0.0
+ 0 Be dx2y2          97.7       2.3       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.11872   1.11872   1.11872   1.11872   1.11872   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be dz2             0.0       0.0       0.0      99.5       0.5       0.0
+ 0 Be dxz           100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be dyz             0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be dx2y2           0.0       0.0       0.0       0.5      99.5       0.0
+ 0 Be dxy             0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be f+2             0.0       0.0       0.0       0.0       0.0     100.0
+
+                     24        25        26        27        28        29   
+                   1.17608   1.17608   1.17608   1.17608   1.17608   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be f0              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be f+1             0.0      65.3      34.7       0.0       0.0       0.0
+ 0 Be f-1            63.2       0.0       0.0      36.8       0.0       0.0
+ 0 Be f-2             0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be f+3             0.0      34.7      65.3       0.0       0.0       0.0
+ 0 Be f-3            36.8       0.0       0.0      63.2       0.0       0.0
+
+                     30        31        32        33        34        35   
+                   3.00760  10.93379  10.93379  10.93379  11.95175  65.24445
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0       0.0       0.0       0.0     100.0     100.0
+ 0 Be pz              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py              0.0     100.0       0.0       0.0       0.0       0.0
+
+
+----------------------------
+LOEWDIN REDUCED ACTIVE MOs  
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... casscf_beryllium_atom_sym.scfp.tmp
+BaseName (.gbw .S,...)              ... casscf_beryllium_atom_sym
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 Be:    0.000000
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 Be:    0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 Be     4.0000     4.0000     0.0000     0.7336     0.0000     0.7336
+
+
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.093188947 (    -0.093188947,      0.000000000,      0.000000000)
+ MO   3:      0.093188947 (    -0.000000000,      0.093188947,     -0.000000000)
+ MO   4:      0.093188947 (     0.000000000,     -0.000000000,      0.093188947)
+MO   1:
+ MO   2:      1.461408146 (     1.461408146,     -0.000000000,     -0.000000000)
+ MO   3:      1.461408146 (     0.000000000,     -1.461408146,      0.000000000)
+ MO   4:      1.461408146 (    -0.000000000,      0.000000000,     -1.461408146)
+MO   2:
+MO   3:
+MO   4:
+  newgto Be
+  0 15
+    1      29646.704407000001         0.000038108224
+    2       4428.761435400000         0.000297340321
+    3       1005.470133200000         0.001564016408
+    4        284.153395780000         0.006560712877
+    5         92.504356461000         0.023217340382
+    6         33.311016058000         0.069760422481
+    7         12.911553314000         0.170883257267
+    8          5.266549736100         0.318204229410
+    9         22.995386380000        -0.000026605257
+   10          6.623635417600        -0.000260226477
+   11          2.228959500300         0.379026890551
+   12          0.953024334500         0.186086635305
+   13          0.246516024400         0.006073816978
+   14          0.101538953100        -0.011158857101
+   15          0.041551374600        -0.001939619455
+  0 15
+    1      29646.704407000001         0.000006656465
+    2       4428.761435400000         0.000051937223
+    3       1005.470133200000         0.000273190897
+    4        284.153395780000         0.001145977130
+    5         92.504356461000         0.004055434462
+    6         33.311016058000         0.012185238136
+    7         12.911553314000         0.029848632063
+    8          5.266549736100         0.055581577250
+    9         22.995386380000         0.001088706138
+   10          6.623635417600         0.010648653488
+   11          2.228959500300         0.118828786568
+   12          0.953024334500         0.107283329848
+   13          0.246516024400        -0.284089779426
+   14          0.101538953100        -0.628004193294
+   15          0.041551374600        -0.214441958613
+  1 7
+    1         14.099789445000         0.004692441536
+    2          3.180318848200         0.029430526501
+    3          0.904892205000         0.119327406732
+    4          0.304115855100         0.359106958297
+    5          0.113026066600         0.606477568468
+    6          0.042831733700         0.037784957345
+    7          6.400000000000        -0.004717453605
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.000672 sec
+-------------------------------------------------------------
+
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+-------------------
+ABSORPTION SPECTRUM
+-------------------
+
+Center of mass           = (  0.0000,  0.0000,  0.0000)
+Nuclear contribution to the dipole moment =     0.000000,    0.000000,    0.000000 au
+
+Calculating the dipole integrals                  ... done
+Transforming integrals                            ... done
+Calculating the Linear Momentum integrals         ... done
+Transforming integrals                            ... done
+Calculating the Angular Momentum integrals        ... done
+Transforming integrals                            ... done
+
+Ground state mult:    1
+Ground state block:   0
+Ground state root:    0
+
+
+------------------------------------------------------------------------------
+                                 DIPOLE MOMENTS
+------------------------------------------------------------------------------
+  Root  Block           TX        TY        TZ           |T|
+                      (Debye)   (Debye)   (Debye)      (Debye)
+------------------------------------------------------------------------------
+    0    0           -0.00000  -0.00000  -0.00000      0.00000
+
+--------------
+CASSCF TIMINGS
+--------------
+
+Total time                       ...        0.6 sec
+Sum of individual times          ...        0.3 sec ( 56.1%)
+
+Calculation of AO operators
+   F(Core) operator              ...        0.0 sec (  5.0%)
+   G(Act) operator               ...        0.1 sec ( 11.3%)
+   J(AO) operators               ...        0.0 sec (  0.0%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.2 sec ( 33.3%)
+   (pq|rs) integrals             ...        0.0 sec (  0.0%)
+   AO->MO one electron integrals ...        0.0 sec (  1.8%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  0.1%)
+   CI-solution phase             ...        0.0 sec (  3.8%)
+   Generation of densities       ...        0.0 sec (  0.2%)
+Orbital improvement steps
+   Orbital gradient              ...        0.0 sec (  0.1%)
+   O(1) converger                ...        0.0 sec (  0.1%)
+Properties                       ...        0.0 sec (  0.4%)
+   SOC integral calculation      ...        0.0 sec (  0.0%)
+   SSC RMEs (incl. integrals)    ...        0.0 sec (  0.0%)
+   SOC RMEs                      ...        0.0 sec (  0.0%)
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -14.616497008249
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... casscf_beryllium_atom_sym.gbw
+Electron density file                           ... casscf_beryllium_atom_sym.scfp.tmp
+The origin for moment calculation is the CENTER OF MASS  = ( 0.000000,  0.000000  0.000000)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:     -0.00000      -0.00000      -0.00000
+Nuclear contribution   :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :     -0.00000      -0.00000      -0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:     0.000000     0.000000     0.000000 
+Rotational constants in MHz :     0.000000     0.000000     0.000000 
+
+ Dipole components along the rotational axes: 
+x,y,z [a.u.] :    -0.000000    -0.000000    -0.000000 
+x,y,z [Debye]:    -0.000000    -0.000000    -0.000000 
+
+ 
+
+Timings for individual modules:
+
+Sum of individual times         ...        1.791 sec (=   0.030 min)
+GTO integral calculation        ...        0.279 sec (=   0.005 min)  15.6 %
+SCF iterations                  ...        0.278 sec (=   0.005 min)  15.5 %
+CASSCF iterations               ...        1.233 sec (=   0.021 min)  68.9 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 2 seconds 201 msec

--- a/ORCA/ORCA4.2/casscf_beryllium_atom_nosym.in
+++ b/ORCA/ORCA4.2/casscf_beryllium_atom_nosym.in
@@ -1,0 +1,10 @@
+! def2-qzvpp verytightscf noautostart nousesym
+
+%casscf
+ nel 2
+ norb 4
+ end
+
+* xyz 0 1
+Be 0 0 0
+*

--- a/ORCA/ORCA4.2/casscf_beryllium_atom_nosym.out
+++ b/ORCA/ORCA4.2/casscf_beryllium_atom_nosym.out
@@ -1,0 +1,901 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #               Directorship: Frank Neese             #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.2.1 -  RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM Hessian, Gaussian charge scheme
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : CASSCF linear response (MC-RPA)
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Lucas Lang             : DCDCAS
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, Multilevel, MM, QM/MM, CI optimization
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 4.2.3
+ For citations please refer to: https://tddft.org/programs/libxc/
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-QZVPP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = casscf_beryllium_atom_nosym.in
+|  1> ! def2-qzvpp verytightscf noautostart nousesym
+|  2> 
+|  3> %casscf
+|  4>  nel 2
+|  5>  norb 4
+|  6>  end
+|  7> 
+|  8> * xyz 0 1
+|  9> Be 0 0 0
+| 10> *
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  Be     0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 Be    4.0000    0     9.012    0.000000    0.000000    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type Be  : 15s7p2d1f contracted to 7s4p2d1f pattern {8211111/4111/11/1}
+
+Atom   0Be   basis set group =>   1
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...   25
+ # of primitive gaussian functions       ...   53
+ # of contracted shells                  ...   14
+ # of contracted basis functions         ...   36
+ Highest angular momentum                ...    3
+ Maximum contraction depth               ...    8
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  1.000e-12
+ Primitive cut-off              TCut     ...  1.000e-14
+
+
+------------------------------ INTEGRAL EVALUATION ----------------------------
+
+
+ * One electron integrals 
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.000 sec)
+
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... casscf_beryllium_atom_nosym
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   36
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 6.741e-03
+Time for diagonalization                   ...    0.065 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.005 sec
+Total time needed                          ...    0.070 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-12
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   1678 (   0.0 sec)
+# of grid points (after weights+screening)   ...   1678 (   0.0 sec)
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     1678
+Total number of batches                      ...       27
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1678
+Average number of shells per batch           ...    11.54 (82.40%)
+Average number of basis functions per batch  ...    31.75 (88.19%)
+Average number of large shells per batch     ...    11.21 (97.21%)
+Average number of large basis fcns per batch ...    31.43 (98.99%)
+Maximum spatial batch extension              ...  21.83, 39.91, 39.91 au
+Average spatial batch extension              ...  10.55, 12.37, 14.01 au
+
+Time for grid setup =    0.020 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Setting up the integral package                    ... done
+Initializing the effective Hamiltonian             ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.1 sec)
+                      ------------------
+
+
+ ... the calculation is a CASSCF calculation -I'm leaving here GOOD LUCK!!!
+
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Setting up the integral package       ... done
+Building the CAS space                ... done (10 configurations for Mult=1)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    2
+Number of active orbitals           ...    4
+Total number of electrons           ...    4
+Total number of orbitals            ...   36
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   35 (  31 orbitals)
+Number of rotation parameters      ...    159
+
+CI-STEP:
+CI strategy                         ... General CI
+Number of multiplicity blocks       ...    1
+BLOCK  1 WEIGHT=   1.0000
+  Multiplicity                      ...    1
+  #(Configurations)                 ...   10
+  #(CSFs)                           ...   10
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+  N(GuessMat)                       ...       512
+  MaxDim(CI)                        ...        10
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  1.00e-09
+  Residual Tolerance CI             ...  1.00e-09
+  Shift(CI)                         ...  1.00e-04
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI(PT)
+  Default Parametrization           ... CAYLEY
+  Act-Act rotations                 ... depends on algorithm used
+
+  Note: SuperCI(PT) will ignore FreezeIE, FreezeAct and FreezeGrad. In general Default settings are encouraged.
+        In conjunction with ShiftUp, ShiftDn or GradScaling the performance of SuperCI(PT) is less optimal.  
+
+  MaxRot                            ... 2.00e-01 
+  Max. no of vectors (DIIS)         ... 15
+  DThresh (cut-off) metric          ... 1.00e-06
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... SuperCI(PT)    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  1.00e-12
+  Primitive cutoff TCut             ...  1.00e-14
+  Energy convergence tolerance      ...  1.00e-08
+  Orbital gradient convergence      ...  1.00e-05
+  Max. number of iterations         ...        75  
+
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Inactive Energy E0 = -13.60390391 Eh
+CI-ITERATION   0: 
+   -14.604424771   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  1 MULT= 1 NROOTS= 1 
+ROOT   0:  E=     -14.6044247712 Eh
+      0.90756 [     0]: 2000
+      0.03081 [     9]: 0002
+      0.03081 [     4]: 0200
+      0.03081 [     7]: 0020
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -14.604424771 Eh DE=     0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.065   Act-Int = 4.462
+   N(occ)=  1.81512 0.06163 0.06163 0.06163
+   ||g|| =      0.512945368 Max(G)=     0.348355028 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.342427500 Max(X)(7,4) =      0.181605614 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   2: 
+   --- Inactive Energy E0 = -13.61070861 Eh
+CI-ITERATION   0: 
+   -14.615891588   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.615891588 Eh DE=    -0.011466817
+   --- Energy gap subspaces: Ext-Act = 0.035   Act-Int = 4.444
+   N(occ)=  1.80034 0.06655 0.06655 0.06655
+   ||g|| =      0.046434164 Max(G)=     0.024705010 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.077240157 Max(X)(7,4) =      0.043762639 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   3: 
+   --- Inactive Energy E0 = -13.61017255 Eh
+CI-ITERATION   0: 
+   -14.616467015   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616467015 Eh DE=    -0.000575427
+   --- Energy gap subspaces: Ext-Act = 0.022   Act-Int = 4.437
+   N(occ)=  1.80346 0.06551 0.06551 0.06551
+   ||g|| =      0.010141554 Max(G)=    -0.006481043 Rot=5,1
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.011058651 Max(X)(8,4) =      0.005754296 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   4: 
+   --- Inactive Energy E0 = -13.61008825 Eh
+CI-ITERATION   0: 
+   -14.616496888   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496888 Eh DE=    -0.000029873
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80382 0.06539 0.06539 0.06539
+   ||g|| =      0.000764647 Max(G)=    -0.000412067 Rot=5,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.001059019 Max(X)(6,4) =     -0.000447813 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   5: 
+   --- Inactive Energy E0 = -13.61009983 Eh
+CI-ITERATION   0: 
+   -14.616497002   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497002 Eh DE=    -0.000000114
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80373 0.06542 0.06542 0.06542
+   ||g|| =      0.000248514 Max(G)=    -0.000176206 Rot=34,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.000276300 Max(X)(8,2) =      0.000144845 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=    -0.000000007
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =      0.000016063 Max(G)=     0.000011695 Rot=14,1
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Forming Natural Orbitals
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=    -0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =      0.000016063 Max(G)=     0.000011575 Rot=14,1
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -14.616497008 Eh    -397.7351 eV
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000      -4.711845      -128.2158 
+   1   1.8038      -0.277797        -7.5592 
+   2   0.0654       0.112653         3.0655 
+   3   0.0654       0.112653         3.0655 
+   4   0.0654       0.112653         3.0655 
+   5   0.0000       0.127743         3.4761 
+   6   0.0000       0.150920         4.1067 
+   7   0.0000       0.150920         4.1067 
+   8   0.0000       0.150920         4.1067 
+   9   0.0000       0.274858         7.4793 
+  10   0.0000       0.274858         7.4793 
+  11   0.0000       0.274858         7.4793 
+  12   0.0000       0.274858         7.4793 
+  13   0.0000       0.274858         7.4793 
+  14   0.0000       0.681115        18.5341 
+  15   0.0000       0.767036        20.8721 
+  16   0.0000       0.767036        20.8721 
+  17   0.0000       0.767036        20.8721 
+  18   0.0000       1.118724        30.4420 
+  19   0.0000       1.118724        30.4420 
+  20   0.0000       1.118724        30.4420 
+  21   0.0000       1.118724        30.4420 
+  22   0.0000       1.118724        30.4420 
+  23   0.0000       1.176080        32.0028 
+  24   0.0000       1.176080        32.0028 
+  25   0.0000       1.176080        32.0028 
+  26   0.0000       1.176080        32.0028 
+  27   0.0000       1.176080        32.0028 
+  28   0.0000       1.176080        32.0028 
+  29   0.0000       1.176080        32.0028 
+  30   0.0000       3.007595        81.8408 
+  31   0.0000      10.933785       297.5234 
+  32   0.0000      10.933785       297.5234 
+  33   0.0000      10.933785       297.5234 
+  34   0.0000      11.951752       325.2237 
+  35   0.0000      65.244448      1775.3917 
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  1 MULT= 1 NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -14.6164970082 Eh
+      0.90188 [     0]: 2000
+      0.03271 [     9]: 0002
+      0.03271 [     7]: 0020
+      0.03271 [     4]: 0200
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                   0          1          2          3    
+      0       1.803752   0.000000   0.000000   0.000000
+      1       0.000000   0.065416   0.000000   0.000000
+      2       0.000000   0.000000   0.065416   0.000000
+      3       0.000000   0.000000   0.000000   0.065416
+Trace of the electron density:  2.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -19.082312356 Eh        -519.2561 eV
+Two electron energy          :      4.465815348 Eh         121.5210 eV
+Nuclear repulsion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -14.616497008
+
+Kinetic energy               :     14.616237926 Eh         397.7281 eV
+Potential energy             :    -29.232734934 Eh        -795.4632 eV
+Virial ratio                 :     -2.000017726 
+                               ----------------
+                                  -14.616497008
+
+Core energy                  :    -13.610095236 Eh     -370.3495 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.3       4.8      94.9       0.0
+ 0 Be px              0.0       0.0      99.7       0.0       0.2       0.0
+ 0 Be py              0.0       0.0       0.0      95.2       4.8       0.0
+
+                      6         7         8         9        10        11   
+                   0.15092   0.15092   0.15092   0.27486   0.27486   0.27486
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be pz             97.6       0.2       2.3       0.0       0.0       0.0
+ 0 Be px              2.3       0.0      97.7       0.0       0.0       0.0
+ 0 Be py              0.1      99.8       0.0       0.0       0.0       0.0
+ 0 Be dxz             0.0       0.0       0.0      48.8       5.3      45.9
+ 0 Be dyz             0.0       0.0       0.0      33.5      54.6      11.9
+ 0 Be dxy             0.0       0.0       0.0      17.8      40.1      42.1
+
+                     12        13        14        15        16        17   
+                   0.27486   0.27486   0.68111   0.76704   0.76704   0.76704
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s               0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be pz              0.0       0.0       0.0      74.6      22.8       2.6
+ 0 Be px              0.0       0.0       0.0       7.7       3.3      89.0
+ 0 Be py              0.0       0.0       0.0      17.8      73.9       8.3
+ 0 Be dz2            72.4      27.6       0.0       0.0       0.0       0.0
+ 0 Be dx2y2          27.6      72.4       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.11872   1.11872   1.11872   1.11872   1.11872   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be dz2             0.0       0.0       0.0      71.3      28.7       0.0
+ 0 Be dxz            41.9      49.7       8.4       0.0       0.0       0.0
+ 0 Be dyz            57.9      33.1       9.0       0.0       0.0       0.0
+ 0 Be dx2y2           0.0       0.0       0.0      28.7      71.3       0.0
+ 0 Be dxy             0.2      17.2      82.6       0.0       0.0       0.0
+ 0 Be f+1             0.0       0.0       0.0       0.0       0.0       1.2
+ 0 Be f-1             0.0       0.0       0.0       0.0       0.0       0.1
+ 0 Be f+2             0.0       0.0       0.0       0.0       0.0       0.1
+ 0 Be f-2             0.0       0.0       0.0       0.0       0.0      98.0
+ 0 Be f+3             0.0       0.0       0.0       0.0       0.0       0.5
+
+                     24        25        26        27        28        29   
+                   1.17608   1.17608   1.17608   1.17608   1.17608   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be f0              0.0       1.1       0.0       6.9      51.5      40.5
+ 0 Be f+1             0.1      55.4      11.5      31.3       0.4       0.2
+ 0 Be f-1            20.1       9.8      36.7       0.6      11.3      21.5
+ 0 Be f+2            68.2       6.7      24.7       0.0       0.2       0.0
+ 0 Be f-2             0.0       2.0       0.0       0.0       0.0       0.0
+ 0 Be f+3             0.1      23.7       6.1      60.1       9.2       0.3
+ 0 Be f-3            11.5       1.4      20.9       1.1      27.4      37.5
+
+                     30        31        32        33        34        35   
+                   3.00760  10.93379  10.93379  10.93379  11.95175  65.24445
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0       0.0       0.0       0.0     100.0     100.0
+ 0 Be pz              0.0      99.7       0.0       0.2       0.0       0.0
+ 0 Be px              0.0       0.2      23.9      75.9       0.0       0.0
+ 0 Be py              0.0       0.0      76.1      23.9       0.0       0.0
+
+
+----------------------------
+LOEWDIN REDUCED ACTIVE MOs  
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.3       4.8      94.9       0.0
+ 0 Be px              0.0       0.0      99.7       0.0       0.2       0.0
+ 0 Be py              0.0       0.0       0.0      95.2       4.8       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... casscf_beryllium_atom_nosym.scfp
+BaseName (.gbw .S,...)              ... casscf_beryllium_atom_nosym
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 Be:    0.000000
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 Be:    0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 Be     4.0000     4.0000     0.0000     0.7336     0.0000     0.7336
+
+
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.093188947 (     0.093071013,      0.000032207,     -0.004686712)
+ MO   3:      0.093188947 (     0.000997301,      0.090916525,      0.020429651)
+ MO   4:      0.093188947 (    -0.004579486,      0.020453954,     -0.090801123)
+MO   1:
+ MO   2:      1.461408146 (    -1.459558687,     -0.000505071,      0.073497971)
+ MO   3:      1.461408146 (    -0.015639871,     -1.425771563,     -0.320381978)
+ MO   4:      1.461408146 (     0.071816442,     -0.320763093,      1.423961799)
+MO   2:
+MO   3:
+MO   4:
+  newgto Be
+  0 15
+    1      29646.704407000001         0.000038108224
+    2       4428.761435400000         0.000297340321
+    3       1005.470133200000         0.001564016408
+    4        284.153395780000         0.006560712877
+    5         92.504356461000         0.023217340382
+    6         33.311016058000         0.069760422481
+    7         12.911553314000         0.170883257267
+    8          5.266549736100         0.318204229410
+    9         22.995386380000        -0.000026605257
+   10          6.623635417600        -0.000260226477
+   11          2.228959500300         0.379026890551
+   12          0.953024334500         0.186086635305
+   13          0.246516024400         0.006073816978
+   14          0.101538953100        -0.011158857101
+   15          0.041551374600        -0.001939619455
+  0 15
+    1      29646.704407000001         0.000006656465
+    2       4428.761435400000         0.000051937223
+    3       1005.470133200000         0.000273190897
+    4        284.153395780000         0.001145977130
+    5         92.504356461000         0.004055434462
+    6         33.311016058000         0.012185238136
+    7         12.911553314000         0.029848632063
+    8          5.266549736100         0.055581577250
+    9         22.995386380000         0.001088706138
+   10          6.623635417600         0.010648653488
+   11          2.228959500300         0.118828786568
+   12          0.953024334500         0.107283329848
+   13          0.246516024400        -0.284089779426
+   14          0.101538953100        -0.628004193294
+   15          0.041551374600        -0.214441958613
+  1 7
+    1         14.099789445000         0.004692441536
+    2          3.180318848200         0.029430526501
+    3          0.904892205000         0.119327406732
+    4          0.304115855100         0.359106958297
+    5          0.113026066600         0.606477568468
+    6          0.042831733700         0.037784957345
+    7          6.400000000000        -0.004717453605
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.000513 sec
+-------------------------------------------------------------
+
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+-------------------
+ABSORPTION SPECTRUM
+-------------------
+
+Center of mass           = (  0.0000,  0.0000,  0.0000)
+Nuclear contribution to the dipole moment =     0.000000,    0.000000,    0.000000 au
+
+Calculating the dipole integrals                  ... done
+Transforming integrals                            ... done
+Calculating the Linear Momentum integrals         ... done
+Transforming integrals                            ... done
+Calculating the Angular Momentum integrals        ... done
+Transforming integrals                            ... done
+
+Ground state mult:    1
+Ground state block:   0
+Ground state root:    0
+
+
+------------------------------------------------------------------------------
+                                 DIPOLE MOMENTS
+------------------------------------------------------------------------------
+  Root  Block           TX        TY        TZ           |T|
+                      (Debye)   (Debye)   (Debye)      (Debye)
+------------------------------------------------------------------------------
+    0    0            0.00000  -0.00000  -0.00000      0.00000
+
+--------------
+CASSCF TIMINGS
+--------------
+
+Total time                       ...        0.7 sec
+Sum of individual times          ...        0.4 sec ( 65.2%)
+
+Calculation of AO operators
+   F(Core) operator              ...        0.1 sec (  9.8%)
+   G(Act) operator               ...        0.1 sec (  9.7%)
+   J(AO) operators               ...        0.0 sec (  0.0%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.2 sec ( 32.6%)
+   (pq|rs) integrals             ...        0.0 sec (  0.0%)
+   AO->MO one electron integrals ...        0.0 sec (  1.2%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  3.8%)
+   CI-solution phase             ...        0.0 sec (  4.9%)
+   Generation of densities       ...        0.0 sec (  0.1%)
+Orbital improvement steps
+   Orbital gradient              ...        0.0 sec (  0.1%)
+   O(1) converger                ...        0.0 sec (  2.6%)
+Properties                       ...        0.0 sec (  0.2%)
+   SOC integral calculation      ...        0.0 sec (  0.0%)
+   SSC RMEs (incl. integrals)    ...        0.0 sec (  0.0%)
+   SOC RMEs                      ...        0.0 sec (  0.0%)
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -14.616497008249
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... casscf_beryllium_atom_nosym.gbw
+Electron density file                           ... casscf_beryllium_atom_nosym.scfp
+The origin for moment calculation is the CENTER OF MASS  = ( 0.000000,  0.000000  0.000000)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:      0.00000      -0.00000      -0.00000
+Nuclear contribution   :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :      0.00000      -0.00000      -0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:     0.000000     0.000000     0.000000 
+Rotational constants in MHz :     0.000000     0.000000     0.000000 
+
+ Dipole components along the rotational axes: 
+x,y,z [a.u.] :     0.000000    -0.000000    -0.000000 
+x,y,z [Debye]:     0.000000    -0.000000    -0.000000 
+
+ 
+
+Timings for individual modules:
+
+Sum of individual times         ...        3.674 sec (=   0.061 min)
+GTO integral calculation        ...        0.287 sec (=   0.005 min)   7.8 %
+SCF iterations                  ...        0.273 sec (=   0.005 min)   7.4 %
+CASSCF iterations               ...        3.115 sec (=   0.052 min)  84.8 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 4 seconds 54 msec

--- a/ORCA/ORCA4.2/casscf_beryllium_atom_sym.in
+++ b/ORCA/ORCA4.2/casscf_beryllium_atom_sym.in
@@ -1,0 +1,10 @@
+! def2-qzvpp verytightscf noautostart usesym
+
+%casscf
+ nel 2
+ norb 4
+ end
+
+* xyz 0 1
+Be 0 0 0
+*

--- a/ORCA/ORCA4.2/casscf_beryllium_atom_sym.out
+++ b/ORCA/ORCA4.2/casscf_beryllium_atom_sym.out
@@ -1,0 +1,1004 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #               Directorship: Frank Neese             #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.2.1 -  RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM Hessian, Gaussian charge scheme
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : CASSCF linear response (MC-RPA)
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Lucas Lang             : DCDCAS
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, Multilevel, MM, QM/MM, CI optimization
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 4.2.3
+ For citations please refer to: https://tddft.org/programs/libxc/
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-QZVPP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = casscf_beryllium_atom_sym.in
+|  1> ! def2-qzvpp verytightscf noautostart usesym
+|  2> 
+|  3> %casscf
+|  4>  nel 2
+|  5>  norb 4
+|  6>  end
+|  7> 
+|  8> * xyz 0 1
+|  9> Be 0 0 0
+| 10> *
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+
+------------------------------------------------------------------------------
+                            SYMMETRY HANDLING SETUP
+------------------------------------------------------------------------------
+
+------------------
+SYMMETRY DETECTION
+------------------
+Preparing Data                    ... done
+Detection Threshold:    SymThresh ... 1.0000e-04
+
+Point Group will now be determined:
+Moving molecule to center of mass ... done
+
+POINT GROUP                       ... Kh
+
+The coordinates will now be cleaned:
+Structure cleanup requested       ... yes
+Selected point group              ... Kh
+Cleaning Tolerance      SymThresh ... 1.0000e-04
+
+Cleaning coordinates              ... done
+
+-----------------------------------------------
+SYMMETRY-PERFECTED CARTESIAN COORDINATES (A.U.)
+-----------------------------------------------
+Warning (ORCA_SYM): Coordinates were not cleaned so far!
+
+------------------
+SYMMETRY REDUCTION
+------------------
+ORCA supports only abelian point groups.
+It is now checked, if the determined point group is supported:
+Point Group ( Kh    ) is          ... NOT supported
+Reducing to abelian subgroup      ... D2h
+
+(Re)building abelian point group:
+Creating Character Table          ... done
+Making direct product table       ... done
+Constructing symmetry operations  ... done
+Creating atom transfer table      ... done
+Creating asymmetric unit          ... done
+
+----------------------
+ASYMMETRIC UNIT IN D2h
+----------------------
+  #  AT     MASS              COORDS (A.U.)             BAS
+   0 Be   9.0120   0.00000000   0.00000000   0.00000000   0
+
+----------------------
+SYMMETRY ADAPTED BASIS
+----------------------
+The coefficients for the symmetry adapted linear combinations (SALCS)
+of basis functions will now be computed:
+Number of basis functions         ...    36
+Preparing memory                  ... done
+Constructing Gamma(red)           ... done
+Reducing Gamma(red)               ... done
+Constructing SALCs                ... done
+Checking SALC integrity           ... nothing suspicious
+Normalizing SALCs                 ... done
+
+Storing the symmetry object:
+Symmetry file                     ... casscf_beryllium_atom_sym.sym.tmp
+Writing symmetry information      ... done
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  Be     0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 Be    4.0000    0     9.012    0.000000    0.000000    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type Be  : 15s7p2d1f contracted to 7s4p2d1f pattern {8211111/4111/11/1}
+
+Atom   0Be   basis set group =>   1
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+ # of primitive gaussian shells          ...   25
+ # of primitive gaussian functions       ...   53
+ # of contracted shells                  ...   14
+ # of contracted basis functions         ...   36
+ Highest angular momentum                ...    3
+ Maximum contraction depth               ...    8
+ Integral package used                   ... LIBINT
+ Integral threshhold            Thresh   ...  1.000e-12
+ Primitive cut-off              TCut     ...  1.000e-14
+
+
+------------------------------ INTEGRAL EVALUATION ----------------------------
+
+
+ * One electron integrals 
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... done (   0.000 sec)
+
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... casscf_beryllium_atom_sym
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   36
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+ Symmetry handling      UseSym         .... ON
+ Point group                           .... D2h
+ Used point group                      .... D2h
+ Number of irreps                      .... 8
+   Irrep   Ag has   11 symmetry adapted basis functions (ofs=   0)
+   Irrep  B1g has    2 symmetry adapted basis functions (ofs=  11)
+   Irrep  B2g has    2 symmetry adapted basis functions (ofs=  13)
+   Irrep  B3g has    2 symmetry adapted basis functions (ofs=  15)
+   Irrep   Au has    1 symmetry adapted basis functions (ofs=  17)
+   Irrep  B1u has    6 symmetry adapted basis functions (ofs=  18)
+   Irrep  B2u has    6 symmetry adapted basis functions (ofs=  24)
+   Irrep  B3u has    6 symmetry adapted basis functions (ofs=  30)
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 6.741e-03
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Producing symmetrization matrix            ... done (   0.000 sec)
+Total time needed                          ...    0.001 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-12
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   1678 (   0.0 sec)
+# of grid points (after weights+screening)   ...   1678 (   0.0 sec)
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     1678
+Total number of batches                      ...       27
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1678
+Average number of shells per batch           ...    11.54 (82.40%)
+Average number of basis functions per batch  ...    31.75 (88.19%)
+Average number of large shells per batch     ...    11.21 (97.21%)
+Average number of large basis fcns per batch ...    31.43 (98.99%)
+Maximum spatial batch extension              ...  21.83, 39.91, 39.91 au
+Average spatial batch extension              ...  10.55, 12.37, 14.01 au
+
+Time for grid setup =    0.005 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Setting up the integral package                    ... done
+Initializing the effective Hamiltonian             ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+The symmetry of the initial guess is 1-Ag
+Irrep occupations for operator 0
+    Ag -    2
+   B1g -    0
+   B2g -    0
+   B3g -    0
+    Au -    0
+   B1u -    1
+   B2u -    1
+   B3u -    1
+                      ------------------
+                      INITIAL GUESS DONE (   0.1 sec)
+                      ------------------
+
+
+ ... the calculation is a CASSCF calculation -I'm leaving here GOOD LUCK!!!
+
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Symmetry handling      UseSym     ... ON
+Point group                       ... D2h
+Used point group                  ... D2h
+Number of irreps                  ... 8
+   Irrep   Ag has   11 SALCs (ofs=   0) #(closed)=   1 #(active)=   1
+   Irrep  B1g has    2 SALCs (ofs=  11) #(closed)=   0 #(active)=   0
+   Irrep  B2g has    2 SALCs (ofs=  13) #(closed)=   0 #(active)=   0
+   Irrep  B3g has    2 SALCs (ofs=  15) #(closed)=   0 #(active)=   0
+   Irrep   Au has    1 SALCs (ofs=  17) #(closed)=   0 #(active)=   0
+   Irrep  B1u has    6 SALCs (ofs=  18) #(closed)=   0 #(active)=   1
+   Irrep  B2u has    6 SALCs (ofs=  24) #(closed)=   0 #(active)=   1
+   Irrep  B3u has    6 SALCs (ofs=  30) #(closed)=   0 #(active)=   1
+ Symmetries of active orbitals:
+   MO =    1  IRREP= 0 (Ag)
+   MO =    2  IRREP= 7 (B3u)
+   MO =    3  IRREP= 6 (B2u)
+   MO =    4  IRREP= 5 (B1u)
+
+Setting up the integral package       ... done
+Building the CAS space                ... done (4 configurations for Mult=1 Irrep=0)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    2
+Number of active orbitals           ...    4
+Total number of electrons           ...    4
+Total number of orbitals            ...   36
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   35 (  31 orbitals)
+Number of rotation parameters      ...     34
+
+CI-STEP:
+CI strategy                         ... General CI
+Number of symmetry/multplity blocks ...    1
+BLOCK  1 WEIGHT=   1.0000
+  Multiplicity                      ...    1
+  Irrep                             ...    0 (Ag)
+  #(Configurations)                 ...    4
+  #(CSFs)                           ...    4
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+  N(GuessMat)                       ...       512
+  MaxDim(CI)                        ...        10
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  1.00e-09
+  Residual Tolerance CI             ...  1.00e-09
+  Shift(CI)                         ...  1.00e-04
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI(PT)
+  Default Parametrization           ... CAYLEY
+  Act-Act rotations                 ... depends on algorithm used
+
+  Note: SuperCI(PT) will ignore FreezeIE, FreezeAct and FreezeGrad. In general Default settings are encouraged.
+        In conjunction with ShiftUp, ShiftDn or GradScaling the performance of SuperCI(PT) is less optimal.  
+
+  MaxRot                            ... 2.00e-01 
+  Max. no of vectors (DIIS)         ... 15
+  DThresh (cut-off) metric          ... 1.00e-06
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... SuperCI(PT)    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  1.00e-12
+  Primitive cutoff TCut             ...  1.00e-14
+  Energy convergence tolerance      ...  1.00e-08
+  Orbital gradient convergence      ...  1.00e-05
+  Max. number of iterations         ...        75  
+
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Inactive Energy E0 = -13.60390391 Eh
+CI-ITERATION   0: 
+   -14.604424771   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  1 MULT= 1 NROOTS= 1  IRREP=Ag 
+ROOT   0:  E=     -14.6044247712 Eh
+      0.90756 [     0]: 2000
+      0.03081 [     1]: 0200
+      0.03081 [     3]: 0002
+      0.03081 [     2]: 0020
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -14.604424771 Eh DE=     0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.065   Act-Int = 4.462
+   N(occ)=  1.81512 0.06163 0.06163 0.06163
+   ||g|| =      0.512945368 Max(G)=     0.348355028 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.342427500 Max(X)(6,3) =      0.195627099 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   2: 
+   --- Inactive Energy E0 = -13.61070861 Eh
+CI-ITERATION   0: 
+   -14.615891588   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.615891588 Eh DE=    -0.011466817
+   --- Energy gap subspaces: Ext-Act = 0.035   Act-Int = 4.444
+   N(occ)=  1.80034 0.06655 0.06655 0.06655
+   ||g|| =      0.046434164 Max(G)=     0.024705010 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.077240157 Max(X)(8,2) =     -0.043853727 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   3: 
+   --- Inactive Energy E0 = -13.61017255 Eh
+CI-ITERATION   0: 
+   -14.616467015   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616467015 Eh DE=    -0.000575427
+   --- Energy gap subspaces: Ext-Act = 0.022   Act-Int = 4.437
+   N(occ)=  1.80346 0.06551 0.06551 0.06551
+   ||g|| =      0.010141554 Max(G)=     0.006481043 Rot=5,1
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.011058651 Max(X)(7,4) =     -0.005760039 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   4: 
+   --- Inactive Energy E0 = -13.61008825 Eh
+CI-ITERATION   0: 
+   -14.616496888   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496888 Eh DE=    -0.000029873
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80382 0.06539 0.06539 0.06539
+   ||g|| =      0.000764647 Max(G)=     0.000412067 Rot=5,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.001059019 Max(X)(6,3) =      0.000448218 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   5: 
+   --- Inactive Energy E0 = -13.61009983 Eh
+CI-ITERATION   0: 
+   -14.616497002   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497002 Eh DE=    -0.000000114
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80373 0.06542 0.06542 0.06542
+   ||g|| =      0.000248514 Max(G)=     0.000176206 Rot=34,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.000276300 Max(X)(6,3) =     -0.000144870 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=    -0.000000007
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =      0.000016063 Max(G)=     0.000011695 Rot=14,1
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Forming Natural Orbitals
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=    -0.000000000
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =      0.000016053 Max(G)=    -0.000011575 Rot=14,1
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -14.616497008 Eh    -397.7351 eV
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV)    Irrep 
+   0   2.0000      -4.711845      -128.2158    1-Ag
+   1   1.8038      -0.277797        -7.5592    2-Ag
+   2   0.0654       0.112653         3.0655    1-B3u
+   3   0.0654       0.112653         3.0655    1-B2u
+   4   0.0654       0.112653         3.0655    1-B1u
+   5   0.0000       0.127743         3.4761    3-Ag
+   6   0.0000       0.150920         4.1067    2-B2u
+   7   0.0000       0.150920         4.1067    2-B1u
+   8   0.0000       0.150920         4.1067    2-B3u
+   9   0.0000       0.274858         7.4793    1-B3g
+  10   0.0000       0.274858         7.4793    1-B2g
+  11   0.0000       0.274858         7.4793    1-B1g
+  12   0.0000       0.274858         7.4793    4-Ag
+  13   0.0000       0.274858         7.4793    5-Ag
+  14   0.0000       0.681115        18.5341    6-Ag
+  15   0.0000       0.767036        20.8721    3-B2u
+  16   0.0000       0.767036        20.8721    3-B1u
+  17   0.0000       0.767036        20.8721    3-B3u
+  18   0.0000       1.118724        30.4420    2-B2g
+  19   0.0000       1.118724        30.4420    2-B3g
+  20   0.0000       1.118724        30.4420    2-B1g
+  21   0.0000       1.118724        30.4420    7-Ag
+  22   0.0000       1.118724        30.4420    8-Ag
+  23   0.0000       1.176080        32.0028    1-Au
+  24   0.0000       1.176080        32.0028    4-B1u
+  25   0.0000       1.176080        32.0028    4-B3u
+  26   0.0000       1.176080        32.0028    4-B2u
+  27   0.0000       1.176080        32.0028    5-B3u
+  28   0.0000       1.176080        32.0028    5-B2u
+  29   0.0000       1.176080        32.0028    5-B1u
+  30   0.0000       3.007595        81.8408    9-Ag
+  31   0.0000      10.933785       297.5234    6-B1u
+  32   0.0000      10.933785       297.5234    6-B2u
+  33   0.0000      10.933785       297.5234    6-B3u
+  34   0.0000      11.951752       325.2237   10-Ag
+  35   0.0000      65.244448      1775.3917   11-Ag
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  1 MULT= 1 IRREP= Ag NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -14.6164970082 Eh
+      0.90188 [     0]: 2000
+      0.03271 [     1]: 0200
+      0.03271 [     2]: 0020
+      0.03271 [     3]: 0002
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                   0          1          2          3    
+      0       1.803752   0.000000   0.000000   0.000000
+      1       0.000000   0.065416   0.000000   0.000000
+      2       0.000000   0.000000   0.065416   0.000000
+      3       0.000000   0.000000   0.000000   0.065416
+Trace of the electron density:  2.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -19.082312356 Eh        -519.2561 eV
+Two electron energy          :      4.465815348 Eh         121.5210 eV
+Nuclear repulsion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -14.616497008
+
+Kinetic energy               :     14.616237926 Eh         397.7281 eV
+Potential energy             :    -29.232734934 Eh        -795.4632 eV
+Virial ratio                 :     -2.000017726 
+                               ----------------
+                                  -14.616497008
+
+Core energy                  :    -13.610095236 Eh     -370.3495 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+
+                      6         7         8         9        10        11   
+                   0.15092   0.15092   0.15092   0.27486   0.27486   0.27486
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be pz              0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py            100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be dxz             0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be dyz             0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be dxy             0.0       0.0       0.0       0.0       0.0     100.0
+
+                     12        13        14        15        16        17   
+                   0.27486   0.27486   0.68111   0.76704   0.76704   0.76704
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s               0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be pz              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be px              0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be dz2             2.3      97.7       0.0       0.0       0.0       0.0
+ 0 Be dx2y2          97.7       2.3       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.11872   1.11872   1.11872   1.11872   1.11872   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be dz2             0.0       0.0       0.0      99.5       0.5       0.0
+ 0 Be dxz           100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be dyz             0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be dx2y2           0.0       0.0       0.0       0.5      99.5       0.0
+ 0 Be dxy             0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be f-2             0.0       0.0       0.0       0.0       0.0     100.0
+
+                     24        25        26        27        28        29   
+                   1.17608   1.17608   1.17608   1.17608   1.17608   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be f0              0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be f+1             0.0      65.3       0.0      34.7       0.0       0.0
+ 0 Be f-1             0.0       0.0      63.2       0.0      36.8       0.0
+ 0 Be f+2           100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be f+3             0.0      34.7       0.0      65.3       0.0       0.0
+ 0 Be f-3             0.0       0.0      36.8       0.0      63.2       0.0
+
+                     30        31        32        33        34        35   
+                   3.00760  10.93379  10.93379  10.93379  11.95175  65.24445
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0       0.0       0.0       0.0     100.0     100.0
+ 0 Be pz              0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be px              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be py              0.0       0.0     100.0       0.0       0.0       0.0
+
+
+----------------------------
+LOEWDIN REDUCED ACTIVE MOs  
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... casscf_beryllium_atom_sym.scfp
+BaseName (.gbw .S,...)              ... casscf_beryllium_atom_sym
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 Be:    0.000000
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 Be:    0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 Be     4.0000     4.0000     0.0000     0.7336     0.0000     0.7336
+
+
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.093188947 (    -0.093188947,      0.000000000,      0.000000000)
+ MO   3:      0.093188947 (    -0.000000000,      0.093188947,     -0.000000000)
+ MO   4:      0.093188947 (     0.000000000,     -0.000000000,      0.093188947)
+MO   1:
+ MO   2:      1.461408146 (     1.461408146,     -0.000000000,     -0.000000000)
+ MO   3:      1.461408146 (     0.000000000,     -1.461408146,      0.000000000)
+ MO   4:      1.461408146 (    -0.000000000,      0.000000000,     -1.461408146)
+MO   2:
+MO   3:
+MO   4:
+  newgto Be
+  0 15
+    1      29646.704407000001         0.000038108224
+    2       4428.761435400000         0.000297340321
+    3       1005.470133200000         0.001564016408
+    4        284.153395780000         0.006560712877
+    5         92.504356461000         0.023217340382
+    6         33.311016058000         0.069760422481
+    7         12.911553314000         0.170883257267
+    8          5.266549736100         0.318204229410
+    9         22.995386380000        -0.000026605257
+   10          6.623635417600        -0.000260226477
+   11          2.228959500300         0.379026890551
+   12          0.953024334500         0.186086635305
+   13          0.246516024400         0.006073816978
+   14          0.101538953100        -0.011158857101
+   15          0.041551374600        -0.001939619455
+  0 15
+    1      29646.704407000001         0.000006656465
+    2       4428.761435400000         0.000051937223
+    3       1005.470133200000         0.000273190897
+    4        284.153395780000         0.001145977130
+    5         92.504356461000         0.004055434462
+    6         33.311016058000         0.012185238136
+    7         12.911553314000         0.029848632063
+    8          5.266549736100         0.055581577250
+    9         22.995386380000         0.001088706138
+   10          6.623635417600         0.010648653488
+   11          2.228959500300         0.118828786568
+   12          0.953024334500         0.107283329848
+   13          0.246516024400        -0.284089779426
+   14          0.101538953100        -0.628004193294
+   15          0.041551374600        -0.214441958613
+  1 7
+    1         14.099789445000         0.004692441536
+    2          3.180318848200         0.029430526501
+    3          0.904892205000         0.119327406732
+    4          0.304115855100         0.359106958297
+    5          0.113026066600         0.606477568468
+    6          0.042831733700         0.037784957345
+    7          6.400000000000        -0.004717453605
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.000149 sec
+-------------------------------------------------------------
+
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+-------------------
+ABSORPTION SPECTRUM
+-------------------
+
+Center of mass           = (  0.0000,  0.0000,  0.0000)
+Nuclear contribution to the dipole moment =     0.000000,    0.000000,    0.000000 au
+
+Calculating the dipole integrals                  ... done
+Transforming integrals                            ... done
+Calculating the Linear Momentum integrals         ... done
+Transforming integrals                            ... done
+Calculating the Angular Momentum integrals        ... done
+Transforming integrals                            ... done
+
+Ground state mult:    1
+Ground state block:   0
+Ground state root:    0
+
+
+------------------------------------------------------------------------------
+                                 DIPOLE MOMENTS
+------------------------------------------------------------------------------
+  Root  Block           TX        TY        TZ           |T|
+                      (Debye)   (Debye)   (Debye)      (Debye)
+------------------------------------------------------------------------------
+    0    0           -0.00000  -0.00000  -0.00000      0.00000
+
+--------------
+CASSCF TIMINGS
+--------------
+
+Total time                       ...        0.5 sec
+Sum of individual times          ...        0.3 sec ( 65.6%)
+
+Calculation of AO operators
+   F(Core) operator              ...        0.0 sec (  6.6%)
+   G(Act) operator               ...        0.1 sec ( 14.3%)
+   J(AO) operators               ...        0.0 sec (  0.0%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.2 sec ( 43.0%)
+   (pq|rs) integrals             ...        0.0 sec (  0.0%)
+   AO->MO one electron integrals ...        0.0 sec (  0.1%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  0.1%)
+   CI-solution phase             ...        0.0 sec (  1.0%)
+   Generation of densities       ...        0.0 sec (  0.0%)
+Orbital improvement steps
+   Orbital gradient              ...        0.0 sec (  0.1%)
+   O(1) converger                ...        0.0 sec (  0.2%)
+Properties                       ...        0.0 sec (  0.3%)
+   SOC integral calculation      ...        0.0 sec (  0.0%)
+   SSC RMEs (incl. integrals)    ...        0.0 sec (  0.0%)
+   SOC RMEs                      ...        0.0 sec (  0.0%)
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -14.616497008249
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... casscf_beryllium_atom_sym.gbw
+Electron density file                           ... casscf_beryllium_atom_sym.scfp
+The origin for moment calculation is the CENTER OF MASS  = ( 0.000000,  0.000000  0.000000)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:     -0.00000      -0.00000      -0.00000
+Nuclear contribution   :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :     -0.00000      -0.00000      -0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:     0.000000     0.000000     0.000000 
+Rotational constants in MHz :     0.000000     0.000000     0.000000 
+
+ Dipole components along the rotational axes: 
+x,y,z [a.u.] :    -0.000000    -0.000000    -0.000000 
+x,y,z [Debye]:    -0.000000    -0.000000    -0.000000 
+
+ 
+
+Timings for individual modules:
+
+Sum of individual times         ...        2.497 sec (=   0.042 min)
+GTO integral calculation        ...        0.215 sec (=   0.004 min)   8.6 %
+SCF iterations                  ...        0.093 sec (=   0.002 min)   3.7 %
+CASSCF iterations               ...        2.189 sec (=   0.036 min)  87.7 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 2 seconds 655 msec

--- a/ORCA/ORCA5.0/casscf_beryllium_atom_nosym.in
+++ b/ORCA/ORCA5.0/casscf_beryllium_atom_nosym.in
@@ -1,0 +1,10 @@
+! def2-qzvpp verytightscf noautostart nousesym
+
+%casscf
+ nel 2
+ norb 4
+ end
+
+* xyz 0 1
+Be 0 0 0
+*

--- a/ORCA/ORCA5.0/casscf_beryllium_atom_nosym.out
+++ b/ORCA/ORCA5.0/casscf_beryllium_atom_nosym.out
@@ -1,0 +1,963 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+                                            #,                                       
+                                            ###                                      
+                                            ####                                     
+                                            #####                                    
+                                            ######                                   
+                                           ########,                                 
+                                     ,,################,,,,,                         
+                               ,,#################################,,                 
+                          ,,##########################################,,             
+                       ,#########################################, ''#####,          
+                    ,#############################################,,   '####,        
+                  ,##################################################,,,,####,       
+                ,###########''''           ''''###############################       
+              ,#####''   ,,,,##########,,,,          '''####'''          '####       
+            ,##' ,,,,###########################,,,                        '##       
+           ' ,,###''''                  '''############,,,                           
+         ,,##''                                '''############,,,,        ,,,,,,###''
+      ,#''                                            '''#######################'''  
+     '                                                          ''''####''''         
+             ,#######,   #######,   ,#######,      ##                                
+            ,#'     '#,  ##    ##  ,#'     '#,    #''#        ######   ,####,        
+            ##       ##  ##   ,#'  ##            #'  '#       #        #'  '#        
+            ##       ##  #######   ##           ,######,      #####,   #    #        
+            '#,     ,#'  ##    ##  '#,     ,#' ,#      #,         ##   #,  ,#        
+             '#######'   ##     ##  '#######'  #'      '#     #####' # '####'        
+
+
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #    Directorship and core code : Frank Neese         #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 5.0.4 -  RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2 properties, NMR spectrum
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM and meta-GGA Hessian, CC/C-PCM, Gaussian charge scheme
+   Yang Guo               : DLPNO-NEVPT2, F12-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : MC-RPA, TRAH-SCF, COSX integrals
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Marcus Kettner         : VPT2
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density, CASPT2, CASPT2-K
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : Initial AUTO-CI
+   Lucas Lang             : DCDCAS
+   Marvin Lechner         : AUTO-CI (C++ implementation), FIC-MRCC
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Anastasios Papadopoulos: AUTO-CI, single reference methods and gradients
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR, DLPNO-MP2 response
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, P. Pracht,  : VdW corrections, initial TS optimization,
+                  C. Bannwarth, S. Ehlert          DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, DLPNO-Multilevel, CI-OPT
+                                                   MM, QMMM, 2- and 3-layer-ONIOM, Crystal-QMMM,
+                                                   LR-CPCM, SF, NACMEs, symmetry and pop. for TD-DFT,
+                                                   nearIR, NL-DFT gradient (VV10), updates on ESD,
+                                                   ML-optimized integration grids
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+   Liviu Ungur et al                             : ANISO software
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 5.1.0
+ For citations please refer to: https://tddft.org/programs/libxc/
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+   Shared memory     :  Shared parallel matrices
+   BLAS/LAPACK       :  OpenBLAS 0.3.15  USE64BITINT DYNAMIC_ARCH NO_AFFINITY Zen SINGLE_THREADED
+        Core in use  :  Zen
+   Copyright (c) 2011-2014, The OpenBLAS Project
+
+
+================================================================================
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-QZVPP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+INFO   : the flag for use of the SHARK integral package has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = casscf_beryllium_atom_nosym.in
+|  1> ! def2-qzvpp verytightscf noautostart nousesym
+|  2> 
+|  3> %casscf
+|  4>  nel 2
+|  5>  norb 4
+|  6>  end
+|  7> 
+|  8> * xyz 0 1
+|  9> Be 0 0 0
+| 10> *
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  Be     0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 Be    4.0000    0     9.012    0.000000    0.000000    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type Be  : 15s7p2d1f contracted to 7s4p2d1f pattern {8211111/4111/11/1}
+
+Atom   0Be   basis set group =>   1
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021                                                         
+------------------------------------------------------------------------------
+
+
+Reading SHARK input file casscf_beryllium_atom_nosym.SHARKINP.tmp ... ok
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...      1
+Number of basis functions                   ...     36
+Number of shells                            ...     14
+Maximum angular momentum                    ...      3
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+Auxiliary Coulomb fitting basis             ... NOT available
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+Integral threshold                          ...     1.000000e-12
+Primitive cut-off                           ...     1.000000e-14
+Primitive pair pre-selection threshold      ...     1.000000e-14
+
+Calculating pre-screening integrals         ... done (  0.0 sec) Dimension = 14
+Organizing shell pair data                  ... done (  0.0 sec)
+Shell pair information
+Total number of shell pairs                 ...       105
+Shell pairs after pre-screening             ...       105
+Total number of primitive shell pairs       ...       360
+Primitive shell pairs kept                  ...       360
+          la=0 lb=0:     28 shell pairs
+          la=1 lb=0:     28 shell pairs
+          la=1 lb=1:     10 shell pairs
+          la=2 lb=0:     14 shell pairs
+          la=2 lb=1:      8 shell pairs
+          la=2 lb=2:      3 shell pairs
+          la=3 lb=0:      7 shell pairs
+          la=3 lb=1:      4 shell pairs
+          la=3 lb=2:      2 shell pairs
+          la=3 lb=3:      1 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=      0.000000000000 Eh
+
+SHARK setup successfully completed in   0.1 seconds
+
+Maximum memory used throughout the entire GTOINT-calculation: 16.0 MB
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... casscf_beryllium_atom_nosym
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   36
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 6.741e-03
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Total time needed                          ...    0.001 sec
+
+Time for model grid setup =    0.004 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Initializing the effective Hamiltonian             ... done
+Setting up the integral package (SHARK)            ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.0 sec)
+                      ------------------
+
+
+ ... the calculation is a CASSCF calculation -I'm leaving here GOOD LUCK!!!
+
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Setting up the integral package       ... done
+Building the CAS space                ... done (10 configurations for Mult=1)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    2
+Number of active orbitals           ...    4
+Total number of electrons           ...    4
+Total number of orbitals            ...   36
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   35 (  31 orbitals)
+Number of rotation parameters      ...    159
+
+CI-STEP:
+CI strategy                         ... General CI
+Number of multiplicity blocks       ...    1
+BLOCK  1 WEIGHT=   1.0000
+  Multiplicity                      ...    1
+  #(Configurations)                 ...   10
+  #(CSFs)                           ...   10
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+  N(GuessMat)                       ...       512
+  MaxDim(CI)                        ...        10
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  1.00e-09
+  Residual Tolerance CI             ...  1.00e-09
+  Shift(CI)                         ...  1.00e-04
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI(PT)
+  Default Parametrization           ... CAYLEY
+  Act-Act rotations                 ... depends on algorithm used
+
+  Note: SuperCI(PT) will ignore FreezeIE, FreezeAct and FreezeGrad. In general Default settings are encouraged.
+        In conjunction with ShiftUp, ShiftDn or GradScaling the performance of SuperCI(PT) is less optimal.  
+
+  MaxRot                            ... 2.00e-01 
+  Max. no of vectors (DIIS)         ... 15
+  DThresh (cut-off) metric          ... 1.00e-06
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... SuperCI(PT)    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  1.00e-12
+  Primitive cutoff TCut             ...  1.00e-14
+  Energy convergence tolerance      ...  1.00e-08
+  Orbital gradient convergence      ...  1.00e-05
+  Max. number of iterations         ...        75  
+
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Inactive Energy E0 = -13.60390405 Eh
+CI-ITERATION   0: 
+   -14.604424915   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  1 MULT= 1 NROOTS= 1 
+ROOT   0:  E=     -14.6044249150 Eh
+      0.90756 [     0]: 2000
+      0.03081 [     7]: 0020
+      0.03081 [     4]: 0200
+      0.03081 [     9]: 0002
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -14.604424915 Eh DE=    0.000000e+00
+   --- Energy gap subspaces: Ext-Act = 0.065   Act-Int = 4.462
+   N(occ)=  1.81512 0.06163 0.06163 0.06163
+   ||g|| =     5.129342e-01 Max(G)=   -3.483484e-01 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.342426993 Max(X)(8,3) =     -0.159477138 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   2: 
+   --- Inactive Energy E0 = -13.61070860 Eh
+CI-ITERATION   0: 
+   -14.615891596   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.615891596 Eh DE=   -1.146668e-02
+   --- Energy gap subspaces: Ext-Act = 0.035   Act-Int = 4.444
+   N(occ)=  1.80034 0.06655 0.06655 0.06655
+   ||g|| =     4.643372e-02 Max(G)=   -2.470462e-02 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.077239841 Max(X)(8,2) =      0.042726836 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   3: 
+   --- Inactive Energy E0 = -13.61017255 Eh
+CI-ITERATION   0: 
+   -14.616467015   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616467015 Eh DE=   -5.754194e-04
+   --- Energy gap subspaces: Ext-Act = 0.022   Act-Int = 4.437
+   N(occ)=  1.80346 0.06551 0.06551 0.06551
+   ||g|| =     1.014140e-02 Max(G)=    6.481003e-03 Rot=5,1
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.011058579 Max(X)(8,2) =      0.004730160 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   4: 
+   --- Inactive Energy E0 = -13.61008825 Eh
+CI-ITERATION   0: 
+   -14.616496888   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496888 Eh DE=   -2.987259e-05
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80382 0.06539 0.06539 0.06539
+   ||g|| =     7.646285e-04 Max(G)=   -4.120669e-04 Rot=5,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.001058992 Max(X)(8,2) =      0.000382101 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   5: 
+   --- Inactive Energy E0 = -13.61009983 Eh
+CI-ITERATION   0: 
+   -14.616497002   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497002 Eh DE=   -1.136735e-07
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80373 0.06542 0.06542 0.06542
+   ||g|| =     2.485089e-04 Max(G)=    1.762019e-04 Rot=34,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.000276301 Max(X)(8,2) =     -0.000119006 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=   -6.684049e-09
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =     1.606362e-05 Max(G)=   -1.169535e-05 Rot=14,1
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Forming Natural Orbitals
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=   -3.730349e-14
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =     1.606362e-05 Max(G)=   -1.157495e-05 Rot=14,1
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -14.616497008 Eh    -397.7351 eV
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000      -4.711845      -128.2158 
+   1   1.8038      -0.277797        -7.5592 
+   2   0.0654       0.112653         3.0655 
+   3   0.0654       0.112653         3.0655 
+   4   0.0654       0.112653         3.0655 
+   5   0.0000       0.127743         3.4761 
+   6   0.0000       0.150920         4.1067 
+   7   0.0000       0.150920         4.1067 
+   8   0.0000       0.150920         4.1067 
+   9   0.0000       0.274858         7.4793 
+  10   0.0000       0.274858         7.4793 
+  11   0.0000       0.274858         7.4793 
+  12   0.0000       0.274858         7.4793 
+  13   0.0000       0.274858         7.4793 
+  14   0.0000       0.681115        18.5341 
+  15   0.0000       0.767036        20.8721 
+  16   0.0000       0.767036        20.8721 
+  17   0.0000       0.767036        20.8721 
+  18   0.0000       1.118724        30.4420 
+  19   0.0000       1.118724        30.4420 
+  20   0.0000       1.118724        30.4420 
+  21   0.0000       1.118724        30.4420 
+  22   0.0000       1.118724        30.4420 
+  23   0.0000       1.176080        32.0028 
+  24   0.0000       1.176080        32.0028 
+  25   0.0000       1.176080        32.0028 
+  26   0.0000       1.176080        32.0028 
+  27   0.0000       1.176080        32.0028 
+  28   0.0000       1.176080        32.0028 
+  29   0.0000       1.176080        32.0028 
+  30   0.0000       3.007595        81.8408 
+  31   0.0000      10.933785       297.5234 
+  32   0.0000      10.933785       297.5234 
+  33   0.0000      10.933785       297.5234 
+  34   0.0000      11.951752       325.2237 
+  35   0.0000      65.244448      1775.3917 
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  1 MULT= 1 NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -14.6164970082 Eh
+      0.90188 [     0]: 2000
+      0.03271 [     9]: 0002
+      0.03271 [     7]: 0020
+      0.03271 [     4]: 0200
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                  0          1          2          3    
+      0       1.803752   0.000000   0.000000  -0.000000
+      1       0.000000   0.065416  -0.000000  -0.000000
+      2       0.000000  -0.000000   0.065416   0.000000
+      3      -0.000000  -0.000000   0.000000   0.065416
+Trace of the electron density:  2.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -19.082312356 Eh        -519.2561 eV
+Two electron energy          :      4.465815348 Eh         121.5210 eV
+Nuclear repulsion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -14.616497008
+
+Kinetic energy               :     14.616237925 Eh         397.7281 eV
+Potential energy             :    -29.232734934 Eh        -795.4632 eV
+Virial ratio                 :     -2.000017726 
+                               ----------------
+                                  -14.616497008
+
+Core energy                  :    -13.610095236 Eh     -370.3495 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0      53.2      46.5       0.3       0.0
+ 0 Be px              0.0       0.0      46.7      52.0       1.3       0.0
+ 0 Be py              0.0       0.0       0.1       1.4      98.4       0.0
+
+                      6         7         8         9        10        11   
+                   0.15092   0.15092   0.15092   0.27486   0.27486   0.27486
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be pz             94.1       4.7       1.2       0.0       0.0       0.0
+ 0 Be px              1.7      72.1      26.2       0.0       0.0       0.0
+ 0 Be py              4.2      23.2      72.6       0.0       0.0       0.0
+ 0 Be dz2             0.0       0.0       0.0      69.0       0.9       6.4
+ 0 Be dxz             0.0       0.0       0.0       0.6       6.9       8.0
+ 0 Be dyz             0.0       0.0       0.0       0.1      77.8      10.0
+ 0 Be dx2y2           0.0       0.0       0.0       0.6       9.8      49.8
+ 0 Be dxy             0.0       0.0       0.0      29.6       4.5      25.8
+
+                     12        13        14        15        16        17   
+                   0.27486   0.27486   0.68111   0.76704   0.76704   0.76704
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s               0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be pz              0.0       0.0       0.0      94.9       0.0       5.0
+ 0 Be px              0.0       0.0       0.0       1.4      68.3      30.3
+ 0 Be py              0.0       0.0       0.0       3.7      31.6      64.7
+ 0 Be dz2            12.1      11.6       0.0       0.0       0.0       0.0
+ 0 Be dxz            62.1      22.4       0.0       0.0       0.0       0.0
+ 0 Be dyz             8.4       3.6       0.0       0.0       0.0       0.0
+ 0 Be dx2y2           4.1      35.7       0.0       0.0       0.0       0.0
+ 0 Be dxy            13.4      26.7       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.11872   1.11872   1.11872   1.11872   1.11872   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be dz2            75.3      12.8       0.2       0.5      11.2       0.0
+ 0 Be dxz             0.5       0.9      93.2       0.1       5.3       0.0
+ 0 Be dyz             0.2       8.4       1.8      58.4      31.2       0.0
+ 0 Be dx2y2           0.3      45.4       0.0      34.1      20.2       0.0
+ 0 Be dxy            23.7      32.5       4.8       6.9      32.1       0.0
+ 0 Be f0              0.0       0.0       0.0       0.0       0.0      18.2
+ 0 Be f+1             0.0       0.0       0.0       0.0       0.0       0.2
+ 0 Be f-1             0.0       0.0       0.0       0.0       0.0      16.9
+ 0 Be f+2             0.0       0.0       0.0       0.0       0.0       6.1
+ 0 Be f-2             0.0       0.0       0.0       0.0       0.0      49.2
+ 0 Be f+3             0.0       0.0       0.0       0.0       0.0       2.4
+ 0 Be f-3             0.0       0.0       0.0       0.0       0.0       7.0
+
+                     24        25        26        27        28        29   
+                   1.17608   1.17608   1.17608   1.17608   1.17608   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be f0             20.2      32.0       2.6      16.7       8.6       1.8
+ 0 Be f+1            18.6       0.3      44.2       8.2      23.6       5.0
+ 0 Be f-1             0.2      30.3       0.0      10.4       9.9      32.2
+ 0 Be f+2            33.7      12.5       0.3      11.6      28.3       7.6
+ 0 Be f-2             6.7       0.0       0.0      39.6       4.5       0.0
+ 0 Be f+3            19.8       1.3      52.9       2.5      17.6       3.4
+ 0 Be f-3             0.9      23.7       0.0      11.0       7.5      49.9
+
+                     30        31        32        33        34        35   
+                   3.00760  10.93379  10.93379  10.93379  11.95175  65.24445
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0       0.0       0.0       0.0     100.0     100.0
+ 0 Be pz              0.0      57.2      35.5       7.2       0.0       0.0
+ 0 Be px              0.0      34.0      64.2       1.8       0.0       0.0
+ 0 Be py              0.0       8.8       0.3      90.9       0.0       0.0
+
+
+----------------------------
+LOEWDIN REDUCED ACTIVE MOs  
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0      53.2      46.5       0.3       0.0
+ 0 Be px              0.0       0.0      46.7      52.0       1.3       0.0
+ 0 Be py              0.0       0.0       0.1       1.4      98.4       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... casscf_beryllium_atom_nosym.scfp
+BaseName (.gbw .S,...)              ... casscf_beryllium_atom_nosym
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 Be:   -0.000000
+Sum of atomic charges:   -0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 Be:   -0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 Be     4.0000     4.0000    -0.0000     0.7336     0.0000     0.7336
+
+
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.093188947 (     0.063677985,     -0.003441286,      0.067951833)
+ MO   3:      0.093188947 (    -0.067230074,      0.011125659,      0.063565058)
+ MO   4:      0.093188947 (    -0.010459979,     -0.092458407,      0.005119723)
+MO   1:
+ MO   2:      1.461408146 (     0.998611200,     -0.053966952,      1.065634557)
+ MO   3:      1.461408146 (    -1.054315789,      0.174474861,      0.996840263)
+ MO   4:      1.461408146 (    -0.164035538,     -1.449951675,      0.080288550)
+MO   2:
+MO   3:
+MO   4:
+  newgto Be
+  0 15
+    1      29646.704407000001         0.000038108224
+    2       4428.761435400000         0.000297340321
+    3       1005.470133200000         0.001564016408
+    4        284.153395780000         0.006560712877
+    5         92.504356461000         0.023217340382
+    6         33.311016058000         0.069760422481
+    7         12.911553314000         0.170883257267
+    8          5.266549736100         0.318204229410
+    9         22.995386380000        -0.000026605258
+   10          6.623635417600        -0.000260226483
+   11          2.228959500300         0.379026890564
+   12          0.953024334500         0.186086635277
+   13          0.246516024400         0.006073817016
+   14          0.101538953100        -0.011158857110
+   15          0.041551374600        -0.001939619433
+  0 15
+    1      29646.704407000001         0.000006656465
+    2       4428.761435400000         0.000051937223
+    3       1005.470133200000         0.000273190897
+    4        284.153395780000         0.001145977130
+    5         92.504356461000         0.004055434462
+    6         33.311016058000         0.012185238136
+    7         12.911553314000         0.029848632065
+    8          5.266549736100         0.055581577253
+    9         22.995386380000         0.001088706138
+   10          6.623635417600         0.010648653488
+   11          2.228959500300         0.118828786580
+   12          0.953024334500         0.107283329766
+   13          0.246516024400        -0.284089778990
+   14          0.101538953100        -0.628004193847
+   15          0.041551374600        -0.214441958372
+  1 7
+    1         14.099789445000         0.004692441533
+    2          3.180318848200         0.029430526482
+    3          0.904892205000         0.119327406656
+    4          0.304115855100         0.359106958068
+    5          0.113026066600         0.606477568734
+    6          0.042831733700         0.037784957355
+    7          6.400000000000        -0.004717453594
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.000165 sec
+-------------------------------------------------------------
+
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+-------------------
+ABSORPTION SPECTRUM
+-------------------
+
+Center of mass           = (  0.0000,  0.0000,  0.0000)
+Nuclear contribution to the dipole moment =     0.000000,    0.000000,    0.000000 au
+
+Calculating the Dipole integrals                  ... done
+Transforming integrals                            ... done
+Calculating the Linear Momentum integrals         ... done
+Transforming integrals                            ... done
+Calculating the Angular Momentum integrals        ... done
+Transforming integrals                            ... done
+
+------------------------------------------------------------------------------
+                                 DIPOLE MOMENTS
+------------------------------------------------------------------------------
+  Root  Block           TX        TY        TZ           |T|
+                      (Debye)   (Debye)   (Debye)      (Debye)
+------------------------------------------------------------------------------
+    0    0            0.00000   0.00000  -0.00000      0.00000
+
+--------------
+CASSCF TIMINGS
+--------------
+
+Total time                       ...        0.4 sec
+Sum of individual times          ...        0.3 sec ( 60.2%)
+
+Calculation of AO operators
+   F(Core) operator              ...        0.0 sec (  7.1%)
+   G(Act) operator               ...        0.1 sec ( 12.5%)
+   J(AO) operators               ...        0.0 sec (  0.0%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.2 sec ( 38.7%)
+   (pq|rs) integrals             ...        0.0 sec (  0.0%)
+   AO->MO one electron integrals ...        0.0 sec (  0.1%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  0.1%)
+   CI-solution phase             ...        0.0 sec (  1.3%)
+   Generation of densities       ...        0.0 sec (  0.1%)
+Orbital improvement steps
+   Orbital gradient              ...        0.0 sec (  0.1%)
+   O(1) converger                ...        0.0 sec (  0.2%)
+Properties                       ...        0.0 sec (  0.0%)
+   SOC integral calculation      ...        0.0 sec (  0.0%)
+   SSC RMEs (incl. integrals)    ...        0.0 sec (  0.0%)
+   SOC RMEs                      ...        0.0 sec (  0.0%)
+
+Maximum memory used throughout the entire CASSCF-calculation: 119.3 MB
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -14.616497008249
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... casscf_beryllium_atom_nosym.gbw
+Electron density                                ... casscf_beryllium_atom_nosym.scfp
+The origin for moment calculation is the CENTER OF MASS  = ( 0.000000,  0.000000  0.000000)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:      0.00000       0.00000      -0.00000
+Nuclear contribution   :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :      0.00000       0.00000      -0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:     0.000000     0.000000     0.000000 
+Rotational constants in MHz :     0.000000     0.000000     0.000000 
+
+ Dipole components along the rotational axes: 
+x,y,z [a.u.] :     0.000000     0.000000    -0.000000 
+x,y,z [Debye]:     0.000000     0.000000    -0.000000 
+
+ 
+
+Timings for individual modules:
+
+Sum of individual times         ...        2.601 sec (=   0.043 min)
+GTO integral calculation        ...        0.077 sec (=   0.001 min)   2.9 %
+SCF iterations                  ...        0.046 sec (=   0.001 min)   1.8 %
+CASSCF iterations               ...        2.479 sec (=   0.041 min)  95.3 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 2 seconds 664 msec

--- a/ORCA/ORCA5.0/casscf_beryllium_atom_sym.in
+++ b/ORCA/ORCA5.0/casscf_beryllium_atom_sym.in
@@ -1,0 +1,10 @@
+! def2-qzvpp verytightscf noautostart usesym
+
+%casscf
+ nel 2
+ norb 4
+ end
+
+* xyz 0 1
+Be 0 0 0
+*

--- a/ORCA/ORCA5.0/casscf_beryllium_atom_sym.out
+++ b/ORCA/ORCA5.0/casscf_beryllium_atom_sym.out
@@ -1,0 +1,1060 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+                                            #,                                       
+                                            ###                                      
+                                            ####                                     
+                                            #####                                    
+                                            ######                                   
+                                           ########,                                 
+                                     ,,################,,,,,                         
+                               ,,#################################,,                 
+                          ,,##########################################,,             
+                       ,#########################################, ''#####,          
+                    ,#############################################,,   '####,        
+                  ,##################################################,,,,####,       
+                ,###########''''           ''''###############################       
+              ,#####''   ,,,,##########,,,,          '''####'''          '####       
+            ,##' ,,,,###########################,,,                        '##       
+           ' ,,###''''                  '''############,,,                           
+         ,,##''                                '''############,,,,        ,,,,,,###''
+      ,#''                                            '''#######################'''  
+     '                                                          ''''####''''         
+             ,#######,   #######,   ,#######,      ##                                
+            ,#'     '#,  ##    ##  ,#'     '#,    #''#        ######   ,####,        
+            ##       ##  ##   ,#'  ##            #'  '#       #        #'  '#        
+            ##       ##  #######   ##           ,######,      #####,   #    #        
+            '#,     ,#'  ##    ##  '#,     ,#' ,#      #,         ##   #,  ,#        
+             '#######'   ##     ##  '#######'  #'      '#     #####' # '####'        
+
+
+
+                  #######################################################
+                  #                        -***-                        #
+                  #          Department of theory and spectroscopy      #
+                  #    Directorship and core code : Frank Neese         #
+                  #        Max Planck Institute fuer Kohlenforschung    #
+                  #                Kaiser Wilhelm Platz 1               #
+                  #                 D-45470 Muelheim/Ruhr               #
+                  #                      Germany                        #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 5.0.4 -  RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2 properties, NMR spectrum
+   Ute Becker             : Parallelization
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM and meta-GGA Hessian, CC/C-PCM, Gaussian charge scheme
+   Yang Guo               : DLPNO-NEVPT2, F12-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Benjamin Helmich-Paris : MC-RPA, TRAH-SCF, COSX integrals
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Marcus Kettner         : VPT2
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density, CASPT2, CASPT2-K
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : Initial AUTO-CI
+   Lucas Lang             : DCDCAS
+   Marvin Lechner         : AUTO-CI (C++ implementation), FIC-MRCC
+   Dagmar Lenk            : GEPOL surface, SMD
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Anastasios Papadopoulos: AUTO-CI, single reference methods and gradients
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Avijit Sen             : IP-ROCIS
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR, DLPNO-MP2 response
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, P. Pracht,  : VdW corrections, initial TS optimization,
+                  C. Bannwarth, S. Ehlert          DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, DLPNO-Multilevel, CI-OPT
+                                                   MM, QMMM, 2- and 3-layer-ONIOM, Crystal-QMMM,
+                                                   LR-CPCM, SF, NACMEs, symmetry and pop. for TD-DFT,
+                                                   nearIR, NL-DFT gradient (VV10), updates on ESD,
+                                                   ML-optimized integration grids
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+   Liviu Ungur et al                             : ANISO software
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 5.1.0
+ For citations please refer to: https://tddft.org/programs/libxc/
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+   Shared memory     :  Shared parallel matrices
+   BLAS/LAPACK       :  OpenBLAS 0.3.15  USE64BITINT DYNAMIC_ARCH NO_AFFINITY Zen SINGLE_THREADED
+        Core in use  :  Zen
+   Copyright (c) 2011-2014, The OpenBLAS Project
+
+
+================================================================================
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-QZVPP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+INFO   : the flag for use of the SHARK integral package has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = casscf_beryllium_atom_sym.in
+|  1> ! def2-qzvpp verytightscf noautostart usesym
+|  2> 
+|  3> %casscf
+|  4>  nel 2
+|  5>  norb 4
+|  6>  end
+|  7> 
+|  8> * xyz 0 1
+|  9> Be 0 0 0
+| 10> *
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+
+------------------------------------------------------------------------------
+                            SYMMETRY HANDLING SETUP
+------------------------------------------------------------------------------
+
+------------------
+SYMMETRY DETECTION
+------------------
+The point group will now be determined using a tolerance of 1.0000e-04.
+The Z matrix contains a single non-dummy atom.
+No further testing needed for point group Kh.
+This point group has been found:    Kh
+Largest non-degenerate subgroup:    D2h
+
+
+Symmetry-perfected Cartesians (point groups Kh and D2h):
+
+Atom          Symmetry-perfected Cartesians (x, y, z; au)
+  0       0.000000000000    0.000000000000    0.000000000000
+
+
+-----------------------------------------------
+SYMMETRY-PERFECTED CARTESIAN COORDINATES (A.U.)
+-----------------------------------------------
+Warning (ORCA_SYM): Coordinates were not cleaned so far!
+
+------------------
+SYMMETRY REDUCTION
+------------------
+ORCA supports only abelian point groups.
+It is now checked, if the determined point group is supported:
+Point Group ( D2h   ) is          ... supported
+
+(Re)building abelian point group:
+Creating Character Table          ... done
+Making direct product table       ... done
+Constructing symmetry operations  ... done
+Creating atom transfer table      ... done
+Creating asymmetric unit          ... done
+
+----------------------
+ASYMMETRIC UNIT IN D2h
+----------------------
+  #  AT     MASS              COORDS (A.U.)             BAS
+   0 Be   9.0120   0.00000000   0.00000000   0.00000000   0
+
+----------------------
+SYMMETRY ADAPTED BASIS
+----------------------
+The coefficients for the symmetry adapted linear combinations (SALCS)
+of basis functions will now be computed:
+Number of basis functions         ...    36
+Preparing memory                  ... done
+Constructing Gamma(red)           ... done
+Reducing Gamma(red)               ... done
+Constructing SALCs                ... done
+Checking SALC integrity           ... nothing suspicious
+Normalizing SALCs                 ... done
+
+Storing the symmetry object:
+Symmetry file                     ... casscf_beryllium_atom_sym.sym.tmp
+Writing symmetry information      ... done
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  Be     0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 Be    4.0000    0     9.012    0.000000    0.000000    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type Be  : 15s7p2d1f contracted to 7s4p2d1f pattern {8211111/4111/11/1}
+
+Atom   0Be   basis set group =>   1
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021                                                         
+------------------------------------------------------------------------------
+
+
+Reading SHARK input file casscf_beryllium_atom_sym.SHARKINP.tmp ... ok
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...      1
+Number of basis functions                   ...     36
+Number of shells                            ...     14
+Maximum angular momentum                    ...      3
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+Auxiliary Coulomb fitting basis             ... NOT available
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+Integral threshold                          ...     1.000000e-12
+Primitive cut-off                           ...     1.000000e-14
+Primitive pair pre-selection threshold      ...     1.000000e-14
+
+Calculating pre-screening integrals         ... done (  0.0 sec) Dimension = 14
+Organizing shell pair data                  ... done (  0.0 sec)
+Shell pair information
+Total number of shell pairs                 ...       105
+Shell pairs after pre-screening             ...       105
+Total number of primitive shell pairs       ...       360
+Primitive shell pairs kept                  ...       360
+          la=0 lb=0:     28 shell pairs
+          la=1 lb=0:     28 shell pairs
+          la=1 lb=1:     10 shell pairs
+          la=2 lb=0:     14 shell pairs
+          la=2 lb=1:      8 shell pairs
+          la=2 lb=2:      3 shell pairs
+          la=3 lb=0:      7 shell pairs
+          la=3 lb=1:      4 shell pairs
+          la=3 lb=2:      2 shell pairs
+          la=3 lb=3:      1 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=      0.000000000000 Eh
+
+SHARK setup successfully completed in   0.4 seconds
+
+Maximum memory used throughout the entire GTOINT-calculation: 16.0 MB
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... casscf_beryllium_atom_sym
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   36
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+ Symmetry handling      UseSym         .... ON
+ Point group                           .... D2h
+ Used point group                      .... D2h
+ Number of irreps                      .... 8
+   Irrep   Ag has   11 symmetry adapted basis functions (ofs=   0)
+   Irrep  B1g has    2 symmetry adapted basis functions (ofs=  11)
+   Irrep  B2g has    2 symmetry adapted basis functions (ofs=  13)
+   Irrep  B3g has    2 symmetry adapted basis functions (ofs=  15)
+   Irrep   Au has    1 symmetry adapted basis functions (ofs=  17)
+   Irrep  B1u has    6 symmetry adapted basis functions (ofs=  18)
+   Irrep  B2u has    6 symmetry adapted basis functions (ofs=  24)
+   Irrep  B3u has    6 symmetry adapted basis functions (ofs=  30)
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 6.741e-03
+Time for diagonalization                   ...    0.015 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Producing symmetrization matrix            ... done (   0.000 sec)
+Total time needed                          ...    0.016 sec
+
+Time for model grid setup =    0.099 sec
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Initializing the effective Hamiltonian             ... done
+Setting up the integral package (SHARK)            ... done
+Starting the Coulomb interaction                   ... done (   0.1 sec)
+Reading the grid                                   ... done
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+The symmetry of the initial guess is 1-Ag
+Irrep occupations for operator 0
+    Ag -    2
+   B1g -    0
+   B2g -    0
+   B3g -    0
+    Au -    0
+   B1u -    1
+   B2u -    1
+   B3u -    1
+                      ------------------
+                      INITIAL GUESS DONE (   0.2 sec)
+                      ------------------
+
+
+ ... the calculation is a CASSCF calculation -I'm leaving here GOOD LUCK!!!
+
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Symmetry handling      UseSym     ... ON
+Point group                       ... D2h
+Used point group                  ... D2h
+Number of irreps                  ... 8
+   Irrep   Ag has   11 SALCs (ofs=   0) #(closed)=   1 #(active)=   1
+   Irrep  B1g has    2 SALCs (ofs=  11) #(closed)=   0 #(active)=   0
+   Irrep  B2g has    2 SALCs (ofs=  13) #(closed)=   0 #(active)=   0
+   Irrep  B3g has    2 SALCs (ofs=  15) #(closed)=   0 #(active)=   0
+   Irrep   Au has    1 SALCs (ofs=  17) #(closed)=   0 #(active)=   0
+   Irrep  B1u has    6 SALCs (ofs=  18) #(closed)=   0 #(active)=   1
+   Irrep  B2u has    6 SALCs (ofs=  24) #(closed)=   0 #(active)=   1
+   Irrep  B3u has    6 SALCs (ofs=  30) #(closed)=   0 #(active)=   1
+ Symmetries of active orbitals:
+   MO =    1  IRREP= 0 (Ag)
+   MO =    2  IRREP= 7 (B3u)
+   MO =    3  IRREP= 6 (B2u)
+   MO =    4  IRREP= 5 (B1u)
+
+Setting up the integral package       ... done
+Building the CAS space                ... done (4 configurations for Mult=1 Irrep=0)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    2
+Number of active orbitals           ...    4
+Total number of electrons           ...    4
+Total number of orbitals            ...   36
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   35 (  31 orbitals)
+Number of rotation parameters      ...     34
+
+CI-STEP:
+CI strategy                         ... General CI
+Number of symmetry/multplity blocks ...    1
+BLOCK  1 WEIGHT=   1.0000
+  Multiplicity                      ...    1
+  Irrep                             ...    0 (Ag)
+  #(Configurations)                 ...    4
+  #(CSFs)                           ...    4
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+  N(GuessMat)                       ...       512
+  MaxDim(CI)                        ...        10
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  1.00e-09
+  Residual Tolerance CI             ...  1.00e-09
+  Shift(CI)                         ...  1.00e-04
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI(PT)
+  Default Parametrization           ... CAYLEY
+  Act-Act rotations                 ... depends on algorithm used
+
+  Note: SuperCI(PT) will ignore FreezeIE, FreezeAct and FreezeGrad. In general Default settings are encouraged.
+        In conjunction with ShiftUp, ShiftDn or GradScaling the performance of SuperCI(PT) is less optimal.  
+
+  MaxRot                            ... 2.00e-01 
+  Max. no of vectors (DIIS)         ... 15
+  DThresh (cut-off) metric          ... 1.00e-06
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... SuperCI(PT)    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  1.00e-12
+  Primitive cutoff TCut             ...  1.00e-14
+  Energy convergence tolerance      ...  1.00e-08
+  Orbital gradient convergence      ...  1.00e-05
+  Max. number of iterations         ...        75  
+
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Inactive Energy E0 = -13.60390405 Eh
+CI-ITERATION   0: 
+   -14.604424915   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  1 MULT= 1 NROOTS= 1  IRREP=Ag 
+ROOT   0:  E=     -14.6044249150 Eh
+      0.90756 [     0]: 2000
+      0.03081 [     3]: 0002
+      0.03081 [     2]: 0020
+      0.03081 [     1]: 0200
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -14.604424915 Eh DE=    0.000000e+00
+   --- Energy gap subspaces: Ext-Act = 0.065   Act-Int = 4.462
+   N(occ)=  1.81512 0.06163 0.06163 0.06163
+   ||g|| =     5.129342e-01 Max(G)=    3.483484e-01 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.342426993 Max(X)(8,2) =      0.195626819 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   2: 
+   --- Inactive Energy E0 = -13.61070860 Eh
+CI-ITERATION   0: 
+   -14.615891596   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.615891596 Eh DE=   -1.146668e-02
+   --- Energy gap subspaces: Ext-Act = 0.035   Act-Int = 4.444
+   N(occ)=  1.80034 0.06655 0.06655 0.06655
+   ||g|| =     4.643372e-02 Max(G)=    2.470462e-02 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.077239841 Max(X)(6,4) =      0.043853578 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   3: 
+   --- Inactive Energy E0 = -13.61017255 Eh
+CI-ITERATION   0: 
+   -14.616467015   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616467015 Eh DE=   -5.754194e-04
+   --- Energy gap subspaces: Ext-Act = 0.022   Act-Int = 4.437
+   N(occ)=  1.80346 0.06551 0.06551 0.06551
+   ||g|| =     1.014140e-02 Max(G)=    6.481003e-03 Rot=5,1
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.011058579 Max(X)(8,2) =      0.005760007 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   4: 
+   --- Inactive Energy E0 = -13.61008825 Eh
+CI-ITERATION   0: 
+   -14.616496888   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496888 Eh DE=   -2.987259e-05
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80382 0.06539 0.06539 0.06539
+   ||g|| =     7.646285e-04 Max(G)=   -4.120669e-04 Rot=5,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.001058992 Max(X)(8,2) =     -0.000448182 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   5: 
+   --- Inactive Energy E0 = -13.61009983 Eh
+CI-ITERATION   0: 
+   -14.616497002   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497002 Eh DE=   -1.136735e-07
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80373 0.06542 0.06542 0.06542
+   ||g|| =     2.485089e-04 Max(G)=    1.762019e-04 Rot=34,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.000276301 Max(X)(6,4) =      0.000144871 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=   -6.684029e-09
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =     1.606362e-05 Max(G)=   -1.169535e-05 Rot=14,1
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Forming Natural Orbitals
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=   -3.907985e-14
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =     1.604844e-05 Max(G)=    1.157495e-05 Rot=14,1
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -14.616497008 Eh    -397.7351 eV
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV)    Irrep 
+   0   2.0000      -4.711845      -128.2158    1-Ag
+   1   1.8038      -0.277797        -7.5592    2-Ag
+   2   0.0654       0.112653         3.0655    1-B3u
+   3   0.0654       0.112653         3.0655    1-B2u
+   4   0.0654       0.112653         3.0655    1-B1u
+   5   0.0000       0.127743         3.4761    3-Ag
+   6   0.0000       0.150920         4.1067    2-B1u
+   7   0.0000       0.150920         4.1067    2-B3u
+   8   0.0000       0.150920         4.1067    2-B2u
+   9   0.0000       0.274858         7.4793    1-B3g
+  10   0.0000       0.274858         7.4793    4-Ag
+  11   0.0000       0.274858         7.4793    1-B2g
+  12   0.0000       0.274858         7.4793    5-Ag
+  13   0.0000       0.274858         7.4793    1-B1g
+  14   0.0000       0.681115        18.5341    6-Ag
+  15   0.0000       0.767036        20.8721    3-B1u
+  16   0.0000       0.767036        20.8721    3-B3u
+  17   0.0000       0.767036        20.8721    3-B2u
+  18   0.0000       1.118724        30.4420    7-Ag
+  19   0.0000       1.118724        30.4420    8-Ag
+  20   0.0000       1.118724        30.4420    2-B2g
+  21   0.0000       1.118724        30.4420    2-B1g
+  22   0.0000       1.118724        30.4420    2-B3g
+  23   0.0000       1.176080        32.0028    4-B2u
+  24   0.0000       1.176080        32.0028    4-B1u
+  25   0.0000       1.176080        32.0028    4-B3u
+  26   0.0000       1.176080        32.0028    5-B1u
+  27   0.0000       1.176080        32.0028    1-Au
+  28   0.0000       1.176080        32.0028    5-B3u
+  29   0.0000       1.176080        32.0028    5-B2u
+  30   0.0000       3.007595        81.8408    9-Ag
+  31   0.0000      10.933785       297.5234    6-B1u
+  32   0.0000      10.933785       297.5234    6-B2u
+  33   0.0000      10.933785       297.5234    6-B3u
+  34   0.0000      11.951752       325.2237   10-Ag
+  35   0.0000      65.244448      1775.3917   11-Ag
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  1 MULT= 1 IRREP= Ag NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -14.6164970082 Eh
+      0.90188 [     0]: 2000
+      0.03271 [     2]: 0020
+      0.03271 [     3]: 0002
+      0.03271 [     1]: 0200
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                  0          1          2          3    
+      0       1.803752   0.000000   0.000000   0.000000
+      1       0.000000   0.065416   0.000000   0.000000
+      2       0.000000   0.000000   0.065416   0.000000
+      3       0.000000   0.000000   0.000000   0.065416
+Trace of the electron density:  2.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -19.082312356 Eh        -519.2561 eV
+Two electron energy          :      4.465815348 Eh         121.5210 eV
+Nuclear repulsion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -14.616497008
+
+Kinetic energy               :     14.616237925 Eh         397.7281 eV
+Potential energy             :    -29.232734934 Eh        -795.4632 eV
+Virial ratio                 :     -2.000017726 
+                               ----------------
+                                  -14.616497008
+
+Core energy                  :    -13.610095236 Eh     -370.3495 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+
+                      6         7         8         9        10        11   
+                   0.15092   0.15092   0.15092   0.27486   0.27486   0.27486
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be pz            100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be px              0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be py              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be dz2             0.0       0.0       0.0       0.0      50.8       0.0
+ 0 Be dxz             0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be dyz             0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be dx2y2           0.0       0.0       0.0       0.0      49.2       0.0
+
+                     12        13        14        15        16        17   
+                   0.27486   0.27486   0.68111   0.76704   0.76704   0.76704
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s               0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be pz              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be px              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be py              0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be dz2            49.2       0.0       0.0       0.0       0.0       0.0
+ 0 Be dx2y2          50.8       0.0       0.0       0.0       0.0       0.0
+ 0 Be dxy             0.0     100.0       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.11872   1.11872   1.11872   1.11872   1.11872   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be dz2            13.8      86.2       0.0       0.0       0.0       0.0
+ 0 Be dxz             0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be dyz             0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be dx2y2          86.2      13.8       0.0       0.0       0.0       0.0
+ 0 Be dxy             0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be f-1             0.0       0.0       0.0       0.0       0.0      99.1
+ 0 Be f-3             0.0       0.0       0.0       0.0       0.0       0.9
+
+                     24        25        26        27        28        29   
+                   1.17608   1.17608   1.17608   1.17608   1.17608   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be f0             19.2       0.0      80.8       0.0       0.0       0.0
+ 0 Be f+1             0.0      62.6       0.0       0.0      37.4       0.0
+ 0 Be f-1             0.0       0.0       0.0       0.0       0.0       0.9
+ 0 Be f+2            80.8       0.0      19.2       0.0       0.0       0.0
+ 0 Be f-2             0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be f+3             0.0      37.4       0.0       0.0      62.6       0.0
+ 0 Be f-3             0.0       0.0       0.0       0.0       0.0      99.1
+
+                     30        31        32        33        34        35   
+                   3.00760  10.93379  10.93379  10.93379  11.95175  65.24445
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0       0.0       0.0       0.0     100.0     100.0
+ 0 Be pz              0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be px              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be py              0.0       0.0     100.0       0.0       0.0       0.0
+
+
+----------------------------
+LOEWDIN REDUCED ACTIVE MOs  
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... casscf_beryllium_atom_sym.scfp
+BaseName (.gbw .S,...)              ... casscf_beryllium_atom_sym
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 Be:   -0.000000
+Sum of atomic charges:   -0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 Be:   -0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 Be     4.0000     4.0000    -0.0000     0.7336     0.0000     0.7336
+
+
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.093188947 (     0.093188947,     -0.000000000,      0.000000000)
+ MO   3:      0.093188947 (    -0.000000000,      0.093188947,     -0.000000000)
+ MO   4:      0.093188947 (     0.000000000,     -0.000000000,      0.093188947)
+MO   1:
+ MO   2:      1.461408146 (     1.461408146,     -0.000000000,     -0.000000000)
+ MO   3:      1.461408146 (    -0.000000000,      1.461408146,      0.000000000)
+ MO   4:      1.461408146 (    -0.000000000,      0.000000000,      1.461408146)
+MO   2:
+MO   3:
+MO   4:
+  newgto Be
+  0 15
+    1      29646.704407000001         0.000038108224
+    2       4428.761435400000         0.000297340321
+    3       1005.470133200000         0.001564016408
+    4        284.153395780000         0.006560712877
+    5         92.504356461000         0.023217340382
+    6         33.311016058000         0.069760422481
+    7         12.911553314000         0.170883257267
+    8          5.266549736100         0.318204229410
+    9         22.995386380000        -0.000026605258
+   10          6.623635417600        -0.000260226483
+   11          2.228959500300         0.379026890564
+   12          0.953024334500         0.186086635277
+   13          0.246516024400         0.006073817016
+   14          0.101538953100        -0.011158857110
+   15          0.041551374600        -0.001939619433
+  0 15
+    1      29646.704407000001         0.000006656465
+    2       4428.761435400000         0.000051937223
+    3       1005.470133200000         0.000273190897
+    4        284.153395780000         0.001145977130
+    5         92.504356461000         0.004055434462
+    6         33.311016058000         0.012185238136
+    7         12.911553314000         0.029848632065
+    8          5.266549736100         0.055581577253
+    9         22.995386380000         0.001088706138
+   10          6.623635417600         0.010648653488
+   11          2.228959500300         0.118828786580
+   12          0.953024334500         0.107283329766
+   13          0.246516024400        -0.284089778990
+   14          0.101538953100        -0.628004193847
+   15          0.041551374600        -0.214441958372
+  1 7
+    1         14.099789445000         0.004692441533
+    2          3.180318848200         0.029430526482
+    3          0.904892205000         0.119327406656
+    4          0.304115855100         0.359106958068
+    5          0.113026066600         0.606477568734
+    6          0.042831733700         0.037784957355
+    7          6.400000000000        -0.004717453594
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.005788 sec
+-------------------------------------------------------------
+
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+-------------------
+ABSORPTION SPECTRUM
+-------------------
+
+Center of mass           = (  0.0000,  0.0000,  0.0000)
+Nuclear contribution to the dipole moment =     0.000000,    0.000000,    0.000000 au
+
+Calculating the Dipole integrals                  ... done
+Transforming integrals                            ... done
+Calculating the Linear Momentum integrals         ... done
+Transforming integrals                            ... done
+Calculating the Angular Momentum integrals        ... done
+Transforming integrals                            ... done
+
+------------------------------------------------------------------------------
+                                 DIPOLE MOMENTS
+------------------------------------------------------------------------------
+  Root  Block           TX        TY        TZ           |T|
+                      (Debye)   (Debye)   (Debye)      (Debye)
+------------------------------------------------------------------------------
+    0    0           -0.00000  -0.00000   0.00000      0.00000
+
+--------------
+CASSCF TIMINGS
+--------------
+
+Total time                       ...        0.7 sec
+Sum of individual times          ...        0.5 sec ( 74.3%)
+
+Calculation of AO operators
+   F(Core) operator              ...        0.1 sec ( 16.6%)
+   G(Act) operator               ...        0.1 sec (  8.4%)
+   J(AO) operators               ...        0.0 sec (  0.0%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.3 sec ( 38.5%)
+   (pq|rs) integrals             ...        0.0 sec (  0.0%)
+   AO->MO one electron integrals ...        0.0 sec (  0.1%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  2.5%)
+   CI-solution phase             ...        0.1 sec (  7.1%)
+   Generation of densities       ...        0.0 sec (  0.0%)
+Orbital improvement steps
+   Orbital gradient              ...        0.0 sec (  0.1%)
+   O(1) converger                ...        0.0 sec (  0.2%)
+Properties                       ...        0.0 sec (  0.8%)
+   SOC integral calculation      ...        0.0 sec (  0.0%)
+   SSC RMEs (incl. integrals)    ...        0.0 sec (  0.0%)
+   SOC RMEs                      ...        0.0 sec (  0.0%)
+
+Maximum memory used throughout the entire CASSCF-calculation: 119.3 MB
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -14.616497008249
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... casscf_beryllium_atom_sym.gbw
+Electron density                                ... casscf_beryllium_atom_sym.scfp
+The origin for moment calculation is the CENTER OF MASS  = ( 0.000000,  0.000000  0.000000)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:     -0.00000      -0.00000       0.00000
+Nuclear contribution   :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :     -0.00000      -0.00000       0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:     0.000000     0.000000     0.000000 
+Rotational constants in MHz :     0.000000     0.000000     0.000000 
+
+ Dipole components along the rotational axes: 
+x,y,z [a.u.] :    -0.000000    -0.000000     0.000000 
+x,y,z [Debye]:    -0.000000    -0.000000     0.000000 
+
+ 
+
+Timings for individual modules:
+
+Sum of individual times         ...        3.826 sec (=   0.064 min)
+GTO integral calculation        ...        0.488 sec (=   0.008 min)  12.7 %
+SCF iterations                  ...        0.375 sec (=   0.006 min)   9.8 %
+CASSCF iterations               ...        2.964 sec (=   0.049 min)  77.5 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 3 seconds 945 msec

--- a/ORCA/ORCA6.0/casscf_beryllium_atom_nosym.in
+++ b/ORCA/ORCA6.0/casscf_beryllium_atom_nosym.in
@@ -1,0 +1,10 @@
+! def2-qzvpp verytightscf noautostart nousesym
+
+%casscf
+ nel 2
+ norb 4
+ end
+
+* xyz 0 1
+Be 0 0 0
+*

--- a/ORCA/ORCA6.0/casscf_beryllium_atom_nosym.out
+++ b/ORCA/ORCA6.0/casscf_beryllium_atom_nosym.out
@@ -1,0 +1,1168 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+                                            #,                                       
+                                            ###                                      
+                                            ####                                     
+                                            #####                                    
+                                            ######                                   
+                                           ########,                                 
+                                     ,,################,,,,,                         
+                               ,,#################################,,                 
+                          ,,##########################################,,             
+                       ,#########################################, ''#####,          
+                    ,#############################################,,   '####,        
+                  ,##################################################,,,,####,       
+                ,###########''''           ''''###############################       
+              ,#####''   ,,,,##########,,,,          '''####'''          '####       
+            ,##' ,,,,###########################,,,                        '##       
+           ' ,,###''''                  '''############,,,                           
+         ,,##''                                '''############,,,,        ,,,,,,###''
+      ,#''                                            '''#######################'''  
+     '                                                          ''''####''''         
+             ,#######,   #######,   ,#######,      ##                                
+            ,#'     '#,  ##    ##  ,#'     '#,    #''#        ,####,   ,####,        
+            ##       ##  ##   ,#'  ##            #'  '#       #'       #'  '#        
+            ##       ##  #######   ##           ,######,      #####,   #    #        
+            '#,     ,#'  ##    ##  '#,     ,#' ,#      #,     #,   #   #,  ,#        
+             '#######'   ##     ##  '#######'  #'      '#     '####' # '####'        
+
+
+
+                #########################################################
+                #                        -***-                          #
+                #          Department of theory and spectroscopy        #
+                #                                                       #
+                #                      Frank Neese                      #
+                #                                                       #
+                #     Directorship, Architecture, Infrastructure        #
+                #                    SHARK, DRIVERS                     #
+                #        Core code/Algorithms in most modules           #
+                #                                                       #
+                #        Max Planck Institute fuer Kohlenforschung      #
+                #                Kaiser Wilhelm Platz 1                 #
+                #                 D-45470 Muelheim/Ruhr                 #
+                #                      Germany                          #
+                #                                                       #
+                #                  All rights reserved                  #
+                #                        -***-                          #
+                #########################################################
+
+
+                         Program Version 6.0.0  -   RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2 properties, NMR spectrum
+   Ute Becker             : All parallelization in ORCA, NUMFREQ, NUMCALC
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : pre 5.0 version of the SCF Hessian
+   Marcos Casanova-Páez   : Triplet and SCS-CIS(D). UHF-(DLPNO)-IP/EA/STEOM-CCSD. UHF-CVS-IP/STEOM-CCSD
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Pauline Colinet        : FMM embedding
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Nicolas Foglia         : Exact transition moments, OPA infrastructure, MCD improvements
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM and meta-GGA Hessian, CCSD/C-PCM, Gaussian charge scheme
+   Tiago L. C. Gouveia    : GS-ROHF, GS-ROCIS
+   Yang Guo               : DLPNO-NEVPT2, F12-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Ingolf Harden          : AUTO-CI MPn and infrastructure 
+   Benjamin Helmich-Paris : MC-RPA, TRAH-(SCF,CASSCF), AVAS, COSX integrals, SCF dyn. polar.
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Riya Kayal             : Wick's Theorem for AUTO-CI, AUTO-CI UHF-CCSDT
+   Emily Kempfer          : AUTO-CI, RHF CISDT and CCSDT
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density, CASPT2, CASPT2-K, improved NEVPT2
+   Axel Koslowski         : Symmetry handling
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, (MP2 Hessian; deprecated post 5.0)
+   Lucas Lang             : DCDCAS
+   Marvin Lechner         : AUTO-CI (C++ implementation), FIC-MRCC
+   Spencer Leger          : CASSCF response
+   Dagmar Lenk            : GEPOL surface, SMD, ORCA-2-JSON
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes. LFT, Crystal Embedding
+   Dimitrios Pantazis     : SARC Basis sets
+   Anastasios Papadopoulos: AUTO-CI, single reference methods and gradients
+   Taras Petrenko         : pre 6.0 DFT Hessian and TD-DFT gradient, (ASA, deprecated), ECA, 1-Electron XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Kantharuban Sivalingam : CASSCF convergence/infrastructure, NEVPT2 and variants, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR, DLPNO-MP2 response, X2C
+   Van Anh Tran           : RI-MP2 g-tensors
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Zikuan Wang            : NOTCH, Electric field optimization 
+   Frank Wennmohs         : Technical directorship and infrastructure
+   Hang Xu                : AUTO-CI-Response properties 
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, P. Pracht,  : VdW corrections, initial TS optimization,
+                  C. Bannwarth, S. Ehlert,         DFT functionals, gCP, sTDA/sTD-DF
+                  L. Wittmann, M. Mueller
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Simon Mueller                                 : openCOSMO-RS
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, DLPNO-Multilevel, CI-OPT
+                                                   MM, QMMM, 2- and 3-layer-ONIOM, Crystal-QMMM,
+                                                   LR-CPCM, SF, NACMEs, symmetry and pop. for TD-DFT,
+                                                   nearIR, NL-DFT gradient (VV10), updates on ESD,
+                                                   ML-optimized integration grids, MBIS, APM,
+                                                   GOAT, DOCKER, SOLVATOR, interface openCOSMO-RS
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+   Liviu Ungur et al                             : ANISO software
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 6.2.2
+ For citations please refer to: https://libxc.gitlab.io
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+   Shared memory     :  Shared parallel matrices
+   BLAS/LAPACK       :  OpenBLAS 0.3.27  USE64BITINT DYNAMIC_ARCH NO_AFFINITY Zen SINGLE_THREADED
+        Core in use  :  Zen
+   Copyright (c) 2011-2014, The OpenBLAS Project
+
+
+================================================================================
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-QZVPP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = casscf_beryllium_atom_nosym.in
+|  1> ! def2-qzvpp verytightscf noautostart nousesym
+|  2> 
+|  3> %casscf
+|  4>  nel 2
+|  5>  norb 4
+|  6>  end
+|  7> 
+|  8> * xyz 0 1
+|  9> Be 0 0 0
+| 10> *
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  Be     0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 Be    4.0000    0     9.012    0.000000    0.000000    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type Be  : 15s7p2d1f contracted to 7s4p2d1f pattern {8211111/4111/11/1}
+
+Atom   0Be   basis set group =>   1
+------------------------------------------------------------------------------
+                             ORCA STARTUP CALCULATIONS
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...      1
+Number of basis functions                   ...     36
+Number of shells                            ...     14
+Maximum angular momentum                    ...      3
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 1.000e-12
+   Tcut                                     ... 1.000e-14
+   Tpresel                                  ... 1.000e-14 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... NOT available
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 14
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   1.0e-14
+Total number of shell pairs                 ...       105
+Shell pairs after pre-screening             ...       105
+Total number of primitive shell pairs       ...       360
+Primitive shell pairs kept                  ...       360
+          la=0 lb=0:     28 shell pairs
+          la=1 lb=0:     28 shell pairs
+          la=1 lb=1:     10 shell pairs
+          la=2 lb=0:     14 shell pairs
+          la=2 lb=1:      8 shell pairs
+          la=2 lb=2:      3 shell pairs
+          la=3 lb=0:      7 shell pairs
+          la=3 lb=1:      4 shell pairs
+          la=3 lb=2:      2 shell pairs
+          la=3 lb=3:      1 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=      0.000000000000 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 6.741e-03
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Total time needed                          ...    0.001 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-12
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+
+Total number of grid points                  ...     6136
+Total number of batches                      ...       96
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     6136
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.1 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.9 MB
+-------------------------------------------------------------------------------
+                                 ORCA GUESS
+                   Start orbitals & Density for SCF / CASSCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... casscf_beryllium_atom_nosym
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   36
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Initializing the effective Hamiltonian             ... done
+Setting up the integral package (SHARK)            ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Making the grid                                    ... done (   0.0 sec)
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.0 sec)
+                      ------------------
+             **** ENERGY FILE WAS UPDATED (casscf_beryllium_atom_nosym.en.tmp) ****
+Finished Guess after   0.0 sec
+Maximum memory used throughout the entire GUESS-calculation: 5.6 MB
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Setting up the integral package     ... Building the CAS space              ... done (10 configurations for Mult=1)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    2
+Number of active orbitals           ...    4
+Total number of electrons           ...    4
+Total number of orbitals            ...   36
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   35 (  31 orbitals)
+Number of rotation parameters      ...    159
+
+CI-STEP:
+CI strategy                         ... General CI
+Number of multiplicity blocks       ...    1
+BLOCK  0 WEIGHT=   1.0000
+  Multiplicity                      ...    1
+  #(Configurations)                 ...   10
+  #(CSFs)                           ...   10
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+  N(GuessMat)                       ...      2048
+  MaxDim(CI)                        ...        10
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  1.00e-09
+  Residual Tolerance CI             ...  1.00e-09
+  Shift(CI)                         ...  1.00e-04
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI(PT)
+  Default Parametrization           ... CAYLEY
+  Act-Act rotations                 ... depends on algorithm used
+
+  Note: SuperCI(PT) will ignore FreezeIE, FreezeAct and FreezeGrad. In general Default settings are encouraged.
+        In conjunction with ShiftUp, ShiftDn or GradScaling the performance of SuperCI(PT) is less optimal.  
+
+  MaxRot                            ... 2.00e-01 
+  Max. no of vectors (DIIS)         ... 15
+  DThresh (cut-off) metric          ... 1.00e-06
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... SuperCI(PT)    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  1.00e-12
+  Primitive cutoff TCut             ...  1.00e-14
+  Energy convergence tolerance      ...  1.00e-08
+  Orbital gradient convergence      ...  1.00e-05
+  Max. number of iterations         ...        75  
+
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Inactive Energy E0 = -13.60390405 Eh
+CI-ITERATION   0: 
+   -14.604424915   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  0 MULT= 1 NROOTS= 1 
+ROOT   0:  E=     -14.6044249150 Eh
+      0.90756 [     0]: 2000
+      0.03081 [     7]: 0020
+      0.03081 [     4]: 0200
+      0.03081 [     9]: 0002
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -14.604424915 Eh DE=    0.000000e+00
+   --- Energy gap subspaces: Ext-Act = 0.065   Act-Int = 4.462
+   N(occ)=  1.81512 0.06163 0.06163 0.06163
+   ||g|| =     5.129342e-01 Max(G)=    3.483484e-01 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.342426993 Max(X)(6,3) =     -0.182338003 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   2: 
+   --- Inactive Energy E0 = -13.61070860 Eh
+CI-ITERATION   0: 
+   -14.615891596   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.615891596 Eh DE=   -1.146668e-02
+   --- Energy gap subspaces: Ext-Act = 0.035   Act-Int = 4.444
+   N(occ)=  1.80034 0.06655 0.06655 0.06655
+   ||g|| =     4.643372e-02 Max(G)=    2.470462e-02 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.077239841 Max(X)(8,3) =     -0.035314357 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   3: 
+   --- Inactive Energy E0 = -13.61017255 Eh
+CI-ITERATION   0: 
+   -14.616467015   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616467015 Eh DE=   -5.754194e-04
+   --- Energy gap subspaces: Ext-Act = 0.022   Act-Int = 4.437
+   N(occ)=  1.80346 0.06551 0.06551 0.06551
+   ||g|| =     1.014140e-02 Max(G)=    6.481003e-03 Rot=5,1
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.011058579 Max(X)(7,2) =     -0.004167157 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   4: 
+   --- Inactive Energy E0 = -13.61008825 Eh
+CI-ITERATION   0: 
+   -14.616496888   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496888 Eh DE=   -2.987259e-05
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80382 0.06539 0.06539 0.06539
+   ||g|| =     7.646285e-04 Max(G)=   -4.120669e-04 Rot=5,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.001058992 Max(X)(7,3) =     -0.000335998 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   5: 
+   --- Inactive Energy E0 = -13.61009983 Eh
+CI-ITERATION   0: 
+   -14.616497002   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497002 Eh DE=   -1.136735e-07
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80373 0.06542 0.06542 0.06542
+   ||g|| =     2.485089e-04 Max(G)=    1.762019e-04 Rot=34,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.000276301 Max(X)(8,3) =      0.000129868 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=   -6.684045e-09
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =     1.606362e-05 Max(G)=    1.169535e-05 Rot=14,1
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=   -8.881784e-15
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =     1.606362e-05 Max(G)=   -1.157495e-05 Rot=14,1
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -14.616497008 Eh    -397.7351 eV
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000      -4.711845      -128.2158 
+   1   1.8038      -0.277797        -7.5592 
+   2   0.0654       0.112653         3.0655 
+   3   0.0654       0.112653         3.0655 
+   4   0.0654       0.112653         3.0655 
+   5   0.0000       0.127743         3.4761 
+   6   0.0000       0.150920         4.1067 
+   7   0.0000       0.150920         4.1067 
+   8   0.0000       0.150920         4.1067 
+   9   0.0000       0.274858         7.4793 
+  10   0.0000       0.274858         7.4793 
+  11   0.0000       0.274858         7.4793 
+  12   0.0000       0.274858         7.4793 
+  13   0.0000       0.274858         7.4793 
+  14   0.0000       0.681115        18.5341 
+  15   0.0000       0.767036        20.8721 
+  16   0.0000       0.767036        20.8721 
+  17   0.0000       0.767036        20.8721 
+  18   0.0000       1.118724        30.4420 
+  19   0.0000       1.118724        30.4420 
+  20   0.0000       1.118724        30.4420 
+  21   0.0000       1.118724        30.4420 
+  22   0.0000       1.118724        30.4420 
+  23   0.0000       1.176080        32.0028 
+  24   0.0000       1.176080        32.0028 
+  25   0.0000       1.176080        32.0028 
+  26   0.0000       1.176080        32.0028 
+  27   0.0000       1.176080        32.0028 
+  28   0.0000       1.176080        32.0028 
+  29   0.0000       1.176080        32.0028 
+  30   0.0000       3.007595        81.8408 
+  31   0.0000      10.933785       297.5234 
+  32   0.0000      10.933785       297.5234 
+  33   0.0000      10.933785       297.5234 
+  34   0.0000      11.951752       325.2237 
+  35   0.0000      65.244448      1775.3917 
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  0 MULT= 1 NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -14.6164970082 Eh
+      0.90188 [     0]: 2000
+      0.03271 [     9]: 0002
+      0.03271 [     7]: 0020
+      0.03271 [     4]: 0200
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                  0          1          2          3    
+      0       1.803752  -0.000000   0.000000   0.000000
+      1      -0.000000   0.065416  -0.000000   0.000000
+      2       0.000000  -0.000000   0.065416  -0.000000
+      3       0.000000   0.000000  -0.000000   0.065416
+Trace of the electron density:  2.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -19.082312356 Eh        -519.2561 eV
+Two electron energy          :      4.465815348 Eh         121.5210 eV
+Nuclear repulsion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -14.616497008
+
+Kinetic energy               :     14.616237925 Eh         397.7281 eV
+Potential energy             :    -29.232734934 Eh        -795.4632 eV
+Virial ratio                 :     -2.000017726 
+                               ----------------
+                                  -14.616497008
+
+Core energy                  :    -13.610095236 Eh     -370.3495 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0      29.5      65.8       4.7       0.0
+ 0 Be px              0.0       0.0       0.3       5.0      94.7       0.0
+ 0 Be py              0.0       0.0      70.2      29.2       0.6       0.0
+
+                      6         7         8         9        10        11   
+                   0.15092   0.15092   0.15092   0.27486   0.27486   0.27486
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be pz              4.3      64.9      30.7       0.0       0.0       0.0
+ 0 Be px             49.1       7.4      43.4       0.0       0.0       0.0
+ 0 Be py             46.5      27.6      25.8       0.0       0.0       0.0
+ 0 Be dz2             0.0       0.0       0.0      25.3       3.9      16.2
+ 0 Be dxz             0.0       0.0       0.0      34.5      26.1       6.9
+ 0 Be dyz             0.0       0.0       0.0      34.4      61.3       0.0
+ 0 Be dx2y2           0.0       0.0       0.0       4.2       1.8      41.4
+ 0 Be dxy             0.0       0.0       0.0       1.5       6.9      35.4
+
+                     12        13        14        15        16        17   
+                   0.27486   0.27486   0.68111   0.76704   0.76704   0.76704
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s               0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be pz              0.0       0.0       0.0      84.4       0.2      15.4
+ 0 Be px              0.0       0.0       0.0       8.7      54.4      37.0
+ 0 Be py              0.0       0.0       0.0       6.9      45.5      47.6
+ 0 Be dz2            50.3       4.3       0.0       0.0       0.0       0.0
+ 0 Be dxz            24.3       8.1       0.0       0.0       0.0       0.0
+ 0 Be dyz             3.2       1.0       0.0       0.0       0.0       0.0
+ 0 Be dx2y2          13.4      39.1       0.0       0.0       0.0       0.0
+ 0 Be dxy             8.8      47.4       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.11872   1.11872   1.11872   1.11872   1.11872   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be dz2            12.3       1.9      11.2      68.1       6.5       0.0
+ 0 Be dxz            66.1       7.5       6.4       2.6      17.4       0.0
+ 0 Be dyz             7.5      85.1       5.7       1.7       0.0       0.0
+ 0 Be dx2y2           1.2       4.1      38.3       0.4      56.0       0.0
+ 0 Be dxy            12.8       1.4      38.5      27.3      20.0       0.0
+ 0 Be f+1             0.0       0.0       0.0       0.0       0.0      60.6
+ 0 Be f-1             0.0       0.0       0.0       0.0       0.0       0.6
+ 0 Be f+2             0.0       0.0       0.0       0.0       0.0       0.4
+ 0 Be f-2             0.0       0.0       0.0       0.0       0.0       0.9
+ 0 Be f+3             0.0       0.0       0.0       0.0       0.0      36.5
+ 0 Be f-3             0.0       0.0       0.0       0.0       0.0       1.0
+
+                     24        25        26        27        28        29   
+                   1.17608   1.17608   1.17608   1.17608   1.17608   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be f0              6.8      18.0      39.2      23.3       8.2       4.4
+ 0 Be f+1            19.2       2.6       3.4       2.2       6.3       5.7
+ 0 Be f-1             0.5      10.6       0.2      17.8      51.3      19.0
+ 0 Be f+2            34.9      23.5      12.5       0.9      13.3      14.6
+ 0 Be f-2             5.9       5.1      44.2      21.1       9.7      13.1
+ 0 Be f+3            32.5      16.0       0.4       1.1       6.9       6.6
+ 0 Be f-3             0.2      24.2       0.1      33.6       4.4      36.7
+
+                     30        31        32        33        34        35   
+                   3.00760  10.93379  10.93379  10.93379  11.95175  65.24445
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0       0.0       0.0       0.0     100.0     100.0
+ 0 Be pz              0.0      93.8       2.1       4.2       0.0       0.0
+ 0 Be px              0.0       4.4       0.0      95.6       0.0       0.0
+ 0 Be py              0.0       1.9      97.9       0.2       0.0       0.0
+
+
+----------------------------
+LOEWDIN REDUCED ACTIVE MOs  
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0      29.5      65.8       4.7       0.0
+ 0 Be px              0.0       0.0       0.3       5.0      94.7       0.0
+ 0 Be py              0.0       0.0      70.2      29.2       0.6       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... casscf_beryllium_atom_nosym.scfp
+BaseName (.gbw .S,...)              ... casscf_beryllium_atom_nosym
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 Be:   -0.000000
+Sum of atomic charges:   -0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 Be:    0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 Be     4.0000     4.0000    -0.0000     0.7336     0.0000     0.7336
+
+  => No bond orders to print
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.093188947 (    -0.005223249,     -0.078065689,      0.050622581)
+ MO   3:      0.093188947 (     0.020823927,     -0.050396946,     -0.075569118)
+ MO   4:      0.093188947 (     0.090682201,      0.007076425,      0.020269250)
+MO   1:
+ MO   2:      1.461408146 (     0.081912061,      1.224242120,     -0.793873677)
+ MO   3:      1.461408146 (    -0.326565088,      0.790335235,      1.185090388)
+ MO   4:      1.461408146 (    -1.422096841,     -0.110973948,     -0.317866522)
+MO   2:
+MO   3:
+MO   4:
+  newgto Be
+  0 15
+    1      29646.704407000001         0.000038108224
+    2       4428.761435400000         0.000297340321
+    3       1005.470133200000         0.001564016408
+    4        284.153395780000         0.006560712877
+    5         92.504356461000         0.023217340382
+    6         33.311016058000         0.069760422481
+    7         12.911553314000         0.170883257267
+    8          5.266549736100         0.318204229410
+    9         22.995386380000        -0.000026605258
+   10          6.623635417600        -0.000260226483
+   11          2.228959500300         0.379026890564
+   12          0.953024334500         0.186086635277
+   13          0.246516024400         0.006073817016
+   14          0.101538953100        -0.011158857110
+   15          0.041551374600        -0.001939619433
+  0 15
+    1      29646.704407000001         0.000006656465
+    2       4428.761435400000         0.000051937223
+    3       1005.470133200000         0.000273190897
+    4        284.153395780000         0.001145977130
+    5         92.504356461000         0.004055434462
+    6         33.311016058000         0.012185238136
+    7         12.911553314000         0.029848632065
+    8          5.266549736100         0.055581577253
+    9         22.995386380000         0.001088706138
+   10          6.623635417600         0.010648653488
+   11          2.228959500300         0.118828786580
+   12          0.953024334500         0.107283329766
+   13          0.246516024400        -0.284089778990
+   14          0.101538953100        -0.628004193847
+   15          0.041551374600        -0.214441958372
+  1 7
+    1         14.099789445000         0.004692441533
+    2          3.180318848200         0.029430526482
+    3          0.904892205000         0.119327406656
+    4          0.304115855100         0.359106958068
+    5          0.113026066600         0.606477568734
+    6          0.042831733700         0.037784957355
+    7          6.400000000000        -0.004717453594
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.0 sec
+-------------------------------------------------------------
+Memory for address arrays  		      ... done
+Make address arrays			      ... done
+Memory for buffers 			      ... done
+Setting up spin-function prototypes	      ... (MAXOPEN=2) 0 2 4 done
+Trivial cases - DOMO's			      ... done (  0.0 MB)
+Number of open shells			    ...  0
+domo->virtual excitations			... done (  0.0 MB)
+domo->somo excitations				... done (  0.0 MB)
+somo->virtual excitations			... done (  0.0 MB)
+somo->somo excitations				... done (  0.0 MB)
+Number of open shells			    ...  2
+domo->virtual excitations			... done (  0.0 MB)
+domo->somo excitations				... done (  0.0 MB)
+somo->virtual excitations			... done (  0.0 MB)
+somo->somo excitations				... done (  0.0 MB)
+Coupling container construction done
+
+--------------
+CASSCF TIMINGS
+--------------
+
+Total time                       ...        0.2 sec
+Sum of individual times          ...        0.2 sec ( 77.6%)
+
+Calculation of AO operators
+   F(Core) operator              ...        0.0 sec ( 12.8%)
+   G(Act) operator               ...        0.0 sec ( 20.1%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.1 sec ( 38.8%)
+   AO->MO one electron integrals ...        0.0 sec (  0.1%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  0.6%)
+   CI-solution phase             ...        0.0 sec (  4.1%)
+   Generation of densities       ...        0.0 sec (  0.1%)
+Orbital improvement steps
+   Orbital gradient              ...        0.0 sec (  0.3%)
+   O(1) converger                ...        0.0 sec (  0.4%)
+CPCM steps
+   Total CPCM time               ...        0.0 sec (  0.2%)
+Properties                       ...        0.0 sec (  0.1%)
+   SOC integral calculation      ...        0.0 sec (  0.0%)
+   SSC RMEs (incl. integrals)    ...        0.0 sec (  0.0%)
+   SOC RMEs                      ...        0.0 sec (  0.0%)
+
+Maximum memory used throughout the entire CASSCF-calculation: 37.8 MB
+
+------------------------------------------------------------------------------
+                         ORCA PROPERTY INTEGRAL CALCULATIONS
+------------------------------------------------------------------------------
+
+GBWName                                   ... casscf_beryllium_atom_nosym.gbw
+Number of atoms                           ...      1
+Number of basis functions                 ...     36
+Max core memory                           ...   1024 MB
+
+Dipole integrals                          ... YES
+Quadrupole integrals                      ...  NO
+Linear momentum integrals                 ...  NO
+Angular momentum integrals                ... YES
+Higher moments length integrals           ...  NO
+Higher moments velocity integrals         ...  NO
+Kinetic energy integrals                  ...  NO
+GIAO right hand sides                     ...  NO
+GIAO dipole derivative integrals          ...  NO
+SOC integrals                             ...  NO
+EPR diamagnetic integrals (GIAO)          ...  NO
+EPR gauge integrals                       ...  NO
+Field gradient integrals                  ...  NO (   0 nuclei)
+Spin-dipole/Fermi contact integrals       ...  NO (   0 nuclei)
+Contact density integrals                 ...  NO (   0 nuclei)
+Nucleus-orbit integrals                   ...  NO (   0 nuclei)
+Geometric perturbations                   ...  NO (   1 nuclei)
+
+Choice of electric origin   ... Center of mass
+Position of electric origin ... (  0.0000,  0.0000,  0.0000) 
+Choice of magnetic origin   ... GIAO
+Position of magnetic origin ... (  0.0000,  0.0000,  0.0000) 
+
+Calculating integrals                     ... Electric Dipole (Length)     done (  0.0 sec)
+Calculating integrals                     ... Angular Momentum  (ElOri)    done (  0.0 sec)
+
+Property integrals calculated in   0.0 sec
+
+Maximum memory used throughout the entire PROPINT-calculation: 5.7 MB
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Setting up the integral package     ... done
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+Calculating Transition_Moments                                   ... 
+
+--------------
+CASSCF TIMINGS
+--------------
+
+Total time                       ...        0.0 sec
+Sum of individual times          ...        0.0 sec ( 98.5%)
+
+Calculation of AO operators
+Calculation of MO transformed quantities
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec ( 98.5%)
+Orbital improvement steps
+Properties                       ...        0.0 sec (  0.0%)
+   SOC integral calculation      ...        0.0 sec (  0.0%)
+   SSC RMEs (incl. integrals)    ...        0.0 sec (  0.0%)
+   SOC RMEs                      ...        0.0 sec (  0.0%)
+
+Maximum memory used throughout the entire CASSCF-calculation: 25.3 MB
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -14.616497008249
+-------------------------   --------------------
+
+
+------------------------------------------------------------------------------
+                              ORCA PROPERTY CALCULATIONS
+------------------------------------------------------------------------------
+
+GBWName                                 ... casscf_beryllium_atom_nosym.gbw
+Number of atoms                         ...      1
+Number of basis functions               ...     36
+Max core memory                         ...   1024 MB
+
+Electric properties:
+Dipole moment                           ... YES
+Quadrupole moment                       ...  NO
+Static polarizability (Dipole/Dipole)   ...  NO
+Static polarizability (Dipole/Quad.)    ...  NO
+Static polarizability (Quad./Quad.)     ...  NO
+Static polarizability (Velocity)        ...  NO
+
+Atomic electric properties:
+Dipole moment                           ...  NO
+Quadrupole moment                       ...  NO
+Static polarizability                   ...  NO
+
+Choice of electric origin               ... Center of mass
+Position of electric origin             ...     0.000000     0.000000     0.000000
+
+General magnetic properties:
+Magnetizability                         ...  NO
+
+EPR properties:
+g-Tensor (aka g-matrix)                 ...  NO
+Zero-Field splitting spin-orbit         ...  NO
+Zero-field splitting spin-spin          ...  NO
+Hyperfine couplings                     ...  NO (   0 nuclei)
+Quadrupole couplings                    ...  NO (   0 nuclei)
+Contact density                         ...  NO (   0 nuclei)
+
+NMR properties:
+Chemical shifts                         ...  NO (   0 nuclei)
+Spin-rotation constants                 ...  NO (   0 nuclei)
+Spin-spin couplings                     ...  NO (   0 nuclei,    0 pairs)
+
+Choice of magnetic origin               ... GIAO
+Position of magnetic origin             ...     0.000000     0.000000     0.000000
+
+Properties with geometric perturbations:
+SCF Hessian                             ...  NO
+IR spectrum                             ...  NO
+VCD spectrum                            ...  NO
+X-ray spectroscopy properties:
+SCF XES/XAS/RIXS spectra                ...  NO
+
+
+-------------
+DIPOLE MOMENT
+-------------
+
+Method             : CASSCF
+Type of density    : Electron Density
+Level              : Relaxed density
+State              :   0
+Multiplicity       :   1
+Irrep              :   0
+Energy             :   -14.6164970082491283 Eh
+Relativity type    : 
+Basis              : AO
+                                X                 Y                 Z
+Electronic contribution:      0.000000000      -0.000000000      -0.000000000
+Nuclear contribution   :      0.000000000       0.000000000       0.000000000
+                        -----------------------------------------
+Total Dipole Moment    :      0.000000000      -0.000000000      -0.000000000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.000000000
+Magnitude (Debye)      :      0.000000000
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:             0.000000             0.000000             0.000000 
+Rotational constants in MHz :             0.000000             0.000000             0.000000 
+
+Dipole components along the rotational axes: 
+x,y,z [a.u.] :     0.000000    -0.000000    -0.000000 
+x,y,z [Debye]:     0.000000    -0.000000    -0.000000 
+
+ 
+
+Dipole moment calculation done in   0.0 sec 
+
+Maximum memory used throughout the entire PROP-calculation: 2.3 MB
+
+--------------------------------
+SUGGESTED CITATIONS FOR THIS RUN
+--------------------------------
+
+Below you find a list of papers that are relevant to this ORCA run
+We neither can nor want to force you to cite these papers, but we appreciate if you do
+You receive ORCA, which is the product of decades of hard work by many enthusiastic individuals, for free
+The only thing we kindly ask in return is that you cite our papers,
+We deeply appreciate it, if you show your appreciation for ORCA by not just citing the generic ORCA reference.
+
+Please note that relegating all ORCA citations to the supporting information does *not* help us.
+SI sections are not indexed - citations you put there will not count into any citation statistics
+But we need these citations in order to attract the funding resources that allow us to do what we are doing
+
+Therefore, if you are a happy ORCA user, please consider citing a few of the papers listed below in the main body of your paper
+
+In addition to the list printed below, the program has created the file casscf_beryllium_atom_nosym.bibtex that contains the list in bibtex format
+You can import this file easily into all common literature databanks and citation aid programs
+
+
+List of essential papers. We consider these as the minimum necessary citations
+
+  1. Neese,F.
+     Software update: the ORCA program system, version 5.0
+     WIRES Comput. Molec. Sci., 2022 12(1)e1606
+     doi.org/10.1002/wcms.1606
+
+List of papers to cite with high priority. The work reported in these papers was absolutely
+necessary for this run to complete.
+Our perspective: the developers of density functionals and basis sets usually get cited in chemistry papers
+Good! But without the algorithms to do something with them, the functionals or basis sets would not do anything.
+Hence, in our opinion, the algorithm design and method developments papers are equally worthy of getting cited
+
+  1. Kollmar,C.; Sivalingam,K.; Helmich-Paris,B.; Angeli,C.; Neese,F.
+     A perturbation-based super-CI approach for the orbital optimization of a CASSCF wave function
+     J. Comput. Chem., 2019 40 1463-1470
+     doi.org/10.1002/jcc.25801
+  2. Neese,F.
+     The SHARK Integral Generation and Digestion System
+     J. Comp. Chem., 2022  1-16
+     doi.org/10.1002/jcc.26942
+  3. Ugandi,M.; Roemelt,M.
+     A recursive formulation of one-electron coupling coefficients for spin-adapted configuration interaction calculations featuring many unpaired electrons
+     Int. J. Quantum Chem., 2023 123 e27045
+     doi.org/10.1002/qua.27045
+
+List of suggested additional citations. These are papers that are important in the 'surrounding' of 
+of this run, or papers that preceded the highly important papers. If you like your results we are grateful for a citation.
+
+  1. Neese,F.
+     The ORCA program system
+     WIRES Comput. Molec. Sci., 2012 2(1)73-78
+     doi.org/10.1002/wcms.81
+  2. Neese,F.
+     Software update: the ORCA program system, version 4.0
+     WIRES Comput. Molec. Sci., 2018 8(1)1-6
+     doi.org/10.1002/wcms.1327
+  3. Neese,F.; Wennmohs,F.; Becker,U.; Riplinger,C.
+     The ORCA quantum chemistry program package
+     J. Chem. Phys., 2020 152 Art. No. L224108
+     doi.org/10.1063/5.0004608
+
+List of optional additional citations
+
+  1. Neese,F.
+     Approximate second-order SCF convergence for spin unrestricted wavefunctions
+     Chem. Phys. Lett., 2000 325(1-3)93-98
+     doi.org/10.1016/s0009-2614(00)00662-x
+
+Timings for individual modules:
+
+Sum of individual times          ...        0.556 sec (=   0.009 min)
+Startup calculation              ...        0.083 sec (=   0.001 min)  14.8 %
+SCF iterations                   ...        0.056 sec (=   0.001 min)  10.0 %
+CASSCF iterations                ...        0.345 sec (=   0.006 min)  62.1 %
+Property integrals               ...        0.038 sec (=   0.001 min)   6.8 %
+Property calculations            ...        0.035 sec (=   0.001 min)   6.3 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 0 seconds 615 msec

--- a/ORCA/ORCA6.0/casscf_beryllium_atom_sym.in
+++ b/ORCA/ORCA6.0/casscf_beryllium_atom_sym.in
@@ -1,0 +1,10 @@
+! def2-qzvpp verytightscf noautostart usesym
+
+%casscf
+ nel 2
+ norb 4
+ end
+
+* xyz 0 1
+Be 0 0 0
+*

--- a/ORCA/ORCA6.0/casscf_beryllium_atom_sym.out
+++ b/ORCA/ORCA6.0/casscf_beryllium_atom_sym.out
@@ -1,0 +1,1232 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+                                            #,                                       
+                                            ###                                      
+                                            ####                                     
+                                            #####                                    
+                                            ######                                   
+                                           ########,                                 
+                                     ,,################,,,,,                         
+                               ,,#################################,,                 
+                          ,,##########################################,,             
+                       ,#########################################, ''#####,          
+                    ,#############################################,,   '####,        
+                  ,##################################################,,,,####,       
+                ,###########''''           ''''###############################       
+              ,#####''   ,,,,##########,,,,          '''####'''          '####       
+            ,##' ,,,,###########################,,,                        '##       
+           ' ,,###''''                  '''############,,,                           
+         ,,##''                                '''############,,,,        ,,,,,,###''
+      ,#''                                            '''#######################'''  
+     '                                                          ''''####''''         
+             ,#######,   #######,   ,#######,      ##                                
+            ,#'     '#,  ##    ##  ,#'     '#,    #''#        ,####,   ,####,        
+            ##       ##  ##   ,#'  ##            #'  '#       #'       #'  '#        
+            ##       ##  #######   ##           ,######,      #####,   #    #        
+            '#,     ,#'  ##    ##  '#,     ,#' ,#      #,     #,   #   #,  ,#        
+             '#######'   ##     ##  '#######'  #'      '#     '####' # '####'        
+
+
+
+                #########################################################
+                #                        -***-                          #
+                #          Department of theory and spectroscopy        #
+                #                                                       #
+                #                      Frank Neese                      #
+                #                                                       #
+                #     Directorship, Architecture, Infrastructure        #
+                #                    SHARK, DRIVERS                     #
+                #        Core code/Algorithms in most modules           #
+                #                                                       #
+                #        Max Planck Institute fuer Kohlenforschung      #
+                #                Kaiser Wilhelm Platz 1                 #
+                #                 D-45470 Muelheim/Ruhr                 #
+                #                      Germany                          #
+                #                                                       #
+                #                  All rights reserved                  #
+                #                        -***-                          #
+                #########################################################
+
+
+                         Program Version 6.0.0  -   RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2 properties, NMR spectrum
+   Ute Becker             : All parallelization in ORCA, NUMFREQ, NUMCALC
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : pre 5.0 version of the SCF Hessian
+   Marcos Casanova-Páez   : Triplet and SCS-CIS(D). UHF-(DLPNO)-IP/EA/STEOM-CCSD. UHF-CVS-IP/STEOM-CCSD
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Pauline Colinet        : FMM embedding
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Nicolas Foglia         : Exact transition moments, OPA infrastructure, MCD improvements
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM and meta-GGA Hessian, CCSD/C-PCM, Gaussian charge scheme
+   Tiago L. C. Gouveia    : GS-ROHF, GS-ROCIS
+   Yang Guo               : DLPNO-NEVPT2, F12-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Ingolf Harden          : AUTO-CI MPn and infrastructure 
+   Benjamin Helmich-Paris : MC-RPA, TRAH-(SCF,CASSCF), AVAS, COSX integrals, SCF dyn. polar.
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Riya Kayal             : Wick's Theorem for AUTO-CI, AUTO-CI UHF-CCSDT
+   Emily Kempfer          : AUTO-CI, RHF CISDT and CCSDT
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density, CASPT2, CASPT2-K, improved NEVPT2
+   Axel Koslowski         : Symmetry handling
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, (MP2 Hessian; deprecated post 5.0)
+   Lucas Lang             : DCDCAS
+   Marvin Lechner         : AUTO-CI (C++ implementation), FIC-MRCC
+   Spencer Leger          : CASSCF response
+   Dagmar Lenk            : GEPOL surface, SMD, ORCA-2-JSON
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes. LFT, Crystal Embedding
+   Dimitrios Pantazis     : SARC Basis sets
+   Anastasios Papadopoulos: AUTO-CI, single reference methods and gradients
+   Taras Petrenko         : pre 6.0 DFT Hessian and TD-DFT gradient, (ASA, deprecated), ECA, 1-Electron XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Kantharuban Sivalingam : CASSCF convergence/infrastructure, NEVPT2 and variants, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR, DLPNO-MP2 response, X2C
+   Van Anh Tran           : RI-MP2 g-tensors
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Zikuan Wang            : NOTCH, Electric field optimization 
+   Frank Wennmohs         : Technical directorship and infrastructure
+   Hang Xu                : AUTO-CI-Response properties 
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, P. Pracht,  : VdW corrections, initial TS optimization,
+                  C. Bannwarth, S. Ehlert,         DFT functionals, gCP, sTDA/sTD-DF
+                  L. Wittmann, M. Mueller
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Simon Mueller                                 : openCOSMO-RS
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, DLPNO-Multilevel, CI-OPT
+                                                   MM, QMMM, 2- and 3-layer-ONIOM, Crystal-QMMM,
+                                                   LR-CPCM, SF, NACMEs, symmetry and pop. for TD-DFT,
+                                                   nearIR, NL-DFT gradient (VV10), updates on ESD,
+                                                   ML-optimized integration grids, MBIS, APM,
+                                                   GOAT, DOCKER, SOLVATOR, interface openCOSMO-RS
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+   Liviu Ungur et al                             : ANISO software
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 6.2.2
+ For citations please refer to: https://libxc.gitlab.io
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+   Shared memory     :  Shared parallel matrices
+   BLAS/LAPACK       :  OpenBLAS 0.3.27  USE64BITINT DYNAMIC_ARCH NO_AFFINITY Zen SINGLE_THREADED
+        Core in use  :  Zen
+   Copyright (c) 2011-2014, The OpenBLAS Project
+
+
+================================================================================
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: def2-QZVPP
+   F. Weigend and R. Ahlrichs, Phys. Chem. Chem. Phys. 7, 3297 (2005).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = casscf_beryllium_atom_sym.in
+|  1> ! def2-qzvpp verytightscf noautostart usesym
+|  2> 
+|  3> %casscf
+|  4>  nel 2
+|  5>  norb 4
+|  6>  end
+|  7> 
+|  8> * xyz 0 1
+|  9> Be 0 0 0
+| 10> *
+| 11> 
+| 12>                          ****END OF INPUT****
+================================================================================
+-----------------------
+SYMMETRY HANDLING SETUP
+-----------------------
+The Z matrix contains a single non-dummy atom.
+Auto-detected point group .... Kh
+Reduced point group       .... D2h
+Root mean square distance .... 0.000000000000000 au
+Maximum distance          .... 0.000000000000000 au
+Threshold in use          .... 0.000100000000000 au
+Time for symmetry setup   .... 0.000 s
+
+
+Symmetry-perfected Cartesians for point group Kh:
+
+Index  Symbol         Symmetry-perfected Cartesians (x, y, z; au)
+   0     Be     0.000000000000000   0.000000000000000   0.000000000000000
+
+Index  Symbol         Symmetry-perfected Cartesians (x, y, z; Ang)
+   0     Be     0.000000000000000   0.000000000000000   0.000000000000000
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  Be     0.000000    0.000000    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 Be    4.0000    0     9.012    0.000000    0.000000    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ Be     0   0   0     0.000000000000     0.00000000     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type Be  : 15s7p2d1f contracted to 7s4p2d1f pattern {8211111/4111/11/1}
+
+Atom   0Be   basis set group =>   1
+------------------------------------------------------------------------------
+                             ORCA STARTUP CALCULATIONS
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...      1
+Number of basis functions                   ...     36
+Number of shells                            ...     14
+Maximum angular momentum                    ...      3
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 1.000e-12
+   Tcut                                     ... 1.000e-14
+   Tpresel                                  ... 1.000e-14 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... NOT available
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 14
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   1.0e-14
+Total number of shell pairs                 ...       105
+Shell pairs after pre-screening             ...       105
+Total number of primitive shell pairs       ...       360
+Primitive shell pairs kept                  ...       360
+          la=0 lb=0:     28 shell pairs
+          la=1 lb=0:     28 shell pairs
+          la=1 lb=1:     10 shell pairs
+          la=2 lb=0:     14 shell pairs
+          la=2 lb=1:      8 shell pairs
+          la=2 lb=2:      3 shell pairs
+          la=3 lb=0:      7 shell pairs
+          la=3 lb=1:      4 shell pairs
+          la=3 lb=2:      2 shell pairs
+          la=3 lb=3:      1 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=      0.000000000000 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 6.741e-03
+Time for diagonalization                   ...    0.021 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Total time needed                          ...    0.022 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-12
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+
+Total number of grid points                  ...     6136
+Total number of batches                      ...       96
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     6136
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.5 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 15.9 MB
+-------------------------------------------------------------------------------
+                                 ORCA GUESS
+                   Start orbitals & Density for SCF / CASSCF
+-------------------------------------------------------------------------------
+
+Producing symmetrization matrix            ... done (   0.000 sec)
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+
+General Settings:
+ Integral files         IntName         .... casscf_beryllium_atom_sym
+ Hartree-Fock type      HFTyp           .... CASSCF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   36
+ Nuclear Repulsion      ENuc            ....      0.0000000000 Eh
+
+ Symmetry handling      UseSym         .... ON
+ Point group                           .... Kh
+ Symmetry-adapted orbitals             .... D2h
+ Petite-list algorithm                 .... OFF
+ Number of irreps                      .... 8
+   Irrep   Ag has   11 symmetry adapted basis functions (ofs=   0)
+   Irrep  B1g has    2 symmetry adapted basis functions (ofs=  11)
+   Irrep  B2g has    2 symmetry adapted basis functions (ofs=  13)
+   Irrep  B3g has    2 symmetry adapted basis functions (ofs=  15)
+   Irrep   Au has    1 symmetry adapted basis functions (ofs=  17)
+   Irrep  B1u has    6 symmetry adapted basis functions (ofs=  18)
+   Irrep  B2u has    6 symmetry adapted basis functions (ofs=  24)
+   Irrep  B3u has    6 symmetry adapted basis functions (ofs=  30)
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Initializing the effective Hamiltonian             ... done
+Setting up the integral package (SHARK)            ... done
+Starting the Coulomb interaction                   ... done (   0.1 sec)
+Making the grid                                    ... done (   0.0 sec)
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.2 sec)
+                      ------------------
+             **** ENERGY FILE WAS UPDATED (casscf_beryllium_atom_sym.en.tmp) ****
+Finished Guess after   0.2 sec
+Maximum memory used throughout the entire GUESS-calculation: 5.6 MB
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Symmetry handling      UseSym     ... ON
+Point group                       ... Kh
+Used point group                  ... D2h
+Number of irreps                  ... 8
+   Irrep   Ag has   11 SALCs (ofs=   0) #(closed)=   1 #(active)=   1
+   Irrep  B1g has    2 SALCs (ofs=  11) #(closed)=   0 #(active)=   0
+   Irrep  B2g has    2 SALCs (ofs=  13) #(closed)=   0 #(active)=   0
+   Irrep  B3g has    2 SALCs (ofs=  15) #(closed)=   0 #(active)=   0
+   Irrep   Au has    1 SALCs (ofs=  17) #(closed)=   0 #(active)=   0
+   Irrep  B1u has    6 SALCs (ofs=  18) #(closed)=   0 #(active)=   1
+   Irrep  B2u has    6 SALCs (ofs=  24) #(closed)=   0 #(active)=   1
+   Irrep  B3u has    6 SALCs (ofs=  30) #(closed)=   0 #(active)=   1
+ Symmetries of active orbitals:
+   MO =    1  IRREP= 0 (Ag)
+   MO =    2  IRREP= 5 (B1u)
+   MO =    3  IRREP= 7 (B3u)
+   MO =    4  IRREP= 6 (B2u)
+
+Setting up the integral package     ... Building the CAS space              ... done (4 configurations for Mult=1 Irrep=0)
+
+SYSTEM-SPECIFIC SETTINGS:
+Number of active electrons          ...    2
+Number of active orbitals           ...    4
+Total number of electrons           ...    4
+Total number of orbitals            ...   36
+
+Determined orbital ranges:
+   Internal       0 -    0 (   1 orbitals)
+   Active         1 -    4 (   4 orbitals)
+   External       5 -   35 (  31 orbitals)
+Number of rotation parameters      ...     34
+
+CI-STEP:
+CI strategy                         ... General CI
+Number of symmetry/multplity blocks ...    1
+BLOCK  0 WEIGHT=   1.0000
+  Multiplicity                      ...    1
+  Irrep                             ...    0 (Ag)
+  #(Configurations)                 ...    4
+  #(CSFs)                           ...    4
+  #(Roots)                          ...    1
+    ROOT=0 WEIGHT=    1.000000
+
+  PrintLevel                        ...    1
+  N(GuessMat)                       ...      2048
+  MaxDim(CI)                        ...        10
+  MaxIter(CI)                       ...        64
+  Energy Tolerance CI               ...  1.00e-09
+  Residual Tolerance CI             ...  1.00e-09
+  Shift(CI)                         ...  1.00e-04
+
+INTEGRAL-TRANSFORMATION-STEP:
+  Algorithm                         ... EXACT
+
+ORBITAL-IMPROVEMENT-STEP:
+  Algorithm                         ... SuperCI(PT)
+  Default Parametrization           ... CAYLEY
+  Act-Act rotations                 ... depends on algorithm used
+
+  Note: SuperCI(PT) will ignore FreezeIE, FreezeAct and FreezeGrad. In general Default settings are encouraged.
+        In conjunction with ShiftUp, ShiftDn or GradScaling the performance of SuperCI(PT) is less optimal.  
+
+  MaxRot                            ... 2.00e-01 
+  Max. no of vectors (DIIS)         ... 15
+  DThresh (cut-off) metric          ... 1.00e-06
+  Switch step at gradient           ...  3.00e-02 
+  Switch step at iteration          ...        50   
+  Switch step to                    ... SuperCI(PT)    
+
+SCF-SETTINGS:
+  Incremental                       ... on
+  RIJCOSX approximation             ... off
+  RI-JK approximation               ... off
+  AO integral handling              ... DIRECT
+  Integral Neglect Thresh           ...  1.00e-12
+  Primitive cutoff TCut             ...  1.00e-14
+  Energy convergence tolerance      ...  1.00e-08
+  Orbital gradient convergence      ...  1.00e-05
+  Max. number of iterations         ...        75  
+
+
+FINAL ORBITALS:
+  Active   Orbitals                 ... natural 
+  Internal Orbitals                 ... canonical 
+  External Orbitals                 ... canonical 
+
+------------------
+CAS-SCF ITERATIONS
+------------------
+
+
+MACRO-ITERATION   1: 
+   --- Inactive Energy E0 = -13.60390405 Eh
+CI-ITERATION   0: 
+   -14.604424915   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+BLOCK  0 MULT= 1 NROOTS= 1  IRREP=Ag 
+ROOT   0:  E=     -14.6044249150 Eh
+      0.90756 [     0]: 2000
+      0.03081 [     1]: 0200
+      0.03081 [     2]: 0020
+      0.03081 [     3]: 0002
+
+                 <<<<<<<<<<<<<<<<<<INITIAL CI STATE CHECK>>>>>>>>>>>>>>>>>>
+
+   E(CAS)=   -14.604424915 Eh DE=    0.000000e+00
+   --- Energy gap subspaces: Ext-Act = 0.065   Act-Int = 4.462
+   N(occ)=  1.81512 0.06163 0.06163 0.06163
+   ||g|| =     5.129342e-01 Max(G)=   -3.483484e-01 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.342426993 Max(X)(8,4) =      0.195626819 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   2: 
+   --- Inactive Energy E0 = -13.61070860 Eh
+CI-ITERATION   0: 
+   -14.615891596   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.615891596 Eh DE=   -1.146668e-02
+   --- Energy gap subspaces: Ext-Act = 0.035   Act-Int = 4.444
+   N(occ)=  1.80034 0.06655 0.06655 0.06655
+   ||g|| =     4.643372e-02 Max(G)=   -2.470462e-02 Rot=30,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.077239841 Max(X)(8,4) =     -0.043853578 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   3: 
+   --- Inactive Energy E0 = -13.61017255 Eh
+CI-ITERATION   0: 
+   -14.616467015   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616467015 Eh DE=   -5.754194e-04
+   --- Energy gap subspaces: Ext-Act = 0.022   Act-Int = 4.437
+   N(occ)=  1.80346 0.06551 0.06551 0.06551
+   ||g|| =     1.014140e-02 Max(G)=    6.481003e-03 Rot=5,1
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.011058579 Max(X)(8,4) =     -0.005760007 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   4: 
+   --- Inactive Energy E0 = -13.61008825 Eh
+CI-ITERATION   0: 
+   -14.616496888   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616496888 Eh DE=   -2.987259e-05
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80382 0.06539 0.06539 0.06539
+   ||g|| =     7.646285e-04 Max(G)=   -4.120669e-04 Rot=5,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.001058992 Max(X)(8,4) =      0.000448182 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   5: 
+   --- Inactive Energy E0 = -13.61009983 Eh
+CI-ITERATION   0: 
+   -14.616497002   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497002 Eh DE=   -1.136735e-07
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80373 0.06542 0.06542 0.06542
+   ||g|| =     2.485089e-04 Max(G)=   -1.762019e-04 Rot=34,0
+   --- Orbital Update [SuperCI(PT)]
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+   --- SX_PT (Skipped TA=0 IT=0): ||X|| =      0.000276301 Max(X)(6,3) =      0.000144871 
+   --- SFit(Active Orbitals)
+
+MACRO-ITERATION   6: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=   -6.684038e-09
+   --- Energy gap subspaces: Ext-Act = 0.019   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =     1.606362e-05 Max(G)=   -1.169535e-05 Rot=14,1
+                     ---- THE CAS-SCF ENERGY   HAS CONVERGED ----
+                            --- FINALIZING ORBITALS ---
+                    ---- DOING ONE FINAL ITERATION FOR PRINTING ----
+   --- Canonicalize Internal Space
+   --- Canonicalize External Space
+
+MACRO-ITERATION   7: 
+   --- Inactive Energy E0 = -13.61009524 Eh
+   --- All densities will be recomputed
+CI-ITERATION   0: 
+   -14.616497008   0.000000000000 (    0.00)
+   CI-PROBLEM SOLVED
+   DENSITIES MADE
+   E(CAS)=   -14.616497008 Eh DE=   -3.197442e-14
+   --- Energy gap subspaces: Ext-Act = 0.015   Act-Int = 4.434
+   N(occ)=  1.80375 0.06542 0.06542 0.06542
+   ||g|| =     1.599655e-05 Max(G)=    1.157495e-05 Rot=14,1
+--------------
+CASSCF RESULTS
+--------------
+
+Final CASSCF energy       : -14.616497008 Eh    -397.7351 eV
+
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV)    Irrep 
+   0   2.0000      -4.711845      -128.2158    1-Ag
+   1   1.8038      -0.277797        -7.5592    2-Ag
+   2   0.0654       0.112653         3.0655    1-B1u
+   3   0.0654       0.112653         3.0655    1-B3u
+   4   0.0654       0.112653         3.0655    1-B2u
+   5   0.0000       0.127743         3.4761    3-Ag
+   6   0.0000       0.150920         4.1067    2-B1u
+   7   0.0000       0.150920         4.1067    2-B2u
+   8   0.0000       0.150920         4.1067    2-B3u
+   9   0.0000       0.274858         7.4793    1-B2g
+  10   0.0000       0.274858         7.4793    4-Ag
+  11   0.0000       0.274858         7.4793    1-B3g
+  12   0.0000       0.274858         7.4793    1-B1g
+  13   0.0000       0.274858         7.4793    5-Ag
+  14   0.0000       0.681115        18.5341    6-Ag
+  15   0.0000       0.767036        20.8721    3-B2u
+  16   0.0000       0.767036        20.8721    3-B1u
+  17   0.0000       0.767036        20.8721    3-B3u
+  18   0.0000       1.118724        30.4420    2-B2g
+  19   0.0000       1.118724        30.4420    7-Ag
+  20   0.0000       1.118724        30.4420    8-Ag
+  21   0.0000       1.118724        30.4420    2-B1g
+  22   0.0000       1.118724        30.4420    2-B3g
+  23   0.0000       1.176080        32.0028    4-B1u
+  24   0.0000       1.176080        32.0028    4-B3u
+  25   0.0000       1.176080        32.0028    1-Au
+  26   0.0000       1.176080        32.0028    4-B2u
+  27   0.0000       1.176080        32.0028    5-B2u
+  28   0.0000       1.176080        32.0028    5-B1u
+  29   0.0000       1.176080        32.0028    5-B3u
+  30   0.0000       3.007595        81.8408    9-Ag
+  31   0.0000      10.933785       297.5234    6-B3u
+  32   0.0000      10.933785       297.5234    6-B1u
+  33   0.0000      10.933785       297.5234    6-B2u
+  34   0.0000      11.951752       325.2237   10-Ag
+  35   0.0000      65.244448      1775.3917   11-Ag
+
+
+---------------------------------------------
+CAS-SCF STATES FOR BLOCK  0 MULT= 1 IRREP= Ag NROOTS= 1
+---------------------------------------------
+
+ROOT   0:  E=     -14.6164970082 Eh
+      0.90188 [     0]: 2000
+      0.03271 [     1]: 0200
+      0.03271 [     3]: 0002
+      0.03271 [     2]: 0020
+
+
+--------------
+DENSITY MATRIX
+--------------
+
+                  0          1          2          3    
+      0       1.803752   0.000000   0.000000   0.000000
+      1       0.000000   0.065416   0.000000   0.000000
+      2       0.000000   0.000000   0.065416   0.000000
+      3       0.000000   0.000000   0.000000   0.065416
+Trace of the electron density:  2.000000
+
+-----------------
+ENERGY COMPONENTS
+-----------------
+
+One electron energy          :    -19.082312356 Eh        -519.2561 eV
+Two electron energy          :      4.465815348 Eh         121.5210 eV
+Nuclear repulsion energy     :      0.000000000 Eh           0.0000 eV
+                               ----------------
+                                  -14.616497008
+
+Kinetic energy               :     14.616237925 Eh         397.7281 eV
+Potential energy             :    -29.232734934 Eh        -795.4632 eV
+Virial ratio                 :     -2.000017726 
+                               ----------------
+                                  -14.616497008
+
+Core energy                  :    -13.610095236 Eh     -370.3495 eV
+
+
+----------------------------
+LOEWDIN ORBITAL-COMPOSITIONS
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be px              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be py              0.0       0.0       0.0       0.0     100.0       0.0
+
+                      6         7         8         9        10        11   
+                   0.15092   0.15092   0.15092   0.27486   0.27486   0.27486
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be pz            100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be px              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be py              0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be dz2             0.0       0.0       0.0       0.0      28.0       0.0
+ 0 Be dxz             0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be dyz             0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be dx2y2           0.0       0.0       0.0       0.0      72.0       0.0
+
+                     12        13        14        15        16        17   
+                   0.27486   0.27486   0.68111   0.76704   0.76704   0.76704
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s               0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be pz              0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be px              0.0       0.0       0.0       0.0       0.0     100.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be dz2             0.0      72.0       0.0       0.0       0.0       0.0
+ 0 Be dx2y2           0.0      28.0       0.0       0.0       0.0       0.0
+ 0 Be dxy           100.0       0.0       0.0       0.0       0.0       0.0
+
+                     18        19        20        21        22        23   
+                   1.11872   1.11872   1.11872   1.11872   1.11872   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be dz2             0.0      97.7       2.3       0.0       0.0       0.0
+ 0 Be dxz           100.0       0.0       0.0       0.0       0.0       0.0
+ 0 Be dyz             0.0       0.0       0.0       0.0     100.0       0.0
+ 0 Be dx2y2           0.0       2.3      97.7       0.0       0.0       0.0
+ 0 Be dxy             0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be f0              0.0       0.0       0.0       0.0       0.0      58.6
+ 0 Be f+2             0.0       0.0       0.0       0.0       0.0      41.4
+
+                     24        25        26        27        28        29   
+                   1.17608   1.17608   1.17608   1.17608   1.17608   1.17608
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be f0              0.0       0.0       0.0       0.0      41.4       0.0
+ 0 Be f+1            98.5       0.0       0.0       0.0       0.0       1.5
+ 0 Be f-1             0.0       0.0       0.3      99.7       0.0       0.0
+ 0 Be f+2             0.0       0.0       0.0       0.0      58.6       0.0
+ 0 Be f-2             0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be f+3             1.5       0.0       0.0       0.0       0.0      98.5
+ 0 Be f-3             0.0       0.0      99.7       0.3       0.0       0.0
+
+                     30        31        32        33        34        35   
+                   3.00760  10.93379  10.93379  10.93379  11.95175  65.24445
+                   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0       0.0       0.0       0.0     100.0     100.0
+ 0 Be pz              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be px              0.0     100.0       0.0       0.0       0.0       0.0
+ 0 Be py              0.0       0.0       0.0     100.0       0.0       0.0
+
+
+----------------------------
+LOEWDIN REDUCED ACTIVE MOs  
+----------------------------
+
+                      0         1         2         3         4         5   
+                  -4.71185  -0.27780   0.11265   0.11265   0.11265   0.12774
+                   2.00000   1.80375   0.06542   0.06542   0.06542   0.00000
+                  --------  --------  --------  --------  --------  --------
+ 0 Be s             100.0     100.0       0.0       0.0       0.0     100.0
+ 0 Be pz              0.0       0.0     100.0       0.0       0.0       0.0
+ 0 Be px              0.0       0.0       0.0     100.0       0.0       0.0
+ 0 Be py              0.0       0.0       0.0       0.0     100.0       0.0
+
+------------------------------------------------------------------------------
+                           ORCA POPULATION ANALYSIS
+------------------------------------------------------------------------------
+Input electron density              ... casscf_beryllium_atom_sym.scfp
+BaseName (.gbw .S,...)              ... casscf_beryllium_atom_sym
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 Be:    0.000000
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 Be:    0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Bes       :     3.803752  s :     3.803752
+      pz      :     0.065416  p :     0.196248
+      px      :     0.065416
+      py      :     0.065416
+      dz2     :     0.000000  d :     0.000000
+      dxz     :     0.000000
+      dyz     :     0.000000
+      dx2y2   :     0.000000
+      dxy     :     0.000000
+      f0      :     0.000000  f :     0.000000
+      f+1     :     0.000000
+      f-1     :     0.000000
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.000000
+      f-3     :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 Be     4.0000     4.0000     0.0000     0.7336     0.0000     0.7336
+
+  => No bond orders to print
+
+Transition Dipole Moments (a.u.) with input orbitals:
+MO   0:
+ MO   2:      0.093188947 (    -0.000000000,     -0.000000000,     -0.093188947)
+ MO   3:      0.093188947 (    -0.093188947,     -0.000000000,     -0.000000000)
+ MO   4:      0.093188947 (     0.000000000,      0.093188947,      0.000000000)
+MO   1:
+ MO   2:      1.461408146 (     0.000000000,      0.000000000,     -1.461408146)
+ MO   3:      1.461408146 (    -1.461408146,     -0.000000000,      0.000000000)
+ MO   4:      1.461408146 (     0.000000000,      1.461408146,     -0.000000000)
+MO   2:
+MO   3:
+MO   4:
+  newgto Be
+  0 15
+    1      29646.704407000001         0.000038108224
+    2       4428.761435400000         0.000297340321
+    3       1005.470133200000         0.001564016408
+    4        284.153395780000         0.006560712877
+    5         92.504356461000         0.023217340382
+    6         33.311016058000         0.069760422481
+    7         12.911553314000         0.170883257267
+    8          5.266549736100         0.318204229410
+    9         22.995386380000        -0.000026605258
+   10          6.623635417600        -0.000260226483
+   11          2.228959500300         0.379026890564
+   12          0.953024334500         0.186086635277
+   13          0.246516024400         0.006073817016
+   14          0.101538953100        -0.011158857110
+   15          0.041551374600        -0.001939619433
+  0 15
+    1      29646.704407000001         0.000006656465
+    2       4428.761435400000         0.000051937223
+    3       1005.470133200000         0.000273190897
+    4        284.153395780000         0.001145977130
+    5         92.504356461000         0.004055434462
+    6         33.311016058000         0.012185238136
+    7         12.911553314000         0.029848632065
+    8          5.266549736100         0.055581577253
+    9         22.995386380000         0.001088706138
+   10          6.623635417600         0.010648653488
+   11          2.228959500300         0.118828786580
+   12          0.953024334500         0.107283329766
+   13          0.246516024400        -0.284089778990
+   14          0.101538953100        -0.628004193847
+   15          0.041551374600        -0.214441958372
+  1 7
+    1         14.099789445000         0.004692441533
+    2          3.180318848200         0.029430526482
+    3          0.904892205000         0.119327406656
+    4          0.304115855100         0.359106958068
+    5          0.113026066600         0.606477568734
+    6          0.042831733700         0.037784957355
+    7          6.400000000000        -0.004717453594
+  end
+
+-------------------------------------------------------------
+ Forming the transition density       ... done in 0.0 sec
+-------------------------------------------------------------
+Memory for address arrays  		      ... done
+Make address arrays			      ... done
+Memory for buffers 			      ... done
+Setting up spin-function prototypes	      ... (MAXOPEN=2) 0 2 4 done
+Trivial cases - DOMO's			      ... done (  0.0 MB)
+Number of open shells			    ...  0
+domo->virtual excitations			... done (  0.0 MB)
+domo->somo excitations				... done (  0.0 MB)
+somo->virtual excitations			... done (  0.0 MB)
+somo->somo excitations				... done (  0.0 MB)
+Number of open shells			    ...  2
+domo->virtual excitations			... done (  0.0 MB)
+domo->somo excitations				... done (  0.0 MB)
+somo->virtual excitations			... done (  0.0 MB)
+somo->somo excitations				... done (  0.0 MB)
+Coupling container construction done
+
+--------------
+CASSCF TIMINGS
+--------------
+
+Total time                       ...        0.5 sec
+Sum of individual times          ...        0.4 sec ( 81.3%)
+
+Calculation of AO operators
+   F(Core) operator              ...        0.1 sec ( 23.7%)
+   G(Act) operator               ...        0.1 sec ( 15.8%)
+Calculation of MO transformed quantities
+   J(MO) operators               ...        0.1 sec ( 28.3%)
+   AO->MO one electron integrals ...        0.0 sec (  0.1%)
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec (  2.3%)
+   CI-solution phase             ...        0.1 sec ( 10.5%)
+   Generation of densities       ...        0.0 sec (  0.0%)
+Orbital improvement steps
+   Orbital gradient              ...        0.0 sec (  0.1%)
+   O(1) converger                ...        0.0 sec (  0.2%)
+CPCM steps
+   Total CPCM time               ...        0.0 sec (  0.1%)
+Properties                       ...        0.0 sec (  0.0%)
+   SOC integral calculation      ...        0.0 sec (  0.0%)
+   SSC RMEs (incl. integrals)    ...        0.0 sec (  0.0%)
+   SOC RMEs                      ...        0.0 sec (  0.0%)
+
+Maximum memory used throughout the entire CASSCF-calculation: 38.0 MB
+
+------------------------------------------------------------------------------
+                         ORCA PROPERTY INTEGRAL CALCULATIONS
+------------------------------------------------------------------------------
+
+GBWName                                   ... casscf_beryllium_atom_sym.gbw
+Number of atoms                           ...      1
+Number of basis functions                 ...     36
+Max core memory                           ...   1024 MB
+
+Dipole integrals                          ... YES
+Quadrupole integrals                      ...  NO
+Linear momentum integrals                 ...  NO
+Angular momentum integrals                ... YES
+Higher moments length integrals           ...  NO
+Higher moments velocity integrals         ...  NO
+Kinetic energy integrals                  ...  NO
+GIAO right hand sides                     ...  NO
+GIAO dipole derivative integrals          ...  NO
+SOC integrals                             ...  NO
+EPR diamagnetic integrals (GIAO)          ...  NO
+EPR gauge integrals                       ...  NO
+Field gradient integrals                  ...  NO (   0 nuclei)
+Spin-dipole/Fermi contact integrals       ...  NO (   0 nuclei)
+Contact density integrals                 ...  NO (   0 nuclei)
+Nucleus-orbit integrals                   ...  NO (   0 nuclei)
+Geometric perturbations                   ...  NO (   1 nuclei)
+
+Choice of electric origin   ... Center of mass
+Position of electric origin ... (  0.0000,  0.0000,  0.0000) 
+Choice of magnetic origin   ... GIAO
+Position of magnetic origin ... (  0.0000,  0.0000,  0.0000) 
+
+Calculating integrals                     ... Electric Dipole (Length)     done (  0.0 sec)
+Calculating integrals                     ... Angular Momentum  (ElOri)    done (  0.0 sec)
+
+Property integrals calculated in   0.0 sec
+
+Maximum memory used throughout the entire PROPINT-calculation: 5.7 MB
+-------------------------------------------------------------------------------
+                              ORCA-CASSCF
+-------------------------------------------------------------------------------
+
+Symmetry handling      UseSym     ... ON
+Point group                       ... Kh
+Used point group                  ... D2h
+Number of irreps                  ... 8
+   Irrep   Ag has   11 SALCs (ofs=   0) #(closed)=   1 #(active)=   1
+   Irrep  B1g has    2 SALCs (ofs=  11) #(closed)=   0 #(active)=   0
+   Irrep  B2g has    2 SALCs (ofs=  13) #(closed)=   0 #(active)=   0
+   Irrep  B3g has    2 SALCs (ofs=  15) #(closed)=   0 #(active)=   0
+   Irrep   Au has    1 SALCs (ofs=  17) #(closed)=   0 #(active)=   0
+   Irrep  B1u has    6 SALCs (ofs=  18) #(closed)=   0 #(active)=   1
+   Irrep  B2u has    6 SALCs (ofs=  24) #(closed)=   0 #(active)=   1
+   Irrep  B3u has    6 SALCs (ofs=  30) #(closed)=   0 #(active)=   1
+ Symmetries of active orbitals:
+   MO =    1  IRREP= 0 (Ag)
+   MO =    2  IRREP= 5 (B1u)
+   MO =    3  IRREP= 7 (B3u)
+   MO =    4  IRREP= 6 (B2u)
+
+Setting up the integral package     ... done
+
+
+==========================================
+CASSCF UV, CD spectra and dipole moments
+==========================================
+Calculating Transition_Moments                                   ... 
+
+--------------
+CASSCF TIMINGS
+--------------
+
+Total time                       ...        0.1 sec
+Sum of individual times          ...        0.0 sec ( 61.4%)
+
+Calculation of AO operators
+Calculation of MO transformed quantities
+Configuration interaction steps
+   CI-setup phase                ...        0.0 sec ( 61.4%)
+Orbital improvement steps
+Properties                       ...        0.0 sec (  0.0%)
+   SOC integral calculation      ...        0.0 sec (  0.0%)
+   SSC RMEs (incl. integrals)    ...        0.0 sec (  0.0%)
+   SOC RMEs                      ...        0.0 sec (  0.0%)
+
+Maximum memory used throughout the entire CASSCF-calculation: 25.5 MB
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -14.616497008249
+-------------------------   --------------------
+
+
+------------------------------------------------------------------------------
+                              ORCA PROPERTY CALCULATIONS
+------------------------------------------------------------------------------
+
+GBWName                                 ... casscf_beryllium_atom_sym.gbw
+Number of atoms                         ...      1
+Number of basis functions               ...     36
+Max core memory                         ...   1024 MB
+
+Electric properties:
+Dipole moment                           ... YES
+Quadrupole moment                       ...  NO
+Static polarizability (Dipole/Dipole)   ...  NO
+Static polarizability (Dipole/Quad.)    ...  NO
+Static polarizability (Quad./Quad.)     ...  NO
+Static polarizability (Velocity)        ...  NO
+
+Atomic electric properties:
+Dipole moment                           ...  NO
+Quadrupole moment                       ...  NO
+Static polarizability                   ...  NO
+
+Choice of electric origin               ... Center of mass
+Position of electric origin             ...     0.000000     0.000000     0.000000
+
+General magnetic properties:
+Magnetizability                         ...  NO
+
+EPR properties:
+g-Tensor (aka g-matrix)                 ...  NO
+Zero-Field splitting spin-orbit         ...  NO
+Zero-field splitting spin-spin          ...  NO
+Hyperfine couplings                     ...  NO (   0 nuclei)
+Quadrupole couplings                    ...  NO (   0 nuclei)
+Contact density                         ...  NO (   0 nuclei)
+
+NMR properties:
+Chemical shifts                         ...  NO (   0 nuclei)
+Spin-rotation constants                 ...  NO (   0 nuclei)
+Spin-spin couplings                     ...  NO (   0 nuclei,    0 pairs)
+
+Choice of magnetic origin               ... GIAO
+Position of magnetic origin             ...     0.000000     0.000000     0.000000
+
+Properties with geometric perturbations:
+SCF Hessian                             ...  NO
+IR spectrum                             ...  NO
+VCD spectrum                            ...  NO
+X-ray spectroscopy properties:
+SCF XES/XAS/RIXS spectra                ...  NO
+
+
+-------------
+DIPOLE MOMENT
+-------------
+
+Method             : CASSCF
+Type of density    : Electron Density
+Level              : Relaxed density
+State              :   0
+Multiplicity       :   1
+Irrep              :   0
+Energy             :   -14.6164970082491354 Eh
+Relativity type    : 
+Basis              : AO
+                                X                 Y                 Z
+Electronic contribution:     -0.000000000       0.000000000      -0.000000000
+Nuclear contribution   :      0.000000000       0.000000000       0.000000000
+                        -----------------------------------------
+Total Dipole Moment    :     -0.000000000       0.000000000      -0.000000000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.000000000
+Magnitude (Debye)      :      0.000000000
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:             0.000000             0.000000             0.000000 
+Rotational constants in MHz :             0.000000             0.000000             0.000000 
+
+Dipole components along the rotational axes: 
+x,y,z [a.u.] :    -0.000000     0.000000    -0.000000 
+x,y,z [Debye]:    -0.000000     0.000000    -0.000000 
+
+ 
+
+Dipole moment calculation done in   0.0 sec 
+
+Maximum memory used throughout the entire PROP-calculation: 2.4 MB
+
+--------------------------------
+SUGGESTED CITATIONS FOR THIS RUN
+--------------------------------
+
+Below you find a list of papers that are relevant to this ORCA run
+We neither can nor want to force you to cite these papers, but we appreciate if you do
+You receive ORCA, which is the product of decades of hard work by many enthusiastic individuals, for free
+The only thing we kindly ask in return is that you cite our papers,
+We deeply appreciate it, if you show your appreciation for ORCA by not just citing the generic ORCA reference.
+
+Please note that relegating all ORCA citations to the supporting information does *not* help us.
+SI sections are not indexed - citations you put there will not count into any citation statistics
+But we need these citations in order to attract the funding resources that allow us to do what we are doing
+
+Therefore, if you are a happy ORCA user, please consider citing a few of the papers listed below in the main body of your paper
+
+In addition to the list printed below, the program has created the file casscf_beryllium_atom_sym.bibtex that contains the list in bibtex format
+You can import this file easily into all common literature databanks and citation aid programs
+
+
+List of essential papers. We consider these as the minimum necessary citations
+
+  1. Neese,F.
+     Software update: the ORCA program system, version 5.0
+     WIRES Comput. Molec. Sci., 2022 12(1)e1606
+     doi.org/10.1002/wcms.1606
+
+List of papers to cite with high priority. The work reported in these papers was absolutely
+necessary for this run to complete.
+Our perspective: the developers of density functionals and basis sets usually get cited in chemistry papers
+Good! But without the algorithms to do something with them, the functionals or basis sets would not do anything.
+Hence, in our opinion, the algorithm design and method developments papers are equally worthy of getting cited
+
+  1. Kollmar,C.; Sivalingam,K.; Helmich-Paris,B.; Angeli,C.; Neese,F.
+     A perturbation-based super-CI approach for the orbital optimization of a CASSCF wave function
+     J. Comput. Chem., 2019 40 1463-1470
+     doi.org/10.1002/jcc.25801
+  2. Neese,F.
+     The SHARK Integral Generation and Digestion System
+     J. Comp. Chem., 2022  1-16
+     doi.org/10.1002/jcc.26942
+  3. Ugandi,M.; Roemelt,M.
+     A recursive formulation of one-electron coupling coefficients for spin-adapted configuration interaction calculations featuring many unpaired electrons
+     Int. J. Quantum Chem., 2023 123 e27045
+     doi.org/10.1002/qua.27045
+
+List of suggested additional citations. These are papers that are important in the 'surrounding' of 
+of this run, or papers that preceded the highly important papers. If you like your results we are grateful for a citation.
+
+  1. Neese,F.
+     The ORCA program system
+     WIRES Comput. Molec. Sci., 2012 2(1)73-78
+     doi.org/10.1002/wcms.81
+  2. Neese,F.
+     Software update: the ORCA program system, version 4.0
+     WIRES Comput. Molec. Sci., 2018 8(1)1-6
+     doi.org/10.1002/wcms.1327
+  3. Neese,F.; Wennmohs,F.; Becker,U.; Riplinger,C.
+     The ORCA quantum chemistry program package
+     J. Chem. Phys., 2020 152 Art. No. L224108
+     doi.org/10.1063/5.0004608
+
+List of optional additional citations
+
+  1. Neese,F.
+     Approximate second-order SCF convergence for spin unrestricted wavefunctions
+     Chem. Phys. Lett., 2000 325(1-3)93-98
+     doi.org/10.1016/s0009-2614(00)00662-x
+
+Timings for individual modules:
+
+Sum of individual times          ...        2.024 sec (=   0.034 min)
+Startup calculation              ...        0.565 sec (=   0.009 min)  27.9 %
+SCF iterations                   ...        0.330 sec (=   0.006 min)  16.3 %
+CASSCF iterations                ...        0.847 sec (=   0.014 min)  41.8 %
+Property integrals               ...        0.145 sec (=   0.002 min)   7.1 %
+Property calculations            ...        0.138 sec (=   0.002 min)   6.8 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 2 seconds 222 msec

--- a/regressionfiles.yaml
+++ b/regressionfiles.yaml
@@ -856,6 +856,7 @@ regressions:
   - loc_entry: ORCA/ORCA5.0/Benzene_opt_etsyms.log
   - loc_entry: ORCA/ORCA5.0/dvb_soc.log
   - loc_entry: ORCA/ORCA5.0/steom_orbs.log
+  - loc_entry: ORCA/ORCA6.0/ho-h_cas_aDZ_scanSA.out
   - loc_entry: Psi3/Psi3.4/dvb_sp_hf.out
     tests:
       - Psi3SPTest

--- a/regressionfiles.yaml
+++ b/regressionfiles.yaml
@@ -675,6 +675,8 @@ regressions:
     tests:
       - ReferencePolarTest
   - loc_entry: ORCA/ORCA3.0/benzene_td_singlets.out
+  - loc_entry: ORCA/ORCA3.0/casscf_beryllium_atom_nosym.out
+  - loc_entry: ORCA/ORCA3.0/casscf_beryllium_atom_sym.out
   - loc_entry: ORCA/ORCA3.0/chelpg.out
   - loc_entry: ORCA/ORCA3.0/dvb_bomd.out
     tests:
@@ -718,6 +720,8 @@ regressions:
   - loc_entry: ORCA/ORCA4.0/Trp_polar.out
     tests:
       - ReferencePolarTest
+  - loc_entry: ORCA/ORCA4.0/casscf_beryllium_atom_nosym.out
+  - loc_entry: ORCA/ORCA4.0/casscf_beryllium_atom_sym.out
   - loc_entry: ORCA/ORCA4.0/comment_or_blank_line.out
   - loc_entry: ORCA/ORCA4.0/dvb_gopt.out
     tests:
@@ -750,6 +754,8 @@ regressions:
   - loc_entry: ORCA/ORCA4.1/Trp_polar.out
     tests:
       - ReferencePolarTest
+  - loc_entry: ORCA/ORCA4.1/casscf_beryllium_atom_nosym.out
+  - loc_entry: ORCA/ORCA4.1/casscf_beryllium_atom_sym.out
   - loc_entry: ORCA/ORCA4.1/dvb_dispersion_bp86_d3zero.out
     tests:
       - GenericDispersionTest
@@ -801,6 +807,8 @@ regressions:
       - ReferencePolarTest
   - loc_entry: ORCA/ORCA4.2/a_DLPNO.txt
   - loc_entry: ORCA/ORCA4.2/casscf.out
+  - loc_entry: ORCA/ORCA4.2/casscf_beryllium_atom_nosym.out
+  - loc_entry: ORCA/ORCA4.2/casscf_beryllium_atom_sym.out
   - loc_entry: ORCA/ORCA4.2/cope.out
   - loc_entry: ORCA/ORCA4.2/dvb_dispersion_bp86_d3zero.out
     tests:
@@ -854,8 +862,12 @@ regressions:
       - GenericMP3Test
   - loc_entry: ORCA/ORCA5.0/ADBNA_Me_Mes_MesCz.log
   - loc_entry: ORCA/ORCA5.0/Benzene_opt_etsyms.log
+  - loc_entry: ORCA/ORCA5.0/casscf_beryllium_atom_nosym.out
+  - loc_entry: ORCA/ORCA5.0/casscf_beryllium_atom_sym.out
   - loc_entry: ORCA/ORCA5.0/dvb_soc.log
   - loc_entry: ORCA/ORCA5.0/steom_orbs.log
+  - loc_entry: ORCA/ORCA6.0/casscf_beryllium_atom_nosym.out
+  - loc_entry: ORCA/ORCA6.0/casscf_beryllium_atom_sym.out
   - loc_entry: ORCA/ORCA6.0/ho-h_cas_aDZ_scanSA.out
   - loc_entry: Psi3/Psi3.4/dvb_sp_hf.out
     tests:


### PR DESCRIPTION
From cclib/cclib#1577

Also adds, for each ORCA program version, CASSCF calculations with and without symmetry on the beryllium atom.  Beryllium is a good example because the ground state should be ~90% the closed shell configuration ($\mathrm{1s^22s^2}$) and ~3.333...% each of the doubly-excited configurations into the degenerate p orbitals ($\mathrm{1s^22p_{x}^2}$, $\mathrm{1s^22p_{y}^2}$, and $\mathrm{1s^22p_{z}^2}$), which looks like
```
---------------------------------------------
CAS-SCF STATES FOR BLOCK  0 MULT= 1 IRREP= Ag NROOTS= 1
---------------------------------------------

ROOT   0:  E=     -14.6164970082 Eh
      0.90188 [     0]: 2000
      0.03271 [     1]: 0200
      0.03271 [     3]: 0002
      0.03271 [     2]: 0020
```

This could probably become a standard unit test in the future.