### PR TITLE
ORCA: pre-4.1 geometry optimizations missing rotational constants

### DIFF
--- a/regressionfiles.yaml
+++ b/regressionfiles.yaml
@@ -628,7 +628,7 @@ regressions:
   - loc_entry: ORCA/ORCA2.8/co_cosmo.out
   - loc_entry: ORCA/ORCA2.8/dvb_gopt.out
     tests:
-      - OrcaGeoOptTest
+      - OrcaGeoOptTest_norotconsts
   - loc_entry: ORCA/ORCA2.8/dvb_ir.out
     tests:
       - OrcaIRTest_old
@@ -651,7 +651,7 @@ regressions:
   - loc_entry: ORCA/ORCA2.9/PCB_1_122.out
   - loc_entry: ORCA/ORCA2.9/dvb_gopt.out
     tests:
-      - OrcaGeoOptTest
+      - OrcaGeoOptTest_norotconsts
   - loc_entry: ORCA/ORCA2.9/dvb_ir.out
     tests:
       - OrcaIRTest_pre4
@@ -687,7 +687,7 @@ regressions:
       - GenericBOMDTest
   - loc_entry: ORCA/ORCA3.0/dvb_gopt.out
     tests:
-      - OrcaGeoOptTest
+      - OrcaGeoOptTest_norotconsts
   - loc_entry: ORCA/ORCA3.0/dvb_gopt_unconverged.out
   - loc_entry: ORCA/ORCA3.0/dvb_ir.out
     tests:
@@ -729,7 +729,7 @@ regressions:
   - loc_entry: ORCA/ORCA4.0/comment_or_blank_line.out
   - loc_entry: ORCA/ORCA4.0/dvb_gopt.out
     tests:
-      - OrcaGeoOptTest
+      - OrcaGeoOptTest_norotconsts
   - loc_entry: ORCA/ORCA4.0/dvb_ir.out
     tests:
       - OrcaIRTest


### PR DESCRIPTION
Required for https://github.com/cclib/cclib/pull/1601